### PR TITLE
Fix getting the `__eh_frame` section from Mach-O files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,11 @@ fn elf_get_section<'a>(elf: &elf::Elf<'a>, section_name: &str, data: &'a [u8]) -
 }
 
 fn macho_get_section<'a>(macho: &mach::MachO<'a>, section_name: &str) -> Option<&'a [u8]> {
-    let segment_name = "__DWARF";
+    let segment_name = if section_name == ".eh_frame" {
+        "__TEXT"
+    } else {
+        "__DWARF"
+    };
     let section_name = macho_translate_section_name(section_name);
 
     for segment in &*macho.segments {


### PR DESCRIPTION
All the DWARF sections are within the `__DWARF` segment, but the `__eh_frame` section is inside the `__TEXT` section since it is needed at runtime for exception handling.