### PR TITLE
Add some methods useful for locating debug symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/gimli-rs/object"
 
 [dependencies]
 goblin = "0.0.13"
+uuid = "0.5.1"
 
 [dev-dependencies]
 memmap = "0.6"

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -148,6 +148,10 @@ where
     fn is_little_endian(&self) -> bool {
         self.elf.little_endian
     }
+
+    fn has_debug_symbols(&self) -> bool {
+        self.section_data_by_name(".debug_info").is_some()
+    }
 }
 
 impl<'data, 'file> Iterator for ElfSegmentIterator<'data, 'file> {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -3,7 +3,8 @@ use std::slice;
 
 use goblin::{elf, strtab};
 
-use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap};
+use {DebugFileInfo, Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind,
+     SymbolMap};
 
 /// An ELF object file.
 #[derive(Debug)]
@@ -152,6 +153,8 @@ where
     fn has_debug_symbols(&self) -> bool {
         self.section_data_by_name(".debug_info").is_some()
     }
+
+    fn debug_file_info(&self) -> Option<DebugFileInfo> { None }
 }
 
 impl<'data, 'file> Iterator for ElfSegmentIterator<'data, 'file> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,10 @@ where
     fn is_little_endian(&self) -> bool {
         with_inner!(self.inner, FileInternal, |x| x.is_little_endian())
     }
+
+    fn has_debug_symbols(&self) -> bool {
+        with_inner!(self.inner, FileInternal, |x| x.has_debug_symbols())
+    }
 }
 
 impl<'data, 'file> Iterator for SegmentIterator<'data, 'file> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(missing_debug_implementations)]
 
 extern crate goblin;
+extern crate uuid;
 
 use std::fmt;
 use std::io::Cursor;
@@ -24,6 +25,8 @@ pub use pe::*;
 
 mod traits;
 pub use traits::*;
+
+pub use uuid::Uuid;
 
 /// An object file.
 #[derive(Debug)]
@@ -52,6 +55,13 @@ pub enum Machine {
     /// x86-64
     #[allow(non_camel_case_types)]
     X86_64,
+}
+
+/// Information from an object file that can be used to locate separate debug info.
+#[derive(Debug, Clone, Copy)]
+pub enum DebugFileInfo {
+    /// The UUID from a Mach-O `LC_UUID` load command.
+    MachOUuid(Uuid),
 }
 
 /// An iterator over the segments of a `File`.
@@ -321,6 +331,10 @@ where
 
     fn has_debug_symbols(&self) -> bool {
         with_inner!(self.inner, FileInternal, |x| x.has_debug_symbols())
+    }
+
+    fn debug_file_info(&self) -> Option<DebugFileInfo> {
+        with_inner!(self.inner, FileInternal, |x| x.debug_file_info())
     }
 }
 

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -205,6 +205,10 @@ where
     fn is_little_endian(&self) -> bool {
         self.macho.header.is_little_endian()
     }
+
+    fn has_debug_symbols(&self) -> bool {
+        self.section_data_by_name(".debug_info").is_some()
+    }
 }
 
 impl<'data, 'file> Iterator for MachOSegmentIterator<'data, 'file> {

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -2,8 +2,11 @@ use std::fmt;
 use std::slice;
 
 use goblin::mach;
+use goblin::mach::load_command::CommandVariant;
+use uuid::Uuid;
 
-use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap};
+use {DebugFileInfo, Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind,
+     SymbolMap};
 
 /// A Mach-O object file.
 #[derive(Debug)]
@@ -208,6 +211,20 @@ where
 
     fn has_debug_symbols(&self) -> bool {
         self.section_data_by_name(".debug_info").is_some()
+    }
+
+    fn debug_file_info(&self) -> Option<DebugFileInfo> {
+        // Return the UUID from the `LC_UUID` load command, if one is present.
+        self.macho.load_commands.iter().filter_map(|lc| {
+            match lc.command {
+                CommandVariant::Uuid(ref cmd) => {
+                    //TODO: Uuid should have a `from_array` method that can't fail.
+                    Uuid::from_bytes(&cmd.uuid).ok()
+                        .map(|uuid| DebugFileInfo::MachOUuid(uuid))
+                }
+                _ => None,
+            }
+        }).nth(0)
     }
 }
 

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -152,6 +152,13 @@ where
         // characteristics flags, but these are obsolete.
         true
     }
+
+    #[inline]
+    fn has_debug_symbols(&self) -> bool {
+        // TODO: look at what the mingw toolchain does with DWARF-in-PE, and also
+        // whether CodeView-in-PE still works?
+        false
+    }
 }
 
 impl<'data, 'file> Iterator for PeSegmentIterator<'data, 'file> {

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -3,7 +3,8 @@ use std::borrow;
 
 use goblin::pe;
 
-use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap};
+use {DebugFileInfo, Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind,
+     SymbolMap};
 
 /// A PE object file.
 #[derive(Debug)]
@@ -159,6 +160,8 @@ where
         // whether CodeView-in-PE still works?
         false
     }
+
+    fn debug_file_info(&self) -> Option<DebugFileInfo> { None }
 }
 
 impl<'data, 'file> Iterator for PeSegmentIterator<'data, 'file> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use {Machine, SectionKind, Symbol, SymbolMap};
+use {DebugFileInfo, Machine, SectionKind, Symbol, SymbolMap};
 
 /// An object file.
 pub trait Object<'data, 'file> {
@@ -52,6 +52,10 @@ pub trait Object<'data, 'file> {
 
     /// Return true if the file contains debug information sections, false if not.
     fn has_debug_symbols(&self) -> bool;
+
+    /// Get `DebugFileInfo` that can be used to locate external debug symbols for the file
+    /// if present.
+    fn debug_file_info(&self) -> Option<DebugFileInfo>;
 }
 
 /// A loadable segment defined in an object file.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -49,6 +49,9 @@ pub trait Object<'data, 'file> {
 
     /// Return true if the file is little endian, false if it is big endian.
     fn is_little_endian(&self) -> bool;
+
+    /// Return true if the file contains debug information sections, false if not.
+    fn has_debug_symbols(&self) -> bool;
 }
 
 /// A loadable segment defined in an object file.


### PR DESCRIPTION
I have another PR forthcoming to start the `moria` crate, so I've added some useful methods to `Object` in support of that. `Object::has_debug_symbols` is pretty straightforward, and `Object::debug_file_info` exposes the platform-specific info necessary to locate debug info stored in a separate file.