### PR TITLE
Automatically decompress compressed ELF and .zdebug sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/gimli-rs/object"
 
 [dependencies]
+scroll = "0.9"
 uuid = "0.5.1"
+flate2 = { version = "1", optional = true }
 
 [dependencies.goblin]
 version = "0.0.15"
@@ -20,4 +22,5 @@ memmap = "0.6"
 
 [features]
 std = ["goblin/std"]
-default = ["std"]
+compression = ["flate2"]
+default = ["std", "compression"]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::slice;
+use alloc::borrow;
 use alloc::vec::Vec;
 
 use goblin::{elf, strtab};
@@ -106,11 +107,13 @@ where
         }
     }
 
-    fn section_data_by_name(&self, section_name: &str) -> Option<&'data [u8]> {
+    fn section_data_by_name(&self, section_name: &str) -> Option<borrow::Cow<'data, [u8]>> {
         for header in &self.elf.section_headers {
             if let Some(Ok(name)) = self.elf.shdr_strtab.get(header.sh_name) {
                 if name == section_name {
-                    return Some(&self.data[header.sh_offset as usize..][..header.sh_size as usize]);
+                    return Some(borrow::Cow::Borrowed(
+                        &self.data[header.sh_offset as usize..][..header.sh_size as usize]
+                    ));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod alloc {
 }
 
 use std::fmt;
+use alloc::borrow;
 use alloc::vec::Vec;
 
 mod elf;
@@ -312,7 +313,7 @@ where
         }
     }
 
-    fn section_data_by_name(&self, section_name: &str) -> Option<&'data [u8]> {
+    fn section_data_by_name(&self, section_name: &str) -> Option<borrow::Cow<'data, [u8]>> {
         with_inner!(self.inner, FileInternal, |x| {
             x.section_data_by_name(section_name)
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,11 @@ extern crate core as std;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(feature = "compression")]
+extern crate flate2;
+
 extern crate goblin;
+extern crate scroll;
 extern crate uuid;
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,15 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(feature = "std")]
+#[macro_use]
 extern crate std;
 
 #[cfg(not(feature = "std"))]
 extern crate core as std;
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature="compression"))]
+#[macro_use]
+extern crate alloc;
+#[cfg(all(not(feature = "std"), not(feature="compression")))]
 extern crate alloc;
 
 #[cfg(feature = "compression")]
@@ -29,10 +33,11 @@ extern crate uuid;
 #[cfg(feature = "std")]
 mod alloc {
     pub use std::borrow;
+    pub use std::fmt;
     pub use std::vec;
 }
 
-use std::fmt;
+use alloc::fmt;
 use alloc::borrow;
 use alloc::vec::Vec;
 

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::slice;
+use alloc::borrow;
 use alloc::vec::Vec;
 
 use goblin::mach;
@@ -96,7 +97,7 @@ where
         }
     }
 
-    fn section_data_by_name(&self, section_name: &str) -> Option<&'data [u8]> {
+    fn section_data_by_name(&self, section_name: &str) -> Option<borrow::Cow<'data, [u8]>> {
         // Translate the "." prefix to the "__" prefix used by OSX/Mach-O, eg
         // ".debug_info" to "__debug_info".
         let (system_section, section_name) = if section_name.starts_with('.') {
@@ -115,7 +116,7 @@ where
                 if let Ok((section, data)) = section {
                     if let Ok(name) = section.name() {
                         if cmp_section_name(name) {
-                            return Some(data);
+                            return Some(borrow::Cow::Borrowed(data));
                         }
                     }
                 }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -105,14 +105,14 @@ where
         }
     }
 
-    fn section_data_by_name(&self, section_name: &str) -> Option<&'data [u8]> {
+    fn section_data_by_name(&self, section_name: &str) -> Option<borrow::Cow<'data, [u8]>> {
         for section in &self.pe.sections {
             if let Ok(name) = section.name() {
                 if name == section_name {
-                    return Some(
+                    return Some(borrow::Cow::Borrowed(
                         &self.data[section.pointer_to_raw_data as usize..]
                             [..section.size_of_raw_data as usize],
-                    );
+                    ));
                 }
             }
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,5 @@
+use alloc::borrow::Cow;
+
 use {DebugFileInfo, Machine, SectionKind, Symbol, SymbolMap};
 
 /// An object file.
@@ -36,7 +38,9 @@ pub trait Object<'data, 'file> {
     ///
     /// For some object files, multiple segments may contain sections with the same
     /// name. In this case, the first matching section will be used.
-    fn section_data_by_name(&self, section_name: &str) -> Option<&'data [u8]>;
+    ///
+    /// This may decompress section data.
+    fn section_data_by_name(&self, section_name: &str) -> Option<Cow<'data, [u8]>>;
 
     /// Get an iterator over the sections in the file.
     fn sections(&'file self) -> Self::SectionIterator;
@@ -89,9 +93,10 @@ pub trait ObjectSection<'data> {
     /// Returns the size of the section in memory.
     fn size(&self) -> u64;
 
-    /// Returns a reference to the contents of the section.
+    /// Returns a reference to the raw contents of the section.
     /// The length of this data may be different from the size of the
     /// section in memory.
+    /// This does not do any decompression.
     fn data(&self) -> &'data [u8];
 
     /// Returns the name of the section.


### PR DESCRIPTION
I created two separate features for this, `compression` and `zdebug`. I made `zdebug` separate because in theory someone could extend `flate2` to build without `std`, and then `compression` would build without `std` but `zdebug` would not because it requires `format!` (and I don't know how to do string concatenation without `std`). Perhaps we should just not worry about that and eliminate `zdebug`, though the extra feature is on by default so it's not much of a burden.

Note that this is a breaking change to the `find_section_data_by_name`, but I think that's what Philip wanted.