### PR TITLE
Define NativeFile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,22 @@ pub use wasm::*;
 
 pub use uuid::Uuid;
 
+/// The native object file for the target platform.
+#[cfg(target_os = "linux")]
+pub type NativeFile<'data> = ElfFile<'data>;
+
+/// The native object file for the target platform.
+#[cfg(target_os = "macos")]
+pub type NativeFile<'data> = MachOFile<'data>;
+
+/// The native object file for the target platform.
+#[cfg(target_os = "windows")]
+pub type NativeFile<'data> = PeFile<'data>;
+
+/// The native object file for the target platform.
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+pub type NativeFile<'data> = WasmFile<'data>;
+
 /// An object file.
 #[derive(Debug)]
 pub struct File<'data> {


### PR DESCRIPTION
Fixes #53 

I looked into also adding feature flags, but didn't for two reasons
- we would still have to enable all goblin features anyway for `peek_bytes`
- the cfg attributes were getting messy, eg due to unused lifetimes on enums (maybe it would have been better to leave the lifetimes on wasm after all, but that wasn't the only case)