### PR TITLE
Implement debug_file_info() for ELF

### DIFF
--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -40,6 +40,16 @@ fn main() {
             }
         };
 
+        if let Some(uuid) = file.mach_uuid() {
+            println!("Mach UUID: {}", uuid);
+        }
+        if let Some(build_id) = file.build_id() {
+            println!("Build ID: {:x?}", build_id);
+        }
+        if let Some((filename, crc)) = file.gnu_debuglink() {
+            println!("GNU debug link: {} CRC: {:08x}", String::from_utf8_lossy(filename), crc);
+        }
+
         for segment in file.segments() {
             println!("{:?}", segment);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,13 +109,6 @@ pub enum Machine {
     X86_64,
 }
 
-/// Information from an object file that can be used to locate separate debug info.
-#[derive(Debug, Clone, Copy)]
-pub enum DebugFileInfo {
-    /// The UUID from a Mach-O `LC_UUID` load command.
-    MachOUuid(Uuid),
-}
-
 /// An iterator over the segments of a `File`.
 #[derive(Debug)]
 pub struct SegmentIterator<'data, 'file>
@@ -429,8 +422,19 @@ where
         with_inner!(self.inner, FileInternal, |x| x.has_debug_symbols())
     }
 
-    fn debug_file_info(&self) -> Option<DebugFileInfo> {
-        with_inner!(self.inner, FileInternal, |x| x.debug_file_info())
+    #[inline]
+    fn mach_uuid(&self) -> Option<Uuid> {
+        with_inner!(self.inner, FileInternal, |x| x.mach_uuid())
+    }
+
+    #[inline]
+    fn build_id(&self) -> Option<&'data [u8]> {
+        with_inner!(self.inner, FileInternal, |x| x.build_id())
+    }
+
+    #[inline]
+    fn gnu_debuglink(&self) -> Option<(&'data [u8], u32)> {
+        with_inner!(self.inner, FileInternal, |x| x.gnu_debuglink())
     }
 
     fn entry(&self) -> u64 {

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -7,8 +7,7 @@ use goblin::mach;
 use goblin::mach::load_command::CommandVariant;
 use uuid::Uuid;
 
-use {DebugFileInfo, Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind,
-     SymbolMap};
+use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap};
 
 /// A Mach-O object file.
 #[derive(Debug)]
@@ -215,14 +214,13 @@ where
         self.section_data_by_name(".debug_info").is_some()
     }
 
-    fn debug_file_info(&self) -> Option<DebugFileInfo> {
+    fn mach_uuid(&self) -> Option<Uuid> {
         // Return the UUID from the `LC_UUID` load command, if one is present.
         self.macho.load_commands.iter().filter_map(|lc| {
             match lc.command {
                 CommandVariant::Uuid(ref cmd) => {
                     //TODO: Uuid should have a `from_array` method that can't fail.
                     Uuid::from_bytes(&cmd.uuid).ok()
-                        .map(|uuid| DebugFileInfo::MachOUuid(uuid))
                 }
                 _ => None,
             }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -5,8 +5,7 @@ use std::slice;
 use goblin::pe;
 
 use {
-    DebugFileInfo, Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind,
-    SymbolMap,
+    Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap,
 };
 
 /// A PE object file.
@@ -162,10 +161,6 @@ where
         // TODO: look at what the mingw toolchain does with DWARF-in-PE, and also
         // whether CodeView-in-PE still works?
         false
-    }
-
-    fn debug_file_info(&self) -> Option<DebugFileInfo> {
-        None
     }
 
     fn entry(&self) -> u64 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use {DebugFileInfo, Machine, SectionKind, Symbol, SymbolMap};
+use {Uuid, Machine, SectionKind, Symbol, SymbolMap};
 
 /// An object file.
 pub trait Object<'data, 'file> {
@@ -59,9 +59,23 @@ pub trait Object<'data, 'file> {
     /// Return true if the file contains debug information sections, false if not.
     fn has_debug_symbols(&self) -> bool;
 
-    /// Get `DebugFileInfo` that can be used to locate external debug symbols for the file
-    /// if present.
-    fn debug_file_info(&self) -> Option<DebugFileInfo>;
+    /// The UUID from a Mach-O `LC_UUID` load command.
+    #[inline]
+    fn mach_uuid(&self) -> Option<Uuid> {
+        None
+    }
+
+    /// The build ID from an ELF `NT_GNU_BUILD_ID` note.
+    #[inline]
+    fn build_id(&self) -> Option<&'data [u8]> {
+        None
+    }
+
+    /// The filename and CRC from a `.gnu_debuglink` section.
+    #[inline]
+    fn gnu_debuglink(&self) -> Option<(&'data [u8], u32)> {
+        None
+    }
 }
 
 /// A loadable segment defined in an object file.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,7 +5,7 @@ use std::slice;
 use std::u64;
 
 use {
-    DebugFileInfo, Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolMap,
+    Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolMap,
 };
 
 /// A WebAssembly object file.
@@ -169,10 +169,6 @@ impl<'file> Object<'static, 'file> for WasmFile {
             elements::Section::Custom(ref c) => c.name().starts_with(".debug_"),
             _ => false,
         })
-    }
-
-    fn debug_file_info(&self) -> Option<DebugFileInfo> {
-        None
     }
 }
 


### PR DESCRIPTION
I'm not sure that putting both build-id and gnu_debuglink in the same enum is correct, since files can have both. Need to split into separate functions? Any opinion on this @luser?