### PR TITLE
Fix scroll features for no_std builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/gimli-rs/object"
 
 [dependencies]
-scroll = "0.9"
+scroll = { version = "0.9", default-features = false }
 uuid = "0.5.1"
 flate2 = { version = "1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/gimli-rs/object"
 
 [dependencies]
 scroll = { version = "0.9", default-features = false }
-uuid = "0.5.1"
+uuid = { version = "0.6", default-features = false }
 flate2 = { version = "1", optional = true }
 
 [dependencies.goblin]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-features = false
 features = ["endian_fd", "elf32", "elf64", "mach32", "mach64", "pe32", "pe64", "archive"]
 
 [dependencies.parity-wasm]
-version = "0.28.0"
+version = "0.31.0"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Probably should come up with a way of testing this properly so it doesn't break again. Currently I'm partially testing by linking with a binary that uses `#[no_std]`, but even that's not correct because I'm still getting linker errors about missing `_Unwind_Resume`. @whitequark Since you've done a bit of no_std work, can you give any pointers on how to test this properly?