### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "Philip Craig <philipjcraig@gmail.com>"]
 name = "object"
-version = "0.8.0"
+version = "0.9.0"
 description = "A unified interface for parsing object file formats."
 keywords = ["object", "loader", "elf", "mach-o", "pe"]
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
Needed for the no_std work in addr2line. Not much has changed, but uuid is part of the public API so it's a breaking change.