### PR TITLE
Issue #40 -- Support DWARF-in-PE

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use std::cmp;
 use std::slice;
 
 use goblin::pe;
@@ -112,7 +113,7 @@ where
                 if name == section_name {
                     return Some(Cow::from(
                         &self.data[section.pointer_to_raw_data as usize..]
-                            [..section.virtual_size as usize],
+                            [..cmp::min(section.virtual_size, section.size_of_raw_data) as usize]
                     ));
                 }
             }


### PR DESCRIPTION
These changes were sufficient to allow reading DWARF records on Mac, Linux, and Windows systems in my application.  I found no formal documentation on how to read DWARF records from a PE file, but arrived at this solution by looking at other code and poking around in a PE file.

DWARF sections names in PE files are stored indirectly through a symbol table.
Names of the form "/n" where "n" is a number indicate the section name is
stored in index "n" of a hidden symbol table.  The hidden symbol table immediately
follows the COFF symbol table and is a sequence of null terminated CStrings.