### PR TITLE
Implement some ELF/Mach-O relocations

### DIFF
--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -3,7 +3,7 @@ extern crate object;
 
 use std::{env, fs, process};
 
-use object::Object;
+use object::{Object, ObjectSection};
 
 fn main() {
     let arg_len = env::args().len();
@@ -60,6 +60,18 @@ fn main() {
 
         for section in file.sections() {
             println!("{:?}", section);
+        }
+
+        for section in file.sections() {
+            if section.relocations().next().is_some() {
+                println!(
+                    "\n{} relocations",
+                    section.name().unwrap_or("<invalid name>")
+                );
+                for relocation in section.relocations() {
+                    println!("{:?}", relocation);
+                }
+            }
         }
     }
 }

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -47,7 +47,11 @@ fn main() {
             println!("Build ID: {:x?}", build_id);
         }
         if let Some((filename, crc)) = file.gnu_debuglink() {
-            println!("GNU debug link: {} CRC: {:08x}", String::from_utf8_lossy(filename), crc);
+            println!(
+                "GNU debug link: {} CRC: {:08x}",
+                String::from_utf8_lossy(filename),
+                crc
+            );
         }
 
         for segment in file.segments() {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -86,83 +86,39 @@ impl<'data> ElfFile<'data> {
         Ok(ElfFile { elf, data })
     }
 
-    #[cfg(feature = "compression")]
-    fn maybe_decompress_data(&self, header: &elf::SectionHeader) -> Cow<'data, [u8]> {
-        let data = &self.data[header.sh_offset as usize..][..header.sh_size as usize];
-        if (header.sh_flags & elf::section_header::SHF_COMPRESSED as u64) == 0 {
-            Cow::Borrowed(data)
-        } else {
-            let container = match self.elf.header.container() {
-                Ok(c) => c,
-                Err(_) => return Cow::Borrowed(data),
-            };
-            let endianness = match self.elf.header.endianness() {
-                Ok(e) => e,
-                Err(_) => return Cow::Borrowed(data),
-            };
-            let ctx = container::Ctx::new(container, endianness);
-            let (compression_type, uncompressed_size, compressed_data) =
-                match elf::compression_header::CompressionHeader::try_from_ctx(data, ctx) {
-                    Ok((chdr, size)) => (chdr.ch_type, chdr.ch_size, &data[size..]),
-                    Err(_) => return Cow::Borrowed(data),
-                };
-            if compression_type != elf::compression_header::ELFCOMPRESS_ZLIB {
-                return Cow::Borrowed(data);
+    fn raw_section_by_name<'file>(
+        &'file self,
+        section_name: &str,
+    ) -> Option<ElfSection<'data, 'file>> {
+        for section in self.elf.section_headers.iter() {
+            if let Some(Ok(name)) = self.elf.shdr_strtab.get(section.sh_name) {
+                if name == section_name {
+                    return Some(ElfSection {
+                        file: self,
+                        section,
+                    });
+                }
             }
-
-            let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
-            let mut decompress = Decompress::new(true);
-            if let Err(_) = decompress.decompress_vec(
-                compressed_data,
-                &mut decompressed,
-                FlushDecompress::Finish,
-            ) {
-                return Cow::Borrowed(data);
-            }
-            Cow::Owned(decompressed)
         }
-    }
-
-    #[cfg(not(feature = "compression"))]
-    fn maybe_decompress_data(&self, header: &elf::SectionHeader) -> Cow<'data, [u8]> {
-        let data = &self.data[header.sh_offset as usize..][..header.sh_size as usize];
-        Cow::Borrowed(data)
+        None
     }
 
     #[cfg(feature = "compression")]
-    /// Try GNU-style "ZLIB" header decompression.
-    fn maybe_decompress_data_gnu(&self, data: Cow<'data, [u8]>) -> Cow<'data, [u8]> {
-        // Assume ZLIB-style uncompressed data is no more than 4GB to avoid accidentally
-        // huge allocations. This also reduces the chance of accidentally matching on a
-        // .debug_str that happens to start with "ZLIB".
-        if data.len() < 12 || &data[..8] != b"ZLIB\0\0\0\0" {
-            return data;
-        }
-        let uncompressed_size: u32 = data.pread_with(8, scroll::BE).unwrap();
-        let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
-        let mut decompress = Decompress::new(true);
-        if let Err(_) =
-            decompress.decompress_vec(&data[12..], &mut decompressed, FlushDecompress::Finish)
-        {
-            return data;
-        }
-        Cow::Owned(decompressed)
-    }
-
-    #[cfg(feature = "compression")]
-    /// Try GNU-style "ZLIB" header decompression.
-    fn try_zdebug_section_data(&self, section_name: &str) -> Option<Cow<'data, [u8]>> {
+    fn zdebug_section_by_name<'file>(
+        &'file self,
+        section_name: &str,
+    ) -> Option<ElfSection<'data, 'file>> {
         if !section_name.starts_with(".debug_") {
             return None;
         }
-        let z_name = format!(".zdebug_{}", &section_name[7..]);
-        // Note that we accept data in .zdebug_ that isn't actually compressed.
-        self.section_data_by_name(&z_name)
-            .map(|data| self.maybe_decompress_data_gnu(data))
+        self.raw_section_by_name(&format!(".zdebug_{}", &section_name[7..]))
     }
 
     #[cfg(not(feature = "compression"))]
-    fn try_zdebug_section_data(&self, _section_name: &str) -> Option<Cow<'data, [u8]>> {
+    fn zdebug_section_by_name<'file>(
+        &'file self,
+        section_name: &str,
+    ) -> Option<ElfSection<'data, 'file>> {
         None
     }
 }
@@ -194,15 +150,9 @@ where
         }
     }
 
-    fn section_data_by_name(&self, section_name: &str) -> Option<Cow<'data, [u8]>> {
-        for header in &self.elf.section_headers {
-            if let Some(Ok(name)) = self.elf.shdr_strtab.get(header.sh_name) {
-                if name == section_name {
-                    return Some(self.maybe_decompress_data(header));
-                }
-            }
-        }
-        self.try_zdebug_section_data(section_name)
+    fn section_by_name(&'file self, section_name: &str) -> Option<ElfSection<'data, 'file>> {
+        self.raw_section_by_name(section_name)
+            .or_else(|| self.zdebug_section_by_name(section_name))
     }
 
     fn sections(&'file self) -> ElfSectionIterator<'data, 'file> {
@@ -344,6 +294,79 @@ impl<'data, 'file> Iterator for ElfSectionIterator<'data, 'file> {
     }
 }
 
+impl<'data, 'file> ElfSection<'data, 'file> {
+    fn raw_data(&self) -> &'data [u8] {
+        if self.section.sh_type == elf::section_header::SHT_NOBITS {
+            &[]
+        } else {
+            &self.file.data[self.section.sh_offset as usize..][..self.section.sh_size as usize]
+        }
+    }
+
+    #[cfg(feature = "compression")]
+    fn maybe_decompress_data(&self) -> Option<Cow<'data, [u8]>> {
+        if (self.section.sh_flags & elf::section_header::SHF_COMPRESSED as u64) == 0 {
+            return None;
+        }
+
+        let container = match self.file.elf.header.container() {
+            Ok(c) => c,
+            Err(_) => return None,
+        };
+        let endianness = match self.file.elf.header.endianness() {
+            Ok(e) => e,
+            Err(_) => return None,
+        };
+        let ctx = container::Ctx::new(container, endianness);
+        let data = self.raw_data();
+        let (compression_type, uncompressed_size, compressed_data) =
+            match elf::compression_header::CompressionHeader::try_from_ctx(&data, ctx) {
+                Ok((chdr, size)) => (chdr.ch_type, chdr.ch_size, &data[size..]),
+                Err(_) => return None,
+            };
+        if compression_type != elf::compression_header::ELFCOMPRESS_ZLIB {
+            return None;
+        }
+
+        let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
+        let mut decompress = Decompress::new(true);
+        if let Err(_) =
+            decompress.decompress_vec(compressed_data, &mut decompressed, FlushDecompress::Finish)
+        {
+            return None;
+        }
+        Some(Cow::Owned(decompressed))
+    }
+
+    /// Try GNU-style "ZLIB" header decompression.
+    #[cfg(feature = "compression")]
+    fn maybe_decompress_data_gnu(&self) -> Option<Cow<'data, [u8]>> {
+        let name = match self.name() {
+            Some(name) => name,
+            None => return None,
+        };
+        if !name.starts_with(".zdebug_") {
+            return None;
+        }
+        let data = self.raw_data();
+        // Assume ZLIB-style uncompressed data is no more than 4GB to avoid accidentally
+        // huge allocations. This also reduces the chance of accidentally matching on a
+        // .debug_str that happens to start with "ZLIB".
+        if data.len() < 12 || &data[..8] != b"ZLIB\0\0\0\0" {
+            return None;
+        }
+        let uncompressed_size: u32 = data.pread_with(8, scroll::BE).unwrap();
+        let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
+        let mut decompress = Decompress::new(true);
+        if let Err(_) =
+            decompress.decompress_vec(&data[12..], &mut decompressed, FlushDecompress::Finish)
+        {
+            return None;
+        }
+        Some(Cow::Owned(decompressed))
+    }
+}
+
 impl<'data, 'file> ObjectSection<'data> for ElfSection<'data, 'file> {
     #[inline]
     fn address(&self) -> u64 {
@@ -355,12 +378,22 @@ impl<'data, 'file> ObjectSection<'data> for ElfSection<'data, 'file> {
         self.section.sh_size
     }
 
+    #[inline]
     fn data(&self) -> Cow<'data, [u8]> {
-        Cow::from(if self.section.sh_type == elf::section_header::SHT_NOBITS {
-            &[]
-        } else {
-            &self.file.data[self.section.sh_offset as usize..][..self.section.sh_size as usize]
-        })
+        Cow::from(self.raw_data())
+    }
+
+    #[cfg(feature = "compression")]
+    fn uncompressed_data(&self) -> Cow<'data, [u8]> {
+        self.maybe_decompress_data()
+            .or_else(|| self.maybe_decompress_data_gnu())
+            .unwrap_or_else(|| self.data())
+    }
+
+    #[cfg(not(feature = "compression"))]
+    #[inline]
+    fn uncompressed_data(&self) -> Cow<'data, [u8]> {
+        self.data()
     }
 
     fn name(&self) -> Option<&str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(all(not(feature = "std"), feature="compression"))]
+#[cfg(all(not(feature = "std"), feature = "compression"))]
 #[macro_use]
 extern crate alloc;
-#[cfg(all(not(feature = "std"), not(feature="compression")))]
+#[cfg(all(not(feature = "std"), not(feature = "compression")))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 extern crate core as std;
@@ -374,39 +374,34 @@ where
 
     fn segments(&'file self) -> SegmentIterator<'data, 'file> {
         SegmentIterator {
-            inner: map_inner!(self.inner, FileInternal, SegmentIteratorInternal, |x| {
-                x.segments()
-            }),
+            inner: map_inner!(self.inner, FileInternal, SegmentIteratorInternal, |x| x
+                .segments()),
         }
     }
 
     fn section_data_by_name(&self, section_name: &str) -> Option<Cow<'data, [u8]>> {
-        with_inner!(self.inner, FileInternal, |x| x.section_data_by_name(
-            section_name
-        ))
+        with_inner!(self.inner, FileInternal, |x| x
+            .section_data_by_name(section_name))
     }
 
     fn sections(&'file self) -> SectionIterator<'data, 'file> {
         SectionIterator {
-            inner: map_inner!(self.inner, FileInternal, SectionIteratorInternal, |x| {
-                x.sections()
-            }),
+            inner: map_inner!(self.inner, FileInternal, SectionIteratorInternal, |x| x
+                .sections()),
         }
     }
 
     fn symbols(&'file self) -> SymbolIterator<'data, 'file> {
         SymbolIterator {
-            inner: map_inner!(self.inner, FileInternal, SymbolIteratorInternal, |x| {
-                x.symbols()
-            }),
+            inner: map_inner!(self.inner, FileInternal, SymbolIteratorInternal, |x| x
+                .symbols()),
         }
     }
 
     fn dynamic_symbols(&'file self) -> SymbolIterator<'data, 'file> {
         SymbolIterator {
-            inner: map_inner!(self.inner, FileInternal, SymbolIteratorInternal, |x| {
-                x.dynamic_symbols()
-            }),
+            inner: map_inner!(self.inner, FileInternal, SymbolIteratorInternal, |x| x
+                .dynamic_symbols()),
         }
     }
 
@@ -597,8 +592,7 @@ impl<'data> SymbolMap<'data> {
                 } else {
                     std::cmp::Ordering::Less
                 }
-            })
-            .ok()
+            }).ok()
             .and_then(|index| self.symbols.get(index))
     }
 

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use std::fmt;
 use std::slice;
-use alloc::vec::Vec;
 
 use goblin::mach;
 use goblin::mach::load_command::CommandVariant;
@@ -104,10 +104,12 @@ where
         } else {
             (false, section_name)
         };
-        let cmp_section_name = |name: &str| if system_section {
-            name.starts_with("__") && section_name == &name[2..]
-        } else {
-            section_name == name
+        let cmp_section_name = |name: &str| {
+            if system_section {
+                name.starts_with("__") && section_name == &name[2..]
+            } else {
+                section_name == name
+            }
         };
 
         for segment in &self.macho.segments {
@@ -218,15 +220,18 @@ where
 
     fn mach_uuid(&self) -> Option<Uuid> {
         // Return the UUID from the `LC_UUID` load command, if one is present.
-        self.macho.load_commands.iter().filter_map(|lc| {
-            match lc.command {
-                CommandVariant::Uuid(ref cmd) => {
-                    //TODO: Uuid should have a `from_array` method that can't fail.
-                    Uuid::from_slice(&cmd.uuid).ok()
+        self.macho
+            .load_commands
+            .iter()
+            .filter_map(|lc| {
+                match lc.command {
+                    CommandVariant::Uuid(ref cmd) => {
+                        //TODO: Uuid should have a `from_array` method that can't fail.
+                        Uuid::from_slice(&cmd.uuid).ok()
+                    }
+                    _ => None,
                 }
-                _ => None,
-            }
-        }).nth(0)
+            }).nth(0)
     }
 
     fn entry(&self) -> u64 {

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -5,9 +5,7 @@ use std::slice;
 
 use goblin::pe;
 
-use {
-    Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap,
-};
+use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolKind, SymbolMap};
 
 /// A PE object file.
 #[derive(Debug)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use {Machine, SectionKind, Symbol, SymbolMap, Uuid};
+use {Machine, Relocation, SectionKind, Symbol, SymbolMap, Uuid};
 
 /// An object file.
 pub trait Object<'data, 'file> {
@@ -111,6 +111,12 @@ pub trait ObjectSegment<'data> {
 
 /// A section defined in an object file.
 pub trait ObjectSection<'data> {
+    /// An iterator over the relocations for a section.
+    ///
+    /// The first field in the item tuple is the section offset
+    /// that the relocation applies to.
+    type RelocationIterator: Iterator<Item = (u64, Relocation)>;
+
     /// Returns the address of the section.
     fn address(&self) -> u64;
 
@@ -137,4 +143,7 @@ pub trait ObjectSection<'data> {
 
     /// Return the kind of this section.
     fn kind(&self) -> SectionKind;
+
+    /// Get the relocations for this section.
+    fn relocations(&self) -> Self::RelocationIterator;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use {Uuid, Machine, SectionKind, Symbol, SymbolMap};
+use {Machine, SectionKind, Symbol, SymbolMap, Uuid};
 
 /// An object file.
 pub trait Object<'data, 'file> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -27,19 +27,30 @@ pub trait Object<'data, 'file> {
     /// Get the entry point address of the binary
     fn entry(&'file self) -> u64;
 
-    /// Get the contents of the section named `section_name`, if such
-    /// a section exists.
+    /// Get the section named `section_name`, if such a section exists.
     ///
     /// If `section_name` starts with a '.' then it is treated as a system section name,
-    /// and is compared using the conventions specific to the object file format.
-    /// For example, if ".text" is requested for a Mach-O object file, then the actual
+    /// and is compared using the conventions specific to the object file format. This
+    /// includes:
+    /// - if ".text" is requested for a Mach-O object file, then the actual
     /// section name that is searched for is "__text".
+    /// - if ".debug_info" is requested for an ELF object file, then
+    /// ".zdebug_info" may be returned (and similarly for other debug sections).
     ///
     /// For some object files, multiple segments may contain sections with the same
     /// name. In this case, the first matching section will be used.
+    fn section_by_name(&'file self, section_name: &str) -> Option<Self::Section>;
+
+    /// Get the contents of the section named `section_name`, if such
+    /// a section exists.
+    ///
+    /// The `section_name` is interpreted according to `Self::section_by_name`.
     ///
     /// This may decompress section data.
-    fn section_data_by_name(&self, section_name: &str) -> Option<Cow<'data, [u8]>>;
+    fn section_data_by_name(&'file self, section_name: &str) -> Option<Cow<'data, [u8]>> {
+        self.section_by_name(section_name)
+            .map(|section| section.uncompressed_data())
+    }
 
     /// Get an iterator over the sections in the file.
     fn sections(&'file self) -> Self::SectionIterator;
@@ -106,12 +117,17 @@ pub trait ObjectSection<'data> {
     /// Returns the size of the section in memory.
     fn size(&self) -> u64;
 
-    /// Returns a reference to the raw contents of the section.
+    /// Returns the raw contents of the section.
     /// The length of this data may be different from the size of the
     /// section in memory.
     ///
     /// This does not do any decompression.
     fn data(&self) -> Cow<'data, [u8]>;
+
+    /// Returns the uncompressed contents of the section.
+    /// The length of this data may be different from the size of the
+    /// section in memory.
+    fn uncompressed_data(&self) -> Cow<'data, [u8]>;
 
     /// Returns the name of the section.
     fn name(&self) -> Option<&str>;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,9 +4,7 @@ use std::borrow::{Cow, ToOwned};
 use std::slice;
 use std::u64;
 
-use {
-    Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolMap,
-};
+use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolMap};
 
 /// A WebAssembly object file.
 #[derive(Debug)]
@@ -17,10 +15,9 @@ pub struct WasmFile {
 impl<'data> WasmFile {
     /// Parse the raw wasm data.
     pub fn parse(mut data: &'data [u8]) -> Result<Self, &'static str> {
-        let module = elements::Module::deserialize(&mut data).map_err(|_| "failed to parse wasm")?;
-        Ok(WasmFile {
-            module,
-        })
+        let module =
+            elements::Module::deserialize(&mut data).map_err(|_| "failed to parse wasm")?;
+        Ok(WasmFile { module })
     }
 }
 
@@ -75,9 +72,7 @@ impl<'file> Object<'static, 'file> for WasmFile {
     }
 
     fn segments(&'file self) -> Self::SegmentIterator {
-        WasmSegmentIterator {
-            file: self,
-        }
+        WasmSegmentIterator { file: self }
     }
 
     fn entry(&'file self) -> u64 {
@@ -87,37 +82,48 @@ impl<'file> Object<'static, 'file> for WasmFile {
     fn section_data_by_name(&self, section_name: &str) -> Option<Cow<'static, [u8]>> {
         match section_name {
             // Known wasm section names.
-            "Type" => self.module
+            "Type" => self
+                .module
                 .type_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Import" => self.module
+            "Import" => self
+                .module
                 .import_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Function" => self.module
+            "Function" => self
+                .module
                 .function_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Table" => self.module
+            "Table" => self
+                .module
                 .table_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Memory" => self.module
+            "Memory" => self
+                .module
                 .memory_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Global" => self.module
+            "Global" => self
+                .module
                 .global_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Export" => self.module
+            "Export" => self
+                .module
                 .export_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Start" => self.module
+            "Start" => self
+                .module
                 .start_section()
                 .and_then(|s| serialize_to_cow(elements::VarUint32::from(s))),
-            "Element" => self.module
+            "Element" => self
+                .module
                 .elements_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Code" => self.module
+            "Code" => self
+                .module
                 .code_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
-            "Data" => self.module
+            "Data" => self
+                .module
                 .data_section()
                 .and_then(|s| serialize_to_cow(s.clone())),
             // Custom sections.
@@ -141,15 +147,11 @@ impl<'file> Object<'static, 'file> for WasmFile {
     }
 
     fn symbols(&'file self) -> Self::SymbolIterator {
-        WasmSymbolIterator {
-            file: self,
-        }
+        WasmSymbolIterator { file: self }
     }
 
     fn dynamic_symbols(&'file self) -> Self::SymbolIterator {
-        WasmSymbolIterator {
-            file: self,
-        }
+        WasmSymbolIterator { file: self }
     }
 
     fn symbol_map(&self) -> SymbolMap<'static> {
@@ -205,9 +207,7 @@ impl<'file> Iterator for WasmSectionIterator<'file> {
     type Item = WasmSection<'file>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.sections.next().map(|s| WasmSection {
-            section: s,
-        })
+        self.sections.next().map(|s| WasmSection { section: s })
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::slice;
 use std::u64;
 
-use {Machine, Object, ObjectSection, ObjectSegment, SectionKind, Symbol, SymbolMap};
+use {Machine, Object, ObjectSection, ObjectSegment, Relocation, SectionKind, Symbol, SymbolMap};
 
 /// A WebAssembly object file.
 #[derive(Debug)]
@@ -50,6 +50,10 @@ pub struct WasmSection<'file> {
 pub struct WasmSymbolIterator<'file> {
     file: &'file WasmFile,
 }
+
+/// An iterator over the relocations in an `WasmSection`.
+#[derive(Debug)]
+pub struct WasmRelocationIterator;
 
 fn serialize_to_cow<'a, S>(s: S) -> Option<Cow<'a, [u8]>>
 where
@@ -161,6 +165,8 @@ impl<'file> Iterator for WasmSectionIterator<'file> {
 }
 
 impl<'file> ObjectSection<'static> for WasmSection<'file> {
+    type RelocationIterator = WasmRelocationIterator;
+
     #[inline]
     fn address(&self) -> u64 {
         1
@@ -230,6 +236,10 @@ impl<'file> ObjectSection<'static> for WasmSection<'file> {
             elements::Section::Reloc(_) => SectionKind::Other,
         }
     }
+
+    fn relocations(&self) -> WasmRelocationIterator {
+        WasmRelocationIterator
+    }
 }
 
 impl<'file> Iterator for WasmSymbolIterator<'file> {
@@ -237,5 +247,13 @@ impl<'file> Iterator for WasmSymbolIterator<'file> {
 
     fn next(&mut self) -> Option<Self::Item> {
         unimplemented!()
+    }
+}
+
+impl Iterator for WasmRelocationIterator {
+    type Item = (u64, Relocation);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
     }
 }


### PR DESCRIPTION
This returns the relocations only. It is up to the caller to apply them.

These are the minimum ELF relocations that I need to dwarfdump an object file. The Mach-O relocations weren't needed for that (because it has implicit addends), but it helps generalize the API.

I didn't look into PE relocations (it'll only be dynamic linking relocations?), and we don't support COFF yet.

WASM is probably going to be rather different, but I didn't look into it much. It'll be okay to add WASM specific entries to `RelocationKind`.

Note: there's an initial commit with rustfmt changes.

Fixes #4 