### PR TITLE
Fix unused variable `section_name` of `elf::zdebug_section_by_name`

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -135,7 +135,7 @@ impl<'data> ElfFile<'data> {
     #[cfg(not(feature = "compression"))]
     fn zdebug_section_by_name<'file>(
         &'file self,
-        _: &str,
+        _section_name: &str,
     ) -> Option<ElfSection<'data, 'file>> {
         None
     }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -135,7 +135,7 @@ impl<'data> ElfFile<'data> {
     #[cfg(not(feature = "compression"))]
     fn zdebug_section_by_name<'file>(
         &'file self,
-        section_name: &str,
+        _: &str,
     ) -> Option<ElfSection<'data, 'file>> {
         None
     }


### PR DESCRIPTION
From Travis log:
```rust
$ if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo build --no-default-features; fi
   Compiling object v0.11.0 (/home/travis/build/gimli-rs/object)
warning: unused variable: `section_name`
   --> src/elf.rs:138:9
    |
138 |         section_name: &str,
    |         ^^^^^^^^^^^^ help: consider prefixing with an underscore: `_section_name`
    |
    = note: #[warn(unused_variables)] on by default
    Finished dev [unoptimized + debuginfo] target(s) in 0.57s
```