### PR TITLE
Add more details for sections and symbols

### DIFF
--- a/examples/nm.rs
+++ b/examples/nm.rs
@@ -61,12 +61,14 @@ fn print_symbol(symbol: &Symbol<'_>, section_kinds: &HashMap<SectionIndex, Secti
         .section_index()
         .and_then(|index| section_kinds.get(&index))
     {
-        Some(SectionKind::Unknown) => '?',
+        Some(SectionKind::Unknown)
+        | Some(SectionKind::Other)
+        | Some(SectionKind::OtherString)
+        | Some(SectionKind::Metadata) => '?',
         Some(SectionKind::Text) => 't',
-        Some(SectionKind::Data) => 'd',
-        Some(SectionKind::ReadOnlyData) => 'r',
-        Some(SectionKind::UninitializedData) => 'b',
-        Some(SectionKind::Other) => 's',
+        Some(SectionKind::Data) | Some(SectionKind::Tls) => 'd',
+        Some(SectionKind::ReadOnlyData) | Some(SectionKind::ReadOnlyString) => 'r',
+        Some(SectionKind::UninitializedData) | Some(SectionKind::UninitializedTls) => 'b',
         None => 'U',
     };
 

--- a/examples/nm.rs
+++ b/examples/nm.rs
@@ -40,13 +40,13 @@ fn main() {
         let section_kinds = file.sections().map(|s| (s.index(), s.kind())).collect();
 
         println!("Debugging symbols:");
-        for symbol in file.symbols() {
+        for (_, symbol) in file.symbols() {
             print_symbol(&symbol, &section_kinds);
         }
         println!();
 
         println!("Dynamic symbols:");
-        for symbol in file.dynamic_symbols() {
+        for (_, symbol) in file.dynamic_symbols() {
             print_symbol(&symbol, &section_kinds);
         }
     }

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -54,8 +54,12 @@ fn main() {
             println!("{:?}", segment);
         }
 
-        for section in file.sections() {
-            println!("{:?}", section);
+        for (index, section) in file.sections().enumerate() {
+            println!("{}: {:?}", index, section);
+        }
+
+        for (index, symbol) in file.symbols() {
+            println!("{}: {:?}", index.0, symbol);
         }
 
         for section in file.sections() {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -307,6 +307,11 @@ impl<'data, 'file> ObjectSegment<'data> for ElfSegment<'data, 'file> {
         self.segment.p_memsz
     }
 
+    #[inline]
+    fn align(&self) -> u64 {
+        self.segment.p_align
+    }
+
     fn data(&self) -> &'data [u8] {
         &self.file.data[self.segment.p_offset as usize..][..self.segment.p_filesz as usize]
     }
@@ -424,6 +429,11 @@ impl<'data, 'file> ObjectSection<'data> for ElfSection<'data, 'file> {
     #[inline]
     fn size(&self) -> u64 {
         self.section.sh_size
+    }
+
+    #[inline]
+    fn align(&self) -> u64 {
+        self.section.sh_addralign
     }
 
     #[inline]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -102,6 +102,12 @@ impl<'data> ElfFile<'data> {
         Ok(ElfFile { elf, data })
     }
 
+    /// True for 64-bit files.
+    #[inline]
+    pub fn is_64(&self) -> bool {
+        self.elf.is_64
+    }
+
     fn raw_section_by_name<'file>(
         &'file self,
         section_name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,10 @@ impl<'data, 'file> ObjectSegment<'data> for Segment<'data, 'file> {
         with_inner!(self.inner, SegmentInternal, |x| x.size())
     }
 
+    fn align(&self) -> u64 {
+        with_inner!(self.inner, SegmentInternal, |x| x.align())
+    }
+
     fn data(&self) -> &'data [u8] {
         with_inner!(self.inner, SegmentInternal, |x| x.data())
     }
@@ -583,6 +587,10 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
 
     fn size(&self) -> u64 {
         with_inner!(self.inner, SectionInternal, |x| x.size())
+    }
+
+    fn align(&self) -> u64 {
+        with_inner!(self.inner, SectionInternal, |x| x.align())
     }
 
     fn data(&self) -> Cow<'data, [u8]> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,10 @@ where
     Wasm(WasmSymbolIterator<'file>),
 }
 
+/// The index used to identify a symbol of a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SymbolIndex(pub usize);
+
 /// A symbol table entry.
 #[derive(Debug)]
 pub struct Symbol<'data> {
@@ -297,7 +301,7 @@ pub struct SymbolMap<'data> {
 #[derive(Debug)]
 pub struct Relocation {
     kind: RelocationKind,
-    symbol: u64,
+    symbol: SymbolIndex,
     addend: i64,
     implicit_addend: bool,
 }
@@ -487,7 +491,7 @@ where
         }
     }
 
-    fn symbol_by_index(&self, index: u64) -> Option<Symbol<'data>> {
+    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>> {
         with_inner!(self.inner, FileInternal, |x| x.symbol_by_index(index))
     }
 
@@ -660,7 +664,7 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
 }
 
 impl<'data, 'file> Iterator for SymbolIterator<'data, 'file> {
-    type Item = Symbol<'data>;
+    type Item = (SymbolIndex, Symbol<'data>);
 
     fn next(&mut self) -> Option<Self::Item> {
         with_inner_mut!(self.inner, SymbolIteratorInternal, |x| x.next())
@@ -770,7 +774,7 @@ impl Relocation {
 
     /// The index of the symbol within the symbol table, if applicable.
     #[inline]
-    pub fn symbol(&self) -> u64 {
+    pub fn symbol(&self) -> SymbolIndex {
         self.symbol
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,15 +194,45 @@ pub enum SectionKind {
     /// The section kind is unknown.
     Unknown,
     /// An executable code section.
+    ///
+    /// Example ELF sections: `.text`
     Text,
     /// A data section.
+    ///
+    /// Example ELF sections: `.data`
     Data,
     /// A read only data section.
+    ///
+    /// Example ELF sections: `.rodata`
     ReadOnlyData,
+    /// A loadable string section.
+    ///
+    /// Example ELF sections: `.rodata.str`
+    ReadOnlyString,
     /// An uninitialized data section.
+    ///
+    /// Example ELF sections: `.bss`
     UninitializedData,
-    /// Some other type of text or data section.
+    /// A TLS data section.
+    ///
+    /// Example ELF sections: `.tdata`
+    Tls,
+    /// An uninitialized TLS data section.
+    ///
+    /// Example ELF sections: `.tbss`
+    UninitializedTls,
+    /// A non-loadable string section.
+    ///
+    /// Example ELF sections: `.comment`, `.debug_str`
+    OtherString,
+    /// Some other non-loadable section.
+    ///
+    /// Example ELF sections: `.debug_info`
     Other,
+    /// Metadata such as symbols or relocations.
+    ///
+    /// Example ELF sections: `.symtab`, `.strtab`
+    Metadata,
 }
 
 /// An iterator over symbol table entries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,8 @@ pub struct Symbol<'data> {
 pub enum SymbolKind {
     /// The symbol kind is unknown.
     Unknown,
+    /// The symbol is a null placeholder.
+    Null,
     /// The symbol is for executable code.
     Text,
     /// The symbol is for a data object.
@@ -749,7 +751,11 @@ impl<'data> SymbolMap<'data> {
     fn filter(symbol: &Symbol<'_>) -> bool {
         match symbol.kind() {
             SymbolKind::Unknown | SymbolKind::Text | SymbolKind::Data => {}
-            SymbolKind::Section | SymbolKind::File | SymbolKind::Common | SymbolKind::Tls => {
+            SymbolKind::Null
+            | SymbolKind::Section
+            | SymbolKind::File
+            | SymbolKind::Common
+            | SymbolKind::Tls => {
                 return false;
             }
         }

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -454,32 +454,32 @@ impl<'data, 'file> Iterator for MachORelocationIterator<'data, 'file> {
     fn next(&mut self) -> Option<Self::Item> {
         self.relocations.next()?.ok().map(|reloc| {
             let kind = match self.file.macho.header.cputype {
-                mach::cputype::CPU_TYPE_ARM => match (reloc.r_type(), reloc.r_length()) {
-                    (mach::relocation::ARM_RELOC_VANILLA, 2) => RelocationKind::Direct32,
-                    (mach::relocation::ARM_RELOC_VANILLA, 3) => RelocationKind::Direct64,
+                mach::cputype::CPU_TYPE_ARM => match reloc.r_type() {
+                    mach::relocation::ARM_RELOC_VANILLA => RelocationKind::Absolute,
                     _ => RelocationKind::Other(reloc.r_info),
                 },
-                mach::cputype::CPU_TYPE_ARM64 => match (reloc.r_type(), reloc.r_length()) {
-                    (mach::relocation::ARM64_RELOC_UNSIGNED, 2) => RelocationKind::Direct32,
-                    (mach::relocation::ARM64_RELOC_UNSIGNED, 3) => RelocationKind::Direct64,
+                mach::cputype::CPU_TYPE_ARM64 => match reloc.r_type() {
+                    mach::relocation::ARM64_RELOC_UNSIGNED => RelocationKind::Absolute,
                     _ => RelocationKind::Other(reloc.r_info),
                 },
-                mach::cputype::CPU_TYPE_X86 => match (reloc.r_type(), reloc.r_length()) {
-                    (mach::relocation::GENERIC_RELOC_VANILLA, 2) => RelocationKind::Direct32,
-                    (mach::relocation::GENERIC_RELOC_VANILLA, 3) => RelocationKind::Direct64,
+                mach::cputype::CPU_TYPE_X86 => match reloc.r_type() {
+                    mach::relocation::GENERIC_RELOC_VANILLA => RelocationKind::Absolute,
                     _ => RelocationKind::Other(reloc.r_info),
                 },
-                mach::cputype::CPU_TYPE_X86_64 => match (reloc.r_type(), reloc.r_length()) {
-                    (mach::relocation::X86_64_RELOC_UNSIGNED, 2) => RelocationKind::Direct32,
-                    (mach::relocation::X86_64_RELOC_UNSIGNED, 3) => RelocationKind::Direct64,
+                mach::cputype::CPU_TYPE_X86_64 => match reloc.r_type() {
+                    mach::relocation::X86_64_RELOC_UNSIGNED => RelocationKind::Absolute,
                     _ => RelocationKind::Other(reloc.r_info),
                 },
                 _ => RelocationKind::Other(reloc.r_info),
             };
+            let size = reloc.r_length() * 8;
+            // FIXME: reloc.r_pcrel()
             (
                 reloc.r_address as u64,
                 Relocation {
                     kind,
+                    size,
+                    // FIXME: handle reloc.is_extern()
                     symbol: SymbolIndex(reloc.r_symbolnum()),
                     addend: 0,
                     implicit_addend: true,

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -92,6 +92,12 @@ impl<'data> MachOFile<'data> {
         let macho = mach::MachO::parse(data, 0).map_err(|_| "Could not parse Mach-O header")?;
         Ok(MachOFile { macho, data, ctx })
     }
+
+    /// True for 64-bit files.
+    #[inline]
+    pub fn is_64(&self) -> bool {
+        self.macho.is_64
+    }
 }
 
 impl<'data, 'file> Object<'data, 'file> for MachOFile<'data>

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -275,6 +275,12 @@ impl<'data, 'file> ObjectSegment<'data> for MachOSegment<'data, 'file> {
     }
 
     #[inline]
+    fn align(&self) -> u64 {
+        // Page size.
+        0x1000
+    }
+
+    #[inline]
     fn data(&self) -> &'data [u8] {
         self.segment.data
     }
@@ -347,6 +353,11 @@ impl<'data, 'file> ObjectSection<'data> for MachOSection<'data, 'file> {
     #[inline]
     fn size(&self) -> u64 {
         self.section.size
+    }
+
+    #[inline]
+    fn align(&self) -> u64 {
+        1 << self.section.align
     }
 
     #[inline]

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -86,6 +86,12 @@ impl<'data> PeFile<'data> {
         Ok(PeFile { pe, data })
     }
 
+    /// True for 64-bit files.
+    #[inline]
+    pub fn is_64(&self) -> bool {
+        self.pe.is_64
+    }
+
     fn section_alignment(&self) -> u64 {
         u64::from(
             self.pe

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -133,6 +133,9 @@ pub trait ObjectSegment<'data> {
     /// Returns the size of the segment in memory.
     fn size(&self) -> u64;
 
+    /// Returns the alignment of the segment in memory.
+    fn align(&self) -> u64;
+
     /// Returns a reference to the file contents of the segment.
     /// The length of this data may be different from the size of the
     /// segment in memory.
@@ -161,6 +164,9 @@ pub trait ObjectSection<'data> {
 
     /// Returns the size of the section in memory.
     fn size(&self) -> u64;
+
+    /// Returns the alignment of the section in memory.
+    fn align(&self) -> u64;
 
     /// Returns the raw contents of the section.
     /// The length of this data may be different from the size of the

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::alloc::borrow::Cow;
-use crate::{Machine, Relocation, SectionIndex, SectionKind, Symbol, SymbolMap, Uuid};
+use crate::{Machine, Relocation, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap, Uuid};
 
 /// An object file.
 pub trait Object<'data, 'file> {
@@ -16,7 +16,7 @@ pub trait Object<'data, 'file> {
     type SectionIterator: Iterator<Item = Self::Section>;
 
     /// An iterator over the symbols in the object file.
-    type SymbolIterator: Iterator<Item = Symbol<'data>>;
+    type SymbolIterator: Iterator<Item = (SymbolIndex, Symbol<'data>)>;
 
     /// Get the machine type of the file.
     fn machine(&self) -> Machine;
@@ -66,7 +66,7 @@ pub trait Object<'data, 'file> {
     ///
     /// This is similar to `self.symbols().nth(index)`, except that
     /// the index will take into account malformed or unsupported symbols.
-    fn symbol_by_index(&self, index: u64) -> Option<Symbol<'data>>;
+    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>>;
 
     /// Get an iterator over the debugging symbols in the file.
     ///

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -154,6 +154,11 @@ impl<'file> ObjectSegment<'static> for WasmSegment<'file> {
         unreachable!()
     }
 
+    #[inline]
+    fn align(&self) -> u64 {
+        unreachable!()
+    }
+
     fn data(&self) -> &'static [u8] {
         unreachable!()
     }
@@ -195,6 +200,11 @@ impl<'file> ObjectSection<'static> for WasmSection<'file> {
     #[inline]
     fn size(&self) -> u64 {
         serialize_to_cow(self.section.clone()).map_or(0, |b| b.len() as u64)
+    }
+
+    #[inline]
+    fn align(&self) -> u64 {
+        1
     }
 
     fn data(&self) -> Cow<'static, [u8]> {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,7 +5,7 @@ use std::{iter, slice};
 
 use crate::{
     Machine, Object, ObjectSection, ObjectSegment, Relocation, SectionIndex, SectionKind, Symbol,
-    SymbolMap,
+    SymbolIndex, SymbolMap,
 };
 
 /// A WebAssembly object file.
@@ -103,7 +103,7 @@ impl<'file> Object<'static, 'file> for WasmFile {
         }
     }
 
-    fn symbol_by_index(&self, _index: u64) -> Option<Symbol<'static>> {
+    fn symbol_by_index(&self, _index: SymbolIndex) -> Option<Symbol<'static>> {
         unimplemented!()
     }
 
@@ -281,7 +281,7 @@ impl<'file> ObjectSection<'static> for WasmSection<'file> {
 }
 
 impl<'file> Iterator for WasmSymbolIterator<'file> {
-    type Item = Symbol<'static>;
+    type Item = (SymbolIndex, Symbol<'static>);
 
     fn next(&mut self) -> Option<Self::Item> {
         unimplemented!()


### PR DESCRIPTION
The `SectionKind` variants may be too ELF specific. I expect them to evolve as Mach-O and PE support is improved.

~~Needs a new goblin release first.~~ (Deleted that commit for now.)