### PR TITLE
[mach] Make section_by_name support loading sections starting with dot

### DIFF
--- a/src/macho.rs
+++ b/src/macho.rs
@@ -130,20 +130,15 @@ where
     fn section_by_name(&'file self, section_name: &str) -> Option<MachOSection<'data, 'file>> {
         // Translate the "." prefix to the "__" prefix used by OSX/Mach-O, eg
         // ".debug_info" to "__debug_info".
-        let (system_section, section_name) = if section_name.starts_with('.') {
-            (true, &section_name[1..])
-        } else {
-            (false, section_name)
-        };
+        let system_section = section_name.starts_with('.');
         let cmp_section_name = |section: &MachOSection| {
             section
                 .name()
                 .map(|name| {
-                    if system_section {
-                        name.starts_with("__") && section_name == &name[2..]
-                    } else {
-                        section_name == name
-                    }
+                    section_name == name
+                        || (system_section
+                            && name.starts_with("__")
+                            && &section_name[1..] == &name[2..])
                 })
                 .unwrap_or(false)
         };


### PR DESCRIPTION
For example `.rustc` used to be replaced with `__rustc` before searching, which meant `.rustc` was not findable

cc https://github.com/bjorn3/rustc_codegen_cranelift/pull/435