### PR TITLE
Add more relocations

### DIFF
--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -6,7 +6,7 @@ use std::{iter, slice};
 use target_lexicon::Architecture;
 
 use crate::read::{
-    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationKind, RelocationSubkind,
+    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationEncoding, RelocationKind,
     RelocationTarget, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolKind, SymbolMap,
 };
 
@@ -482,7 +482,7 @@ impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
                 u64::from(relocation.virtual_address),
                 Relocation {
                     kind,
-                    subkind: RelocationSubkind::Default,
+                    encoding: RelocationEncoding::Generic,
                     size,
                     target,
                     addend,

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -13,8 +13,8 @@ use std::{iter, slice};
 use target_lexicon::Architecture;
 
 use crate::read::{
-    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationKind, SectionIndex,
-    SectionKind, Symbol, SymbolIndex, SymbolKind, SymbolMap,
+    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationKind, RelocationSubkind,
+    RelocationTarget, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolKind, SymbolMap,
 };
 
 /// An ELF object file.
@@ -594,6 +594,7 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
         loop {
             if let Some(ref mut relocations) = self.relocations {
                 if let Some(reloc) = relocations.next() {
+                    let mut subkind = RelocationSubkind::Default;
                     let (kind, size) = match self.file.elf.header.e_machine {
                         elf::header::EM_ARM => match reloc.r_type {
                             elf::reloc::R_ARM_ABS32 => (RelocationKind::Absolute, 32),
@@ -611,18 +612,27 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
                         elf::header::EM_386 => match reloc.r_type {
                             elf::reloc::R_386_32 => (RelocationKind::Absolute, 32),
                             elf::reloc::R_386_PC32 => (RelocationKind::Relative, 32),
-                            elf::reloc::R_386_GOT32 => (RelocationKind::GotRelative, 32),
+                            elf::reloc::R_386_GOT32 => (RelocationKind::Got, 32),
                             elf::reloc::R_386_PLT32 => (RelocationKind::PltRelative, 32),
+                            elf::reloc::R_386_GOTOFF => (RelocationKind::GotBaseOffset, 32),
+                            elf::reloc::R_386_GOTPC => (RelocationKind::GotBaseRelative, 32),
+                            elf::reloc::R_386_16 => (RelocationKind::Absolute, 16),
+                            elf::reloc::R_386_PC16 => (RelocationKind::Relative, 16),
+                            elf::reloc::R_386_8 => (RelocationKind::Absolute, 8),
+                            elf::reloc::R_386_PC8 => (RelocationKind::Relative, 8),
                             _ => (RelocationKind::Other(reloc.r_type), 0),
                         },
                         elf::header::EM_X86_64 => match reloc.r_type {
                             elf::reloc::R_X86_64_64 => (RelocationKind::Absolute, 64),
                             elf::reloc::R_X86_64_PC32 => (RelocationKind::Relative, 32),
-                            elf::reloc::R_X86_64_GOT32 => (RelocationKind::GotOffset, 32),
+                            elf::reloc::R_X86_64_GOT32 => (RelocationKind::Got, 32),
                             elf::reloc::R_X86_64_PLT32 => (RelocationKind::PltRelative, 32),
                             elf::reloc::R_X86_64_GOTPCREL => (RelocationKind::GotRelative, 32),
                             elf::reloc::R_X86_64_32 => (RelocationKind::Absolute, 32),
-                            elf::reloc::R_X86_64_32S => (RelocationKind::AbsoluteSigned, 32),
+                            elf::reloc::R_X86_64_32S => {
+                                subkind = RelocationSubkind::X86Signed;
+                                (RelocationKind::Absolute, 32)
+                            }
                             elf::reloc::R_X86_64_16 => (RelocationKind::Absolute, 16),
                             elf::reloc::R_X86_64_PC16 => (RelocationKind::Relative, 16),
                             elf::reloc::R_X86_64_8 => (RelocationKind::Absolute, 8),
@@ -631,12 +641,14 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
                         },
                         _ => (RelocationKind::Other(reloc.r_type), 0),
                     };
+                    let target = RelocationTarget::Symbol(SymbolIndex(reloc.r_sym as usize));
                     return Some((
                         reloc.r_offset,
                         Relocation {
                             kind,
+                            subkind,
                             size,
-                            symbol: SymbolIndex(reloc.r_sym as usize),
+                            target,
                             addend: reloc.r_addend.unwrap_or(0),
                             implicit_addend: reloc.r_addend.is_none(),
                         },

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -8,7 +8,7 @@ use target_lexicon::Architecture;
 use uuid::Uuid;
 
 use crate::read::{
-    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationKind, RelocationSubkind,
+    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationEncoding, RelocationKind,
     RelocationTarget, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolKind, SymbolMap,
 };
 
@@ -511,7 +511,7 @@ impl<'data, 'file> Iterator for MachORelocationIterator<'data, 'file> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.relocations.next()?.ok().map(|reloc| {
-            let mut subkind = RelocationSubkind::Default;
+            let mut encoding = RelocationEncoding::Generic;
             let kind = match self.file.macho.header.cputype {
                 mach::cputype::CPU_TYPE_ARM => match reloc.r_type() {
                     mach::relocation::ARM_RELOC_VANILLA => RelocationKind::Absolute,
@@ -528,16 +528,16 @@ impl<'data, 'file> Iterator for MachORelocationIterator<'data, 'file> {
                 mach::cputype::CPU_TYPE_X86_64 => match reloc.r_type() {
                     mach::relocation::X86_64_RELOC_UNSIGNED => RelocationKind::Absolute,
                     mach::relocation::X86_64_RELOC_SIGNED => {
-                        subkind = RelocationSubkind::X86RipRelative;
+                        encoding = RelocationEncoding::X86RipRelative;
                         RelocationKind::Relative
                     }
                     mach::relocation::X86_64_RELOC_BRANCH => {
-                        subkind = RelocationSubkind::X86Branch;
+                        encoding = RelocationEncoding::X86Branch;
                         RelocationKind::Relative
                     }
                     mach::relocation::X86_64_RELOC_GOT => RelocationKind::GotRelative,
                     mach::relocation::X86_64_RELOC_GOT_LOAD => {
-                        subkind = RelocationSubkind::X86RipRelativeMovq;
+                        encoding = RelocationEncoding::X86RipRelativeMovq;
                         RelocationKind::GotRelative
                     }
                     _ => RelocationKind::Other(reloc.r_info),
@@ -555,7 +555,7 @@ impl<'data, 'file> Iterator for MachORelocationIterator<'data, 'file> {
                 reloc.r_address as u64,
                 Relocation {
                     kind,
-                    subkind,
+                    encoding,
                     size,
                     target,
                     addend,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -256,7 +256,7 @@ impl<'data> SymbolMap<'data> {
     }
 }
 
-/// The kind of a relocation.
+/// The operation used to calculate the result of the relocation.
 ///
 /// The relocation descriptions use the following definitions. Note that
 /// these definitions probably don't match any ELF ABI.
@@ -293,24 +293,34 @@ pub enum RelocationKind {
     SectionOffset,
     /// The index of the section containing the symbol.
     SectionIndex,
-    /// Some other kind of relocation. The value is dependent on file format and machine.
+    /// Some other operation and encoding. The value is dependent on file format and machine.
     Other(u32),
 }
 
-/// Extra information about how the relocation should be applied. This is often architecture
-/// specific.
+/// Information about how the result of the relocation operation is encoded in the place.
+///
+/// This is usually architecture specific, such as specifying an addressing mode or
+/// a specific instruction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RelocationSubkind {
-    /// Default subkind for the given relocation kind.
-    Default,
+pub enum RelocationEncoding {
+    /// Generic encoding.
+    Generic,
 
+    /// x86 sign extension at runtime.
+    ///
+    /// Used with `RelocationKind::Absolute`.
+    X86Signed,
     /// x86 rip-relative addressing.
+    ///
+    /// The `RelocationKind` must be PC relative.
     X86RipRelative,
     /// x86 rip-relative addressing in movq instruction.
+    ///
+    /// The `RelocationKind` must be PC relative.
     X86RipRelativeMovq,
-    /// `RelocationKind::Absolute` with sign extension at runtime.
-    X86Signed,
     /// x86 branch instruction.
+    ///
+    /// The `RelocationKind` must be PC relative.
     X86Branch,
 }
 
@@ -327,7 +337,7 @@ pub enum RelocationTarget {
 #[derive(Debug)]
 pub struct Relocation {
     kind: RelocationKind,
-    subkind: RelocationSubkind,
+    encoding: RelocationEncoding,
     size: u8,
     target: RelocationTarget,
     addend: i64,
@@ -335,16 +345,16 @@ pub struct Relocation {
 }
 
 impl Relocation {
-    /// The kind of relocation.
+    /// The operation used to calculate the result of the relocation.
     #[inline]
     pub fn kind(&self) -> RelocationKind {
         self.kind
     }
 
-    /// Extra information about how the relocation should be applied.
+    /// Information about how the result of the relocation operation is encoded in the place.
     #[inline]
-    pub fn subkind(&self) -> RelocationSubkind {
-        self.subkind
+    pub fn encoding(&self) -> RelocationEncoding {
+        self.encoding
     }
 
     /// The size in bits of the place of the relocation.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -147,35 +147,6 @@ pub enum SymbolKind {
     Tls,
 }
 
-/// The kind of a relocation.
-///
-/// The relocation descriptions use the following definitions. Note that
-/// these definitions probably don't match any ELF ABI.
-///
-/// * A - The value of the addend.
-/// * G - The address of the symbol's entry within the global offset table.
-/// * GOT - The address of the global offset table.
-/// * L - The address of the symbol's entry within the procedure linkage table.
-/// * P - The address of the place of the relocation.
-/// * S - The address of the symbol.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RelocationKind {
-    /// S + A
-    Absolute,
-    /// S + A
-    AbsoluteSigned,
-    /// S + A - P
-    Relative,
-    /// G + A - GOT
-    GotOffset,
-    /// G + A - P
-    GotRelative,
-    /// L + A - P
-    PltRelative,
-    /// Some other kind of relocation. The value is dependent on file format and machine.
-    Other(u32),
-}
-
 /// A symbol table entry.
 #[derive(Debug)]
 pub struct Symbol<'data> {
@@ -283,6 +254,35 @@ impl<'data> SymbolMap<'data> {
         }
         !symbol.is_undefined() && symbol.size() > 0
     }
+}
+
+/// The kind of a relocation.
+///
+/// The relocation descriptions use the following definitions. Note that
+/// these definitions probably don't match any ELF ABI.
+///
+/// * A - The value of the addend.
+/// * G - The address of the symbol's entry within the global offset table.
+/// * GOT - The address of the global offset table.
+/// * L - The address of the symbol's entry within the procedure linkage table.
+/// * P - The address of the place of the relocation.
+/// * S - The address of the symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelocationKind {
+    /// S + A
+    Absolute,
+    /// S + A
+    AbsoluteSigned,
+    /// S + A - P
+    Relative,
+    /// G + A - GOT
+    GotOffset,
+    /// G + A - P
+    GotRelative,
+    /// L + A - P
+    PltRelative,
+    /// Some other kind of relocation. The value is dependent on file format and machine.
+    Other(u32),
 }
 
 /// A relocation entry.


### PR DESCRIPTION
This is mainly x86-64 relocations for Mach-O and COFF.

Relocations now have both a kind and subkind. The subkind is used for architecture specific variations.

Relocations now have a `RelocationTarget`, since Mach-O relocations can specify either a symbol or a section. This won't matter in the write module, because there we can model it as section symbols that aren't written.

@pchickey Not sure how much you know about relocations. While this PR is still only for the read module, my main concern here is whether the `RelocationKind` + `RelocationSubkind` abstraction is suitable for users of the write module.

The intent is that these kinds are independent of file format. Additionally, `RelocationKind` is intended to be mostly independent of architecture, with `RelocationSubkind` containing architecture specific variants.

Cranelift currently models relocations as a single [`enum Reloc`](https://github.com/CraneStation/cranelift/blob/9094a3be39fd0d1de625cc27feb653455f1c6c4e/cranelift-codegen/src/binemit/mod.rs#L29) with architecture specific variants.

llvm has an [`enum MCFixupKind`](https://github.com/llvm-mirror/llvm/blob/c313a177b4548602d71b2a0005d5f3e7c8828ae9/include/llvm/MC/MCFixup.h#L22) with some generic variants plus [architecture specific extensions](https://github.com/llvm-mirror/llvm/blob/c313a177b4548602d71b2a0005d5f3e7c8828ae9/lib/Target/X86/MCTargetDesc/X86FixupKinds.h#L16) (which start at `MCFixupKind::FirstTargetFixupKind`). But it also has an [`enum MCSymbolRefExpr::VariantKind`](https://github.com/llvm-mirror/llvm/blob/c313a177b4548602d71b2a0005d5f3e7c8828ae9/include/llvm/MC/MCExpr.h#L167), and both of these are used to select relocations when writing (e.g. [for ELF X86](https://github.com/llvm-mirror/llvm/blob/962b2f3c73782689015dc9866b6108a6f39a5dc1/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp#L198-L215)). I don't know enough about LLVM to understand why these are separate things though.

I started with only `RelocationKind`, and found it was useful to have these generic categories when writing ELF, but it still needed more architecture specific variants. In practice, I think my `RelocationKind` is used similarly to `MCSymbolRefExpr::VariantKind`, and `RelocationSubkind` is used similarly to `MCFixupKind`, but they're not exactly equivalent.

Another difference is that I've kept the relocation size as a separate field (instead of having lots of enum variants), which seems useful for Mach-O.

It's not critical that we get this right immediately, and I expect it will need to evolve as more architectures are added, but any input would be great!