### PR TITLE
Update to target-lexicon 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["/.coveralls.yml", "/.travis.yml"]
 
 [dependencies]
 scroll = { version = "0.9", default-features = false }
-target-lexicon = { version = "0.4" }
+target-lexicon = { version = "0.8" }
 uuid = { version = "0.7", default-features = false }
 flate2 = { version = "1", optional = true }
 crc32fast = { version = "1", optional = true }

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -10,7 +10,7 @@ use goblin::{elf, strtab};
 use scroll::ctx::TryFromCtx;
 use scroll::{self, Pread};
 use std::{iter, slice};
-use target_lexicon::Architecture;
+use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
 
 use crate::read::{
     self, Object, ObjectSection, ObjectSegment, Relocation, RelocationEncoding, RelocationKind,
@@ -89,8 +89,8 @@ where
 
     fn architecture(&self) -> Architecture {
         match self.elf.header.e_machine {
-            elf::header::EM_ARM => Architecture::Arm,
-            elf::header::EM_AARCH64 => Architecture::Aarch64,
+            elf::header::EM_ARM => Architecture::Arm(ArmArchitecture::Arm),
+            elf::header::EM_AARCH64 => Architecture::Aarch64(Aarch64Architecture::Aarch64),
             elf::header::EM_386 => Architecture::I386,
             elf::header::EM_X86_64 => Architecture::X86_64,
             elf::header::EM_MIPS => Architecture::Mips,

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -4,7 +4,7 @@ use goblin::container;
 use goblin::mach;
 use goblin::mach::load_command::CommandVariant;
 use std::{fmt, iter, ops, slice};
-use target_lexicon::Architecture;
+use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
 use uuid::Uuid;
 
 use crate::read::{
@@ -77,8 +77,8 @@ where
 
     fn architecture(&self) -> Architecture {
         match self.macho.header.cputype {
-            mach::cputype::CPU_TYPE_ARM => Architecture::Arm,
-            mach::cputype::CPU_TYPE_ARM64 => Architecture::Aarch64,
+            mach::cputype::CPU_TYPE_ARM => Architecture::Arm(ArmArchitecture::Arm),
+            mach::cputype::CPU_TYPE_ARM64 => Architecture::Aarch64(Aarch64Architecture::Aarch64),
             mach::cputype::CPU_TYPE_X86 => Architecture::I386,
             mach::cputype::CPU_TYPE_X86_64 => Architecture::X86_64,
             mach::cputype::CPU_TYPE_MIPS => Architecture::Mips,

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -58,8 +58,8 @@ impl Object {
 
     fn elf_has_relocation_addend(&self) -> Result<bool, String> {
         Ok(match self.architecture {
-            Architecture::Arm => false,
-            Architecture::Aarch64 => false,
+            Architecture::Arm(_) => false,
+            Architecture::Aarch64(_) => false,
             Architecture::I386 => false,
             Architecture::X86_64 => true,
             _ => {
@@ -294,8 +294,8 @@ impl Object {
 
         // Write file header.
         let e_machine = match self.architecture {
-            Architecture::Arm => elf::EM_ARM,
-            Architecture::Aarch64 => elf::EM_AARCH64,
+            Architecture::Arm(_) => elf::EM_ARM,
+            Architecture::Aarch64(_) => elf::EM_AARCH64,
             Architecture::I386 => elf::EM_386,
             Architecture::X86_64 => elf::EM_X86_64,
             _ => {

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -182,8 +182,8 @@ impl Object {
 
         // Write file header.
         let (cputype, cpusubtype) = match self.architecture {
-            Architecture::Arm => (mach::CPU_TYPE_ARM, mach::CPU_SUBTYPE_ARM_ALL),
-            Architecture::Aarch64 => (mach::CPU_TYPE_ARM64, mach::CPU_SUBTYPE_ARM64_ALL),
+            Architecture::Arm(_) => (mach::CPU_TYPE_ARM, mach::CPU_SUBTYPE_ARM_ALL),
+            Architecture::Aarch64(_) => (mach::CPU_TYPE_ARM64, mach::CPU_SUBTYPE_ARM64_ALL),
             Architecture::I386 => (mach::CPU_TYPE_I386, mach::CPU_SUBTYPE_I386_ALL),
             Architecture::X86_64 => (mach::CPU_TYPE_X86_64, mach::CPU_SUBTYPE_X86_64_ALL),
             _ => {


### PR DESCRIPTION
This updates object to target-lexicon 0.8, which corresponds to the version now being used in cranelift, which is needed for https://github.com/CraneStation/cranelift/pull/937.

I'm also open to suggestions about how target-lexicon could make what this code is doing tidier. Would it be more clear if we renamed `ArmArchitecture::Arm` to `ArmArchitecture::Generic`?