### PR TITLE
write: add TLS sections

### DIFF
--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -45,6 +45,15 @@ impl Object {
             StandardSection::UninitializedData => {
                 (&[], &b".bss"[..], SectionKind::UninitializedData)
             }
+            StandardSection::Tls => (&[], &b".tls$"[..], SectionKind::Tls),
+            StandardSection::UninitializedTls => {
+                // Unsupported section.
+                (&[], &[], SectionKind::UninitializedTls)
+            }
+            StandardSection::TlsVariables => {
+                // Unsupported section.
+                (&[], &[], SectionKind::TlsVariables)
+            }
         }
     }
 

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -46,6 +46,14 @@ impl Object {
             StandardSection::UninitializedData => {
                 (&[], &b".bss"[..], SectionKind::UninitializedData)
             }
+            StandardSection::Tls => (&[], &b".tdata"[..], SectionKind::Tls),
+            StandardSection::UninitializedTls => {
+                (&[], &b".tbss"[..], SectionKind::UninitializedTls)
+            }
+            StandardSection::TlsVariables => {
+                // Unsupported section.
+                (&[], &[], SectionKind::TlsVariables)
+            }
         }
     }
 

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -63,7 +63,110 @@ impl Object {
                 &b"__bss"[..],
                 SectionKind::UninitializedData,
             ),
+            StandardSection::Tls => (&b"__DATA"[..], &b"__thread_data"[..], SectionKind::Tls),
+            StandardSection::UninitializedTls => (
+                &b"__DATA"[..],
+                &b"__thread_bss"[..],
+                SectionKind::UninitializedTls,
+            ),
+            StandardSection::TlsVariables => (
+                &b"__DATA"[..],
+                &b"__thread_vars"[..],
+                SectionKind::TlsVariables,
+            ),
         }
+    }
+
+    fn macho_tlv_bootstrap(&mut self) -> SymbolId {
+        match self.tlv_bootstrap {
+            Some(id) => id,
+            None => {
+                let id = self.add_symbol(Symbol {
+                    name: b"_tlv_bootstrap".to_vec(),
+                    value: 0,
+                    size: 0,
+                    kind: SymbolKind::Text,
+                    scope: SymbolScope::Dynamic,
+                    weak: false,
+                    section: None,
+                });
+                self.tlv_bootstrap = Some(id);
+                id
+            }
+        }
+    }
+
+    /// Create the `__thread_vars` entry for a TLS variable.
+    ///
+    /// The symbol given by `symbol_id` will be updated to point to this entry.
+    ///
+    /// A new `SymbolId` will be returned. The caller must update this symbol
+    /// to point to the initializer.
+    ///
+    /// If `symbol_id` is not for a TLS variable, then it is returned unchanged.
+    pub(crate) fn macho_add_thread_var(&mut self, symbol_id: SymbolId) -> SymbolId {
+        let symbol = self.symbol_mut(symbol_id);
+        if symbol.kind != SymbolKind::Tls {
+            return symbol_id;
+        }
+
+        // Create the initializer symbol.
+        let mut name = symbol.name.clone();
+        name.extend(b"$tlv$init");
+        let init_symbol_id = self.add_raw_symbol(Symbol {
+            name,
+            value: 0,
+            size: 0,
+            kind: SymbolKind::Tls,
+            scope: SymbolScope::Compilation,
+            weak: false,
+            section: None,
+        });
+
+        // Add the tlv entry.
+        // Three pointers in size:
+        //   - __tlv_bootstrap - used to make sure support exists
+        //   - spare pointer - used when mapped by the runtime
+        //   - pointer to symbol initializer
+        let section = self.section_id(StandardSection::TlsVariables);
+        let pointer_width = self.architecture.pointer_width().unwrap().bytes();
+        let size = u64::from(pointer_width) * 3;
+        let data = vec![0; size as usize];
+        let offset = self.append_section_data(section, &data, u64::from(pointer_width));
+
+        let tlv_bootstrap = self.macho_tlv_bootstrap();
+        self.add_relocation(
+            section,
+            Relocation {
+                offset: offset,
+                size: pointer_width * 8,
+                kind: RelocationKind::Absolute,
+                encoding: RelocationEncoding::Generic,
+                symbol: tlv_bootstrap,
+                addend: 0,
+            },
+        )
+        .unwrap();
+        self.add_relocation(
+            section,
+            Relocation {
+                offset: offset + u64::from(pointer_width) * 2,
+                size: pointer_width * 8,
+                kind: RelocationKind::Absolute,
+                encoding: RelocationEncoding::Generic,
+                symbol: init_symbol_id,
+                addend: 0,
+            },
+        )
+        .unwrap();
+
+        // Update the symbol to point to the tlv.
+        let symbol = self.symbol_mut(symbol_id);
+        symbol.value = offset;
+        symbol.size = size;
+        symbol.section = Some(section);
+
+        init_symbol_id
     }
 
     pub(crate) fn macho_fixup_relocation(&mut self, mut relocation: &mut Relocation) -> i64 {
@@ -140,7 +243,7 @@ impl Object {
         for (index, symbol) in self.symbols.iter().enumerate() {
             if !symbol.is_undefined() {
                 match symbol.kind {
-                    SymbolKind::Text | SymbolKind::Data => {}
+                    SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
                     SymbolKind::File | SymbolKind::Section => continue,
                     _ => return Err(format!("unimplemented symbol {:?}", symbol)),
                 }
@@ -309,7 +412,7 @@ impl Object {
         for (index, symbol) in self.symbols.iter().enumerate() {
             if !symbol.is_undefined() {
                 match symbol.kind {
-                    SymbolKind::Text | SymbolKind::Data => {}
+                    SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
                     SymbolKind::File | SymbolKind::Section => continue,
                     _ => return Err(format!("unimplemented symbol {:?}", symbol)),
                 }

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -1,0 +1,167 @@
+#![cfg(all(feature = "read", feature = "write"))]
+
+use object::read::{Object, ObjectSection};
+use object::{read, write};
+use object::{RelocationEncoding, RelocationKind, SectionKind, SymbolKind, SymbolScope};
+use target_lexicon::{Architecture, BinaryFormat};
+
+#[test]
+fn macho_x86_64_tls() {
+    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+
+    let section = object.section_id(write::StandardSection::Tls);
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"tls1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Tls,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: None,
+    });
+    object.add_symbol_data(symbol, section, &[1; 30], 4);
+
+    let section = object.section_id(write::StandardSection::UninitializedTls);
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"tls2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Tls,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: None,
+    });
+    object.add_symbol_bss(symbol, section, 31, 4);
+
+    let bytes = object.write().unwrap();
+
+    std::fs::write(&"tls.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut sections = object.sections();
+
+    let thread_data = sections.next().unwrap();
+    println!("{:?}", section);
+    let thread_data_index = thread_data.index();
+    assert_eq!(thread_data.name(), Some("__thread_data"));
+    assert_eq!(thread_data.segment_name(), Some("__DATA"));
+    assert_eq!(thread_data.kind(), SectionKind::Tls);
+    assert_eq!(thread_data.size(), 30);
+    assert_eq!(&thread_data.data()[..], &[1; 30]);
+
+    let thread_vars = sections.next().unwrap();
+    println!("{:?}", section);
+    let thread_vars_index = thread_vars.index();
+    assert_eq!(thread_vars.name(), Some("__thread_vars"));
+    assert_eq!(thread_vars.segment_name(), Some("__DATA"));
+    assert_eq!(thread_vars.kind(), SectionKind::TlsVariables);
+    assert_eq!(thread_vars.size(), 2 * 3 * 8);
+
+    let thread_bss = sections.next().unwrap();
+    println!("{:?}", section);
+    let thread_bss_index = thread_bss.index();
+    assert_eq!(thread_bss.name(), Some("__thread_bss"));
+    assert_eq!(thread_bss.segment_name(), Some("__DATA"));
+    assert_eq!(thread_bss.kind(), SectionKind::UninitializedTls);
+    assert_eq!(thread_bss.size(), 31);
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_tls1"));
+    assert_eq!(symbol.kind(), SymbolKind::Tls);
+    assert_eq!(symbol.section_index(), Some(thread_vars_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+
+    let (tls1_init_symbol, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_tls1$tlv$init"));
+    assert_eq!(symbol.kind(), SymbolKind::Tls);
+    assert_eq!(symbol.section_index(), Some(thread_data_index));
+    assert_eq!(symbol.scope(), SymbolScope::Compilation);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+
+    let (tlv_bootstrap_symbol, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("__tlv_bootstrap"));
+    assert_eq!(symbol.kind(), SymbolKind::Unknown);
+    assert_eq!(symbol.section_index(), None);
+    assert_eq!(symbol.scope(), SymbolScope::Unknown);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), true);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_tls2"));
+    assert_eq!(symbol.kind(), SymbolKind::Tls);
+    assert_eq!(symbol.section_index(), Some(thread_vars_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+
+    let (tls2_init_symbol, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_tls2$tlv$init"));
+    assert_eq!(symbol.kind(), SymbolKind::Tls);
+    assert_eq!(symbol.section_index(), Some(thread_bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Compilation);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+
+    let mut relocations = thread_vars.relocations();
+
+    let (offset, relocation) = relocations.next().unwrap();
+    println!("{:?}", relocation);
+    assert_eq!(offset, 0);
+    assert_eq!(relocation.kind(), RelocationKind::Absolute);
+    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+    assert_eq!(relocation.size(), 64);
+    assert_eq!(
+        relocation.target(),
+        read::RelocationTarget::Symbol(tlv_bootstrap_symbol)
+    );
+    assert_eq!(relocation.addend(), 0);
+
+    let (offset, relocation) = relocations.next().unwrap();
+    println!("{:?}", relocation);
+    assert_eq!(offset, 16);
+    assert_eq!(relocation.kind(), RelocationKind::Absolute);
+    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+    assert_eq!(relocation.size(), 64);
+    assert_eq!(
+        relocation.target(),
+        read::RelocationTarget::Symbol(tls1_init_symbol)
+    );
+    assert_eq!(relocation.addend(), 0);
+
+    let (offset, relocation) = relocations.next().unwrap();
+    println!("{:?}", relocation);
+    assert_eq!(offset, 24);
+    assert_eq!(relocation.kind(), RelocationKind::Absolute);
+    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+    assert_eq!(relocation.size(), 64);
+    assert_eq!(
+        relocation.target(),
+        read::RelocationTarget::Symbol(tlv_bootstrap_symbol)
+    );
+    assert_eq!(relocation.addend(), 0);
+
+    let (offset, relocation) = relocations.next().unwrap();
+    println!("{:?}", relocation);
+    assert_eq!(offset, 40);
+    assert_eq!(relocation.kind(), RelocationKind::Absolute);
+    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+    assert_eq!(relocation.size(), 64);
+    assert_eq!(
+        relocation.target(),
+        read::RelocationTarget::Symbol(tls2_init_symbol)
+    );
+    assert_eq!(relocation.addend(), 0);
+}


### PR DESCRIPTION
Fixes #138 

cc @bjorn3 

Compile tested only.

I also considered adding TLS variants to `RelocationKind`, but decided there was too little in common between the architectures, and the code generation already needs to know about the differences anyway.