### PR TITLE
write: support custom Mach-O relocations

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -146,8 +146,17 @@ pub enum RelocationKind {
     SectionOffset,
     /// The index of the section containing the symbol.
     SectionIndex,
-    /// Some other operation and encoding. The value is dependent on file format and machine.
-    Other(u32),
+    /// Some other ELF relocation. The value is dependent on the architecture.
+    Elf(u32),
+    /// Some other Mach-O relocation. The value is dependent on the architecture.
+    MachO {
+        /// The relocation type.
+        value: u8,
+        /// Whether the relocation is relative to the place.
+        relative: bool,
+    },
+    /// Some other COFF relocation. The value is dependent on the architecture.
+    Coff(u16),
 }
 
 /// Information about how the result of the relocation operation is encoded in the place.

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -460,7 +460,7 @@ impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
                     pe::relocation::IMAGE_REL_I386_SECREL => (RelocationKind::SectionOffset, 32, 0),
                     pe::relocation::IMAGE_REL_I386_SECREL7 => (RelocationKind::SectionOffset, 7, 0),
                     pe::relocation::IMAGE_REL_I386_REL32 => (RelocationKind::Relative, 32, -4),
-                    _ => (RelocationKind::Other(u32::from(relocation.typ)), 0, 0),
+                    _ => (RelocationKind::Coff(relocation.typ), 0, 0),
                 },
                 pe::header::COFF_MACHINE_X86_64 => match relocation.typ {
                     pe::relocation::IMAGE_REL_AMD64_ADDR64 => (RelocationKind::Absolute, 64, 0),
@@ -483,9 +483,9 @@ impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
                     pe::relocation::IMAGE_REL_AMD64_SECREL7 => {
                         (RelocationKind::SectionOffset, 7, 0)
                     }
-                    _ => (RelocationKind::Other(u32::from(relocation.typ)), 0, 0),
+                    _ => (RelocationKind::Coff(relocation.typ), 0, 0),
                 },
-                _ => (RelocationKind::Other(u32::from(relocation.typ)), 0, 0),
+                _ => (RelocationKind::Coff(relocation.typ), 0, 0),
             };
             let target =
                 RelocationTarget::Symbol(SymbolIndex(relocation.symbol_table_index as usize));

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -613,7 +613,7 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
                     let (kind, size) = match self.file.elf.header.e_machine {
                         elf::header::EM_ARM => match reloc.r_type {
                             elf::reloc::R_ARM_ABS32 => (RelocationKind::Absolute, 32),
-                            _ => (RelocationKind::Other(reloc.r_type), 0),
+                            _ => (RelocationKind::Elf(reloc.r_type), 0),
                         },
                         elf::header::EM_AARCH64 => match reloc.r_type {
                             elf::reloc::R_AARCH64_ABS64 => (RelocationKind::Absolute, 64),
@@ -622,7 +622,7 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
                             elf::reloc::R_AARCH64_PREL64 => (RelocationKind::Relative, 64),
                             elf::reloc::R_AARCH64_PREL32 => (RelocationKind::Relative, 32),
                             elf::reloc::R_AARCH64_PREL16 => (RelocationKind::Relative, 16),
-                            _ => (RelocationKind::Other(reloc.r_type), 0),
+                            _ => (RelocationKind::Elf(reloc.r_type), 0),
                         },
                         elf::header::EM_386 => match reloc.r_type {
                             elf::reloc::R_386_32 => (RelocationKind::Absolute, 32),
@@ -635,7 +635,7 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
                             elf::reloc::R_386_PC16 => (RelocationKind::Relative, 16),
                             elf::reloc::R_386_8 => (RelocationKind::Absolute, 8),
                             elf::reloc::R_386_PC8 => (RelocationKind::Relative, 8),
-                            _ => (RelocationKind::Other(reloc.r_type), 0),
+                            _ => (RelocationKind::Elf(reloc.r_type), 0),
                         },
                         elf::header::EM_X86_64 => match reloc.r_type {
                             elf::reloc::R_X86_64_64 => (RelocationKind::Absolute, 64),
@@ -652,9 +652,9 @@ impl<'data, 'file> Iterator for ElfRelocationIterator<'data, 'file> {
                             elf::reloc::R_X86_64_PC16 => (RelocationKind::Relative, 16),
                             elf::reloc::R_X86_64_8 => (RelocationKind::Absolute, 8),
                             elf::reloc::R_X86_64_PC8 => (RelocationKind::Relative, 8),
-                            _ => (RelocationKind::Other(reloc.r_type), 0),
+                            _ => (RelocationKind::Elf(reloc.r_type), 0),
                         },
-                        _ => (RelocationKind::Other(reloc.r_type), 0),
+                        _ => (RelocationKind::Elf(reloc.r_type), 0),
                     };
                     let target = RelocationTarget::Symbol(SymbolIndex(reloc.r_sym as usize));
                     return Some((

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -531,15 +531,24 @@ impl<'data, 'file> Iterator for MachORelocationIterator<'data, 'file> {
             let kind = match self.file.macho.header.cputype {
                 mach::cputype::CPU_TYPE_ARM => match (reloc.r_type(), reloc.r_pcrel()) {
                     (mach::relocation::ARM_RELOC_VANILLA, 0) => RelocationKind::Absolute,
-                    _ => RelocationKind::Other(reloc.r_info),
+                    _ => RelocationKind::MachO {
+                        value: reloc.r_type(),
+                        relative: reloc.is_pic(),
+                    },
                 },
                 mach::cputype::CPU_TYPE_ARM64 => match (reloc.r_type(), reloc.r_pcrel()) {
                     (mach::relocation::ARM64_RELOC_UNSIGNED, 0) => RelocationKind::Absolute,
-                    _ => RelocationKind::Other(reloc.r_info),
+                    _ => RelocationKind::MachO {
+                        value: reloc.r_type(),
+                        relative: reloc.is_pic(),
+                    },
                 },
                 mach::cputype::CPU_TYPE_X86 => match (reloc.r_type(), reloc.r_pcrel()) {
                     (mach::relocation::GENERIC_RELOC_VANILLA, 0) => RelocationKind::Absolute,
-                    _ => RelocationKind::Other(reloc.r_info),
+                    _ => RelocationKind::MachO {
+                        value: reloc.r_type(),
+                        relative: reloc.is_pic(),
+                    },
                 },
                 mach::cputype::CPU_TYPE_X86_64 => match (reloc.r_type(), reloc.r_pcrel()) {
                     (mach::relocation::X86_64_RELOC_UNSIGNED, 0) => RelocationKind::Absolute,
@@ -556,9 +565,15 @@ impl<'data, 'file> Iterator for MachORelocationIterator<'data, 'file> {
                         encoding = RelocationEncoding::X86RipRelativeMovq;
                         RelocationKind::GotRelative
                     }
-                    _ => RelocationKind::Other(reloc.r_info),
+                    _ => RelocationKind::MachO {
+                        value: reloc.r_type(),
+                        relative: reloc.is_pic(),
+                    },
                 },
-                _ => RelocationKind::Other(reloc.r_info),
+                _ => RelocationKind::MachO {
+                    value: reloc.r_type(),
+                    relative: reloc.is_pic(),
+                },
             };
             let size = 8 << reloc.r_length();
             let target = if reloc.is_extern() {

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -346,7 +346,7 @@ impl Object {
                             (RelocationKind::SectionOffset, 32, 0) => coff::IMAGE_REL_I386_SECREL,
                             (RelocationKind::SectionOffset, 7, 0) => coff::IMAGE_REL_I386_SECREL7,
                             (RelocationKind::Relative, 32, -4) => coff::IMAGE_REL_I386_REL32,
-                            (RelocationKind::Other(x), _, _) => x as u16,
+                            (RelocationKind::Coff(x), _, _) => x,
                             _ => return Err(format!("unimplemented relocation {:?}", reloc)),
                         },
                         Architecture::X86_64 => match (reloc.kind, reloc.size, reloc.addend) {
@@ -361,7 +361,7 @@ impl Object {
                             (RelocationKind::Relative, 32, -9) => coff::IMAGE_REL_AMD64_REL32_5,
                             (RelocationKind::SectionOffset, 32, 0) => coff::IMAGE_REL_AMD64_SECREL,
                             (RelocationKind::SectionOffset, 7, 0) => coff::IMAGE_REL_AMD64_SECREL7,
-                            (RelocationKind::Other(x), _, _) => x as u16,
+                            (RelocationKind::Coff(x), _, _) => x,
                             _ => return Err(format!("unimplemented relocation {:?}", reloc)),
                         },
                         _ => {

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -100,7 +100,7 @@ impl Object {
                 | RelocationKind::GotRelative
                 | RelocationKind::GotBaseRelative
                 | RelocationKind::PltRelative
-                | RelocationKind::Other(_) => return false,
+                | RelocationKind::Elf(_) => return false,
                 // Absolute relocations are preemptible for non-local data.
                 // TODO: not sure if this rule is exactly correct
                 // This rule was added to handle global data references in debuginfo.
@@ -498,7 +498,7 @@ impl Object {
                             (RelocationKind::Relative, 16) => elf::R_386_PC16,
                             (RelocationKind::Absolute, 8) => elf::R_386_8,
                             (RelocationKind::Relative, 8) => elf::R_386_PC8,
-                            (RelocationKind::Other(x), _) => x,
+                            (RelocationKind::Elf(x), _) => x,
                             _ => return Err(format!("unimplemented relocation {:?}", reloc)),
                         },
                         Architecture::X86_64 => match (reloc.kind, reloc.encoding, reloc.size) {
@@ -519,7 +519,7 @@ impl Object {
                             (RelocationKind::Relative, _, 16) => elf::R_X86_64_PC16,
                             (RelocationKind::Absolute, _, 8) => elf::R_X86_64_8,
                             (RelocationKind::Relative, _, 8) => elf::R_X86_64_PC8,
-                            (RelocationKind::Other(x), _, _) => x,
+                            (RelocationKind::Elf(x), _, _) => x,
                             _ => return Err(format!("unimplemented relocation {:?}", reloc)),
                         },
                         _ => {

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -523,6 +523,9 @@ impl Object {
                                 RelocationEncoding::X86RipRelativeMovq,
                                 -4,
                             ) => (1, mach::X86_64_RELOC_GOT_LOAD),
+                            (RelocationKind::MachO { value, relative }, _, _) => {
+                                (u32::from(relative), value)
+                            }
                             _ => return Err(format!("unimplemented relocation {:?}", reloc)),
                         },
                         _ => {


### PR DESCRIPTION
Fixes #141 

cc @bjorn3 

The differences from #142 are:
- read/write round trip should work
- avoid any knowledge of specific custom relocation values

In particular, this means that cranelift may need to handle the addend differently.