### PR TITLE
Add ObjectSegment::offset and ObjectSection::offset methods

### DIFF
--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -422,6 +422,10 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
         with_inner!(self.inner, SectionInternal, |x| x.align())
     }
 
+    fn file_range(&self) -> Option<(u64, u64)> {
+        with_inner!(self.inner, SectionInternal, |x| x.file_range())
+    }
+
     fn data(&self) -> Cow<'data, [u8]> {
         with_inner!(self.inner, SectionInternal, |x| x.data())
     }

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -319,6 +319,10 @@ impl<'data, 'file> ObjectSegment<'data> for Segment<'data, 'file> {
         with_inner!(self.inner, SegmentInternal, |x| x.align())
     }
 
+    fn file_range(&self) -> (u64, u64) {
+        with_inner!(self.inner, SegmentInternal, |x| x.file_range())
+    }
+
     fn data(&self) -> &'data [u8] {
         with_inner!(self.inner, SegmentInternal, |x| x.data())
     }

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -301,6 +301,14 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
         section_alignment(self.section.characteristics)
     }
 
+    #[inline]
+    fn file_range(&self) -> Option<(u64, u64)> {
+        Some((
+            self.section.pointer_to_raw_data as u64,
+            self.section.size_of_raw_data as u64,
+        ))
+    }
+
     fn data(&self) -> Cow<'data, [u8]> {
         Cow::from(self.raw_data())
     }

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -234,6 +234,14 @@ impl<'data, 'file> ObjectSegment<'data> for CoffSegment<'data, 'file> {
         section_alignment(self.section.characteristics)
     }
 
+    #[inline]
+    fn file_range(&self) -> (u64, u64) {
+        (
+            self.section.pointer_to_raw_data as u64,
+            self.section.size_of_raw_data as u64,
+        )
+    }
+
     fn data(&self) -> &'data [u8] {
         let offset = self.section.pointer_to_raw_data as usize;
         let size = self.section.size_of_raw_data as usize;

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -331,11 +331,19 @@ where
 }
 
 impl<'data, 'file> ElfSection<'data, 'file> {
-    fn raw_data(&self) -> &'data [u8] {
+    fn raw_offset(&self) -> Option<(u64, u64)> {
         if self.section.sh_type == elf::section_header::SHT_NOBITS {
-            &[]
+            None
         } else {
-            &self.file.data[self.section.sh_offset as usize..][..self.section.sh_size as usize]
+            Some((self.section.sh_offset, self.section.sh_size))
+        }
+    }
+
+    fn raw_data(&self) -> &'data [u8] {
+        if let Some((offset, size)) = self.raw_offset() {
+            &self.file.data[offset as usize..][..size as usize]
+        } else {
+            &[]
         }
     }
 
@@ -426,6 +434,11 @@ impl<'data, 'file> ObjectSection<'data> for ElfSection<'data, 'file> {
     #[inline]
     fn align(&self) -> u64 {
         self.section.sh_addralign
+    }
+
+    #[inline]
+    fn file_range(&self) -> Option<(u64, u64)> {
+        self.raw_offset()
     }
 
     #[inline]

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -278,6 +278,11 @@ impl<'data, 'file> ObjectSegment<'data> for ElfSegment<'data, 'file> {
         self.segment.p_align
     }
 
+    #[inline]
+    fn file_range(&self) -> (u64, u64) {
+        (self.segment.p_offset, self.segment.p_filesz)
+    }
+
     fn data(&self) -> &'data [u8] {
         &self.file.data[self.segment.p_offset as usize..][..self.segment.p_filesz as usize]
     }

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -273,6 +273,11 @@ impl<'data, 'file> ObjectSegment<'data> for MachOSegment<'data, 'file> {
     }
 
     #[inline]
+    fn file_range(&self) -> (u64, u64) {
+        (self.segment.fileoff, self.segment.filesize)
+    }
+
+    #[inline]
     fn data(&self) -> &'data [u8] {
         self.segment.data
     }

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -361,6 +361,12 @@ impl<'data, 'file> ObjectSection<'data> for MachOSection<'data, 'file> {
     }
 
     #[inline]
+    fn file_range(&self) -> Option<(u64, u64)> {
+        let internal = &self.internal().section;
+        Some((internal.offset as u64, internal.size))
+    }
+
+    #[inline]
     fn data(&self) -> Cow<'data, [u8]> {
         Cow::from(self.internal().data)
     }

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -280,6 +280,14 @@ impl<'data, 'file> ObjectSection<'data> for PeSection<'data, 'file> {
         self.file.section_alignment()
     }
 
+    #[inline]
+    fn file_range(&self) -> Option<(u64, u64)> {
+        Some((
+            self.section.pointer_to_raw_data as u64,
+            self.section.size_of_raw_data as u64,
+        ))
+    }
+
     fn data(&self) -> Cow<'data, [u8]> {
         Cow::from(self.raw_data())
     }

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -192,6 +192,14 @@ impl<'data, 'file> ObjectSegment<'data> for PeSegment<'data, 'file> {
         self.file.section_alignment()
     }
 
+    #[inline]
+    fn file_range(&self) -> (u64, u64) {
+        (
+            self.section.pointer_to_raw_data as u64,
+            self.section.size_of_raw_data as u64,
+        )
+    }
+
     fn data(&self) -> &'data [u8] {
         let offset = self.section.pointer_to_raw_data as usize;
         let size = cmp::min(self.section.virtual_size, self.section.size_of_raw_data) as usize;

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -186,6 +186,9 @@ pub trait ObjectSection<'data> {
     /// Returns the alignment of the section in memory.
     fn align(&self) -> u64;
 
+    /// Returns offset and size of on-disk segment (if any)
+    fn file_range(&self) -> Option<(u64, u64)>;
+
     /// Returns the raw contents of the section.
     /// The length of this data may be different from the size of the
     /// section in memory.

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -151,6 +151,9 @@ pub trait ObjectSegment<'data> {
     /// Returns the alignment of the segment in memory.
     fn align(&self) -> u64;
 
+    /// Returns the offset and size of the segment in the file.
+    fn file_range(&self) -> (u64, u64);
+
     /// Returns a reference to the file contents of the segment.
     /// The length of this data may be different from the size of the
     /// segment in memory.

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -210,6 +210,11 @@ impl<'file> ObjectSection<'static> for WasmSection<'file> {
         1
     }
 
+    #[inline]
+    fn file_range(&self) -> Option<(u64, u64)> {
+        None
+    }
+
     fn data(&self) -> Cow<'static, [u8]> {
         match *self.section {
             elements::Section::Custom(ref section) => Some(section.payload().to_vec().into()),

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -144,6 +144,11 @@ impl<'file> ObjectSegment<'static> for WasmSegment<'file> {
         unreachable!()
     }
 
+    #[inline]
+    fn file_range(&self) -> (u64, u64) {
+        unreachable!()
+    }
+
     fn data(&self) -> &'static [u8] {
         unreachable!()
     }


### PR DESCRIPTION
Add a method for segments which returns the on-disk file offset and
segment size (distinct from the in-memory size, for formats where they
can differ).
    
This is similar to `data()`, but rather than returning a slice of the
data itself, it returns the location of the data.  This is useful for
when we want to locate the segment within a memory mapping, or use it
to generate the parameters for an IO syscall.

The `Segment::` and `Section::` methods are very similar, except that sections
can have no content associated with them. To handle this, Segment::offset returns
`Option<(u64, u64)>` where None indicates no loadable content.

(Open to suggestions on name.)
