### PR TITLE
Implement common and absolute symbols for ELF and Mach-O

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -33,6 +33,10 @@ pub enum SectionKind {
     ///
     /// Example Mach-O sections: `__DATA/__bss`
     UninitializedData,
+    /// An uninitialized common data section.
+    ///
+    /// Example Mach-O sections: `__DATA/__common`
+    Common,
     /// A TLS data section.
     ///
     /// Example ELF sections: `.tdata`
@@ -73,6 +77,15 @@ pub enum SectionKind {
     Metadata,
 }
 
+impl SectionKind {
+    /// Return true if this section contains zerofill data.
+    pub fn is_bss(self) -> bool {
+        self == SectionKind::UninitializedData
+            || self == SectionKind::UninitializedTls
+            || self == SectionKind::Common
+    }
+}
+
 /// The kind of a symbol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SymbolKind {
@@ -90,8 +103,6 @@ pub enum SymbolKind {
     File,
     /// The symbol is for a code label.
     Label,
-    /// The symbol is for an uninitialized common block.
-    Common,
     /// The symbol is for a thread local storage entity.
     Tls,
 }

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -6,7 +6,7 @@ use target_lexicon::Architecture;
 
 use crate::read::{
     self, Object, ObjectSection, ObjectSegment, Relocation, SectionIndex, SectionKind, Symbol,
-    SymbolIndex, SymbolKind, SymbolMap, SymbolScope,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
 };
 
 /// A PE object file.
@@ -362,8 +362,7 @@ impl<'data, 'file> Iterator for PeSymbolIterator<'data, 'file> {
                     size: 0,
                     kind: SymbolKind::Unknown,
                     // TODO: can we find a section?
-                    section_index: None,
-                    undefined: false,
+                    section: SymbolSection::Unknown,
                     weak: false,
                     scope: SymbolScope::Dynamic,
                 },
@@ -383,8 +382,7 @@ impl<'data, 'file> Iterator for PeSymbolIterator<'data, 'file> {
                     address: 0,
                     size: 0,
                     kind: SymbolKind::Unknown,
-                    section_index: None,
-                    undefined: true,
+                    section: SymbolSection::Undefined,
                     weak: false,
                     scope: SymbolScope::Dynamic,
                 },

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -54,6 +54,10 @@ impl Object {
                 // Unsupported section.
                 (&[], &[], SectionKind::TlsVariables)
             }
+            StandardSection::Common => {
+                // Unsupported section.
+                (&[], &[], SectionKind::Common)
+            }
         }
     }
 

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -54,6 +54,10 @@ impl Object {
                 // Unsupported section.
                 (&[], &[], SectionKind::TlsVariables)
             }
+            StandardSection::Common => {
+                // Unsupported section.
+                (&[], &[], SectionKind::Common)
+            }
         }
     }
 

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -121,7 +121,7 @@ impl Object {
         //     making a shared object; recompile with -fPIC
         let symbol = &self.symbols[relocation.symbol.0];
         if want_section_symbol(relocation, symbol) {
-            if let Some(section) = symbol.section {
+            if let Some(section) = symbol.section.id() {
                 relocation.addend += symbol.value as i64;
                 relocation.symbol = self.section_symbol(section);
             }
@@ -240,6 +240,7 @@ impl Object {
         for symbol in &self.symbols {
             let index = symbol
                 .section
+                .id()
                 .map(|s| section_offsets[s.0].index)
                 .unwrap_or(0);
             if index >= elf::SHN_LORESERVE as usize {
@@ -396,13 +397,14 @@ impl Object {
                 SymbolKind::Data => {
                     if symbol.is_undefined() {
                         elf::STT_NOTYPE
+                    } else if symbol.is_common() {
+                        elf::STT_COMMON
                     } else {
                         elf::STT_OBJECT
                     }
                 }
                 SymbolKind::Section => elf::STT_SECTION,
                 SymbolKind::File => elf::STT_FILE,
-                SymbolKind::Common => elf::STT_COMMON,
                 SymbolKind::Tls => elf::STT_TLS,
                 SymbolKind::Label => elf::STT_NOTYPE,
             };
@@ -420,26 +422,25 @@ impl Object {
             } else {
                 elf::STV_DEFAULT
             };
-            let st_shndx = match symbol.kind {
-                SymbolKind::File => {
-                    if need_symtab_shndx {
-                        symtab_shndx.iowrite_with(0, ctx.le).unwrap();
-                    }
-                    elf::SHN_ABS as usize
-                }
-                _ => {
-                    let index = symbol
-                        .section
-                        .map(|s| section_offsets[s.0].index)
-                        .unwrap_or(elf::SHN_UNDEF as usize);
-                    if need_symtab_shndx {
-                        symtab_shndx.iowrite_with(index as u32, ctx.le).unwrap();
-                    }
-                    if index >= elf::SHN_LORESERVE as usize {
-                        elf::SHN_XINDEX as usize
-                    } else {
-                        index
-                    }
+            let section = if symbol.kind == SymbolKind::File {
+                SymbolSection::Absolute
+            } else {
+                symbol.section
+            };
+            let (st_shndx, xindex) = match section {
+                SymbolSection::Undefined => (elf::SHN_UNDEF, 0),
+                SymbolSection::Absolute => (elf::SHN_ABS, 0),
+                SymbolSection::Common => (elf::SHN_COMMON, 0),
+                SymbolSection::Section(id) => {
+                    let index = section_offsets[id.0].index;
+                    (
+                        index as u32,
+                        if index >= elf::SHN_LORESERVE as usize {
+                            elf::SHN_XINDEX as usize
+                        } else {
+                            index
+                        },
+                    )
                 }
             };
             let st_name = symbol_offsets[index]
@@ -452,13 +453,16 @@ impl Object {
                         st_name,
                         st_info: (st_bind << 4) + st_type,
                         st_other,
-                        st_shndx,
+                        st_shndx: st_shndx as usize,
                         st_value: symbol.value,
                         st_size: symbol.size,
                     },
                     ctx,
                 )
                 .unwrap();
+            if need_symtab_shndx {
+                symtab_shndx.iowrite_with(xindex, ctx.le).unwrap();
+            }
         };
         for (index, symbol) in self.symbols.iter().enumerate() {
             if symbol.is_local() {
@@ -597,7 +601,7 @@ impl Object {
                 | SectionKind::Unknown
                 | SectionKind::Metadata
                 | SectionKind::Linker => 0,
-                SectionKind::TlsVariables => {
+                SectionKind::Common | SectionKind::TlsVariables => {
                     return Err(format!("unimplemented section {:?}", section.kind))
                 }
             };

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -252,10 +252,11 @@ impl Object {
         let mut nsyms = 0;
         for (index, symbol) in self.symbols.iter().enumerate() {
             match symbol.kind {
-                SymbolKind::Unknown if symbol.is_undefined() => {}
-                SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
+                SymbolKind::Unknown | SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
                 SymbolKind::File | SymbolKind::Section => continue,
-                _ => return Err(format!("unimplemented symbol {:?}", symbol)),
+                SymbolKind::Null | SymbolKind::Label => {
+                    return Err(format!("unimplemented symbol {:?}", symbol))
+                }
             }
             symbol_offsets[index].index = nsyms;
             nsyms += 1;
@@ -420,10 +421,11 @@ impl Object {
         debug_assert_eq!(symtab_offset, buffer.len());
         for (index, symbol) in self.symbols.iter().enumerate() {
             match symbol.kind {
-                SymbolKind::Unknown if symbol.is_undefined() => {}
-                SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
+                SymbolKind::Unknown | SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
                 SymbolKind::File | SymbolKind::Section => continue,
-                _ => return Err(format!("unimplemented symbol {:?}", symbol)),
+                SymbolKind::Null | SymbolKind::Label => {
+                    return Err(format!("unimplemented symbol {:?}", symbol))
+                }
             }
             // TODO: N_STAB
             let (mut n_type, n_sect) = match symbol.section {

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -88,7 +88,7 @@ impl Object {
                     kind: SymbolKind::Text,
                     scope: SymbolScope::Dynamic,
                     weak: false,
-                    section: None,
+                    section: SymbolSection::Undefined,
                 });
                 self.tlv_bootstrap = Some(id);
                 id
@@ -120,7 +120,7 @@ impl Object {
             kind: SymbolKind::Tls,
             scope: SymbolScope::Compilation,
             weak: false,
-            section: None,
+            section: SymbolSection::Undefined,
         });
 
         // Add the tlv entry.
@@ -164,7 +164,7 @@ impl Object {
         let symbol = self.symbol_mut(symbol_id);
         symbol.value = offset;
         symbol.size = size;
-        symbol.section = Some(section);
+        symbol.section = SymbolSection::Section(section);
 
         init_symbol_id
     }
@@ -222,17 +222,27 @@ impl Object {
         let mut address = 0;
         for (index, section) in self.sections.iter().enumerate() {
             section_offsets[index].index = 1 + index;
-            let len = section.data.len();
-            if len != 0 {
-                offset = align(offset, section.align as usize);
-                section_offsets[index].offset = offset;
-                offset += len;
-            } else {
-                section_offsets[index].offset = offset;
+            if !section.is_bss() {
+                let len = section.data.len();
+                if len != 0 {
+                    offset = align(offset, section.align as usize);
+                    section_offsets[index].offset = offset;
+                    offset += len;
+                } else {
+                    section_offsets[index].offset = offset;
+                }
+                address = align_u64(address, section.align);
+                section_offsets[index].address = address;
+                address += section.size;
             }
-            address = align_u64(address, section.align);
-            section_offsets[index].address = address;
-            address += section.size;
+        }
+        for (index, section) in self.sections.iter().enumerate() {
+            if section.kind.is_bss() {
+                assert!(section.data.is_empty());
+                address = align_u64(address, section.align);
+                section_offsets[index].address = address;
+                address += section.size;
+            }
         }
         let segment_data_size = offset - segment_data_offset;
 
@@ -241,12 +251,11 @@ impl Object {
         let mut symbol_offsets = vec![SymbolOffsets::default(); self.symbols.len()];
         let mut nsyms = 0;
         for (index, symbol) in self.symbols.iter().enumerate() {
-            if !symbol.is_undefined() {
-                match symbol.kind {
-                    SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
-                    SymbolKind::File | SymbolKind::Section => continue,
-                    _ => return Err(format!("unimplemented symbol {:?}", symbol)),
-                }
+            match symbol.kind {
+                SymbolKind::Unknown if symbol.is_undefined() => {}
+                SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
+                SymbolKind::File | SymbolKind::Section => continue,
+                _ => return Err(format!("unimplemented symbol {:?}", symbol)),
             }
             symbol_offsets[index].index = nsyms;
             nsyms += 1;
@@ -350,7 +359,7 @@ impl Object {
                 SectionKind::Data => 0,
                 SectionKind::ReadOnlyData => 0,
                 SectionKind::ReadOnlyString => mach::S_CSTRING_LITERALS,
-                SectionKind::UninitializedData => mach::S_ZEROFILL,
+                SectionKind::UninitializedData | SectionKind::Common => mach::S_ZEROFILL,
                 SectionKind::Tls => mach::S_THREAD_LOCAL_REGULAR,
                 SectionKind::UninitializedTls => mach::S_THREAD_LOCAL_ZEROFILL,
                 SectionKind::TlsVariables => mach::S_THREAD_LOCAL_VARIABLES,
@@ -410,19 +419,20 @@ impl Object {
         write_align(&mut buffer, pointer_align);
         debug_assert_eq!(symtab_offset, buffer.len());
         for (index, symbol) in self.symbols.iter().enumerate() {
-            if !symbol.is_undefined() {
-                match symbol.kind {
-                    SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
-                    SymbolKind::File | SymbolKind::Section => continue,
-                    _ => return Err(format!("unimplemented symbol {:?}", symbol)),
-                }
+            match symbol.kind {
+                SymbolKind::Unknown if symbol.is_undefined() => {}
+                SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
+                SymbolKind::File | SymbolKind::Section => continue,
+                _ => return Err(format!("unimplemented symbol {:?}", symbol)),
             }
             // TODO: N_STAB
-            // TODO: N_ABS
-            let mut n_type = if symbol.is_undefined() {
-                mach::N_UNDF | mach::N_EXT
-            } else {
-                mach::N_SECT
+            let (mut n_type, n_sect) = match symbol.section {
+                SymbolSection::Undefined => (mach::N_UNDF | mach::N_EXT, 0),
+                SymbolSection::Absolute => (mach::N_ABS, 0),
+                SymbolSection::Common => {
+                    return Err(format!("unimplemented symbol.section {:?}", symbol.section))
+                }
+                SymbolSection::Section(id) => (mach::N_SECT, id.0 + 1),
             };
             match symbol.scope {
                 SymbolScope::Unknown | SymbolScope::Compilation => {}
@@ -443,7 +453,7 @@ impl Object {
                 }
             }
 
-            let n_value = match symbol.section {
+            let n_value = match symbol.section.id() {
                 Some(section) => section_offsets[section.0].address + symbol.value,
                 None => symbol.value,
             };
@@ -458,7 +468,7 @@ impl Object {
                     mach::Nlist {
                         n_strx,
                         n_type,
-                        n_sect: symbol.section.map(|x| x.0 + 1).unwrap_or(0),
+                        n_sect,
                         n_desc,
                         n_value,
                     },
@@ -481,7 +491,7 @@ impl Object {
                     let r_symbolnum;
                     let symbol = &self.symbols[reloc.symbol.0];
                     if symbol.kind == SymbolKind::Section {
-                        r_symbolnum = section_offsets[symbol.section.unwrap().0].index as u32;
+                        r_symbolnum = section_offsets[symbol.section.id().unwrap().0].index as u32;
                         r_extern = 0;
                     } else {
                         r_symbolnum = symbol_offsets[reloc.symbol.0].index as u32;

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -74,6 +74,7 @@ impl Object {
                 &b"__thread_vars"[..],
                 SectionKind::TlsVariables,
             ),
+            StandardSection::Common => (&b"__DATA"[..], &b"__common"[..], SectionKind::Common),
         }
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,150 @@
+#![cfg(all(feature = "read", feature = "write"))]
+
+use object::read::{Object, ObjectSection};
+use object::{read, write};
+use object::{SectionKind, SymbolKind, SymbolScope};
+use target_lexicon::{Architecture, BinaryFormat};
+
+#[test]
+fn elf_x86_64_common() {
+    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+
+    let symbol = write::Symbol {
+        name: b"v1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+    };
+    object.add_common_symbol(symbol, 4, 4);
+
+    let symbol = write::Symbol {
+        name: b"v2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+    };
+    object.add_common_symbol(symbol, 8, 8);
+
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"common.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Elf);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some(""));
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section(), read::SymbolSection::Common);
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 4);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section(), read::SymbolSection::Common);
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 8);
+
+    let symbol = symbols.next();
+    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+}
+
+#[test]
+fn macho_x86_64_common() {
+    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+
+    let symbol = write::Symbol {
+        name: b"v1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+    };
+    object.add_common_symbol(symbol, 4, 4);
+
+    let symbol = write::Symbol {
+        name: b"v2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+    };
+    object.add_common_symbol(symbol, 8, 8);
+
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"common.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut sections = object.sections();
+
+    let common = sections.next().unwrap();
+    println!("{:?}", common);
+    let common_index = common.index();
+    assert_eq!(common.name(), Some("__common"));
+    assert_eq!(common.segment_name(), Some("__DATA"));
+    assert_eq!(common.kind(), SectionKind::Common);
+    assert_eq!(common.size(), 16);
+    // This is a bug in goblin: https://github.com/m4b/goblin/pull/195
+    //assert_eq!(&*common.data(), &[]);
+
+    let section = sections.next();
+    assert!(
+        section.is_none(),
+        format!("unexpected section {:?}", section)
+    );
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_v1"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(common_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_v2"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(common_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 8);
+
+    let symbol = symbols.next();
+    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -6,6 +6,68 @@ use object::{SectionKind, SymbolKind, SymbolScope};
 use target_lexicon::{Architecture, BinaryFormat};
 
 #[test]
+fn coff_x86_64_common() {
+    let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+
+    let symbol = write::Symbol {
+        name: b"v1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+    };
+    object.add_common_symbol(symbol, 4, 4);
+
+    let symbol = write::Symbol {
+        name: b"v2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+    };
+    object.add_common_symbol(symbol, 8, 8);
+
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"common.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Coff);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section(), read::SymbolSection::Common);
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 4);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section(), read::SymbolSection::Common);
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 8);
+
+    let symbol = symbols.next();
+    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+}
+
+#[test]
 fn elf_x86_64_common() {
     let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
 

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -21,7 +21,7 @@ fn coff_x86_64() {
         kind: SymbolKind::Text,
         scope: SymbolScope::Linkage,
         weak: false,
-        section: Some(text),
+        section: write::SymbolSection::Section(text),
     });
     object
         .add_relocation(
@@ -97,7 +97,7 @@ fn elf_x86_64() {
         kind: SymbolKind::Text,
         scope: SymbolScope::Linkage,
         weak: false,
-        section: Some(text),
+        section: write::SymbolSection::Section(text),
     });
     object
         .add_relocation(
@@ -190,7 +190,7 @@ fn macho_x86_64() {
         kind: SymbolKind::Text,
         scope: SymbolScope::Linkage,
         weak: false,
-        section: Some(text),
+        section: write::SymbolSection::Section(text),
     });
     object
         .add_relocation(

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -121,7 +121,7 @@ fn elf_x86_64() {
     let mut sections = object.sections();
 
     let section = sections.next().unwrap();
-    println!("{:?}", text);
+    println!("{:?}", section);
     assert_eq!(section.name(), Some(""));
     assert_eq!(section.kind(), SectionKind::Metadata);
     assert_eq!(section.address(), 0);

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -35,7 +35,7 @@ fn macho_x86_64_tls() {
 
     let bytes = object.write().unwrap();
 
-    std::fs::write(&"tls.o", &bytes).unwrap();
+    //std::fs::write(&"tls.o", &bytes).unwrap();
 
     let object = read::File::parse(&bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Macho);
@@ -44,7 +44,7 @@ fn macho_x86_64_tls() {
     let mut sections = object.sections();
 
     let thread_data = sections.next().unwrap();
-    println!("{:?}", section);
+    println!("{:?}", thread_data);
     let thread_data_index = thread_data.index();
     assert_eq!(thread_data.name(), Some("__thread_data"));
     assert_eq!(thread_data.segment_name(), Some("__DATA"));
@@ -53,7 +53,7 @@ fn macho_x86_64_tls() {
     assert_eq!(&thread_data.data()[..], &[1; 30]);
 
     let thread_vars = sections.next().unwrap();
-    println!("{:?}", section);
+    println!("{:?}", thread_vars);
     let thread_vars_index = thread_vars.index();
     assert_eq!(thread_vars.name(), Some("__thread_vars"));
     assert_eq!(thread_vars.segment_name(), Some("__DATA"));
@@ -61,7 +61,7 @@ fn macho_x86_64_tls() {
     assert_eq!(thread_vars.size(), 2 * 3 * 8);
 
     let thread_bss = sections.next().unwrap();
-    println!("{:?}", section);
+    println!("{:?}", thread_bss);
     let thread_bss_index = thread_bss.index();
     assert_eq!(thread_bss.name(), Some("__thread_bss"));
     assert_eq!(thread_bss.segment_name(), Some("__DATA"));

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -17,7 +17,7 @@ fn macho_x86_64_tls() {
         kind: SymbolKind::Tls,
         scope: SymbolScope::Linkage,
         weak: false,
-        section: None,
+        section: write::SymbolSection::Undefined,
     });
     object.add_symbol_data(symbol, section, &[1; 30], 4);
 
@@ -29,7 +29,7 @@ fn macho_x86_64_tls() {
         kind: SymbolKind::Tls,
         scope: SymbolScope::Linkage,
         weak: false,
-        section: None,
+        section: write::SymbolSection::Undefined,
     });
     object.add_symbol_bss(symbol, section, 31, 4);
 


### PR DESCRIPTION
Also hopefully fixes address calculations for BSS sections in Mach-O.

~~`write::Object` will probably also need an `add_common_symbol` method so code generators can handle the differences between ELF and Mach-O (and COFF, which I have no idea about yet), but that's not needed for objcopy, so leaving that until someone needs/tests it.~~ Done.

Closes #149, closes #158 

cc @jayvdb 