### PR TITLE
objcopy: copy file, section, and symbol flags

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -196,3 +196,73 @@ pub enum RelocationEncoding {
     /// The `RelocationKind` must be PC relative.
     X86Branch,
 }
+
+/// File flags that are specific to each file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileFlags {
+    /// No file flags.
+    None,
+    /// ELF file flags.
+    Elf {
+        /// `e_flags` field in the ELF file header.
+        e_flags: u32,
+    },
+    /// Mach-O file flags.
+    MachO {
+        /// `flags` field in the Mach-O file header.
+        flags: u32,
+    },
+    /// COFF file flags.
+    Coff {
+        /// `Characteristics` field in the COFF file header.
+        characteristics: u16,
+    },
+}
+
+/// Section flags that are specific to each file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionFlags {
+    /// No section flags.
+    None,
+    /// ELF section flags.
+    Elf {
+        /// `sh_flags` field in the section header.
+        sh_flags: u64,
+    },
+    /// Mach-O section flags.
+    MachO {
+        /// `flags` field in the section header.
+        flags: u32,
+    },
+    /// COFF section flags.
+    Coff {
+        /// `Characteristics` field in the section header.
+        characteristics: u32,
+    },
+}
+
+/// Symbol flags that are specific to each file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolFlags<Section> {
+    /// No symbol flags.
+    None,
+    /// ELF symbol flags.
+    Elf {
+        /// `st_info` field in the ELF symbol.
+        st_info: u8,
+        /// `st_other` field in the ELF symbol.
+        st_other: u8,
+    },
+    /// Mach-O symbol flags.
+    MachO {
+        /// `n_desc` field in the Mach-O symbol.
+        n_desc: u16,
+    },
+    /// COFF flags for a section symbol.
+    CoffSection {
+        /// `Selection` field in the auxiliary symbol for the section.
+        selection: u8,
+        /// `Number` field in the auxiliary symbol for the section.
+        associative_section: Section,
+    },
+}

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 use crate::read::wasm;
 use crate::read::{coff, elf, macho, pe};
 use crate::read::{
-    Object, ObjectSection, ObjectSegment, Relocation, SectionIndex, SectionKind, Symbol,
-    SymbolIndex, SymbolMap,
+    FileFlags, Object, ObjectSection, ObjectSegment, Relocation, SectionFlags, SectionIndex,
+    SectionKind, Symbol, SymbolIndex, SymbolMap,
 };
 
 /// Evaluate an expression on the contents of a file format enum.
@@ -241,6 +241,10 @@ where
     fn entry(&self) -> u64 {
         with_inner!(self.inner, FileInternal, |x| x.entry())
     }
+
+    fn flags(&self) -> FileFlags {
+        with_inner!(self.inner, FileInternal, |x| x.flags())
+    }
 }
 
 /// An iterator over the segments of a `File`.
@@ -459,6 +463,10 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
                 |x| x.relocations()
             ),
         }
+    }
+
+    fn flags(&self) -> SectionFlags {
+        with_inner!(self.inner, SectionInternal, |x| x.flags())
     }
 }
 

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -278,9 +278,13 @@ impl<'data, 'file> Iterator for CoffSectionIterator<'data, 'file> {
 
 impl<'data, 'file> CoffSection<'data, 'file> {
     fn raw_data(&self) -> &'data [u8] {
-        let offset = self.section.pointer_to_raw_data as usize;
-        let size = self.section.size_of_raw_data as usize;
-        &self.file.data[offset..][..size]
+        if self.section.characteristics & pe::section_table::IMAGE_SCN_CNT_UNINITIALIZED_DATA != 0 {
+            &[]
+        } else {
+            let offset = self.section.pointer_to_raw_data as usize;
+            let size = self.section.size_of_raw_data as usize;
+            &self.file.data[offset..][..size]
+        }
     }
 }
 
@@ -310,10 +314,14 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
 
     #[inline]
     fn file_range(&self) -> Option<(u64, u64)> {
-        Some((
-            self.section.pointer_to_raw_data as u64,
-            self.section.size_of_raw_data as u64,
-        ))
+        if self.section.characteristics & pe::section_table::IMAGE_SCN_CNT_UNINITIALIZED_DATA != 0 {
+            None
+        } else {
+            Some((
+                self.section.pointer_to_raw_data as u64,
+                self.section.size_of_raw_data as u64,
+            ))
+        }
     }
 
     fn data(&self) -> Cow<'data, [u8]> {

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -13,9 +13,9 @@ use std::{iter, slice};
 use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
 
 use crate::read::{
-    self, Object, ObjectSection, ObjectSegment, Relocation, RelocationEncoding, RelocationKind,
-    RelocationTarget, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolKind, SymbolMap,
-    SymbolScope, SymbolSection,
+    self, FileFlags, Object, ObjectSection, ObjectSegment, Relocation, RelocationEncoding,
+    RelocationKind, RelocationTarget, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
 };
 
 /// An ELF object file.
@@ -223,6 +223,12 @@ where
 
     fn entry(&self) -> u64 {
         self.elf.entry
+    }
+
+    fn flags(&self) -> FileFlags {
+        FileFlags::Elf {
+            e_flags: self.elf.header.e_flags,
+        }
     }
 }
 
@@ -530,6 +536,12 @@ impl<'data, 'file> ObjectSection<'data> for ElfSection<'data, 'file> {
             relocations: None,
         }
     }
+
+    fn flags(&self) -> SectionFlags {
+        SectionFlags::Elf {
+            sh_flags: self.section.sh_flags,
+        }
+    }
 }
 
 /// An iterator over the symbols of an `ElfFile`.
@@ -597,6 +609,10 @@ fn parse_symbol<'data>(
         }
         _ => SymbolScope::Unknown,
     };
+    let flags = SymbolFlags::Elf {
+        st_info: symbol.st_info,
+        st_other: symbol.st_other,
+    };
     Symbol {
         name,
         address: symbol.st_value,
@@ -605,6 +621,7 @@ fn parse_symbol<'data>(
         section,
         weak,
         scope,
+        flags,
     }
 }
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1,7 +1,10 @@
 //! Interface for reading object files.
 
 use crate::alloc::vec::Vec;
-use crate::common::{RelocationEncoding, RelocationKind, SectionKind, SymbolKind, SymbolScope};
+use crate::common::{
+    FileFlags, RelocationEncoding, RelocationKind, SectionFlags, SectionKind, SymbolFlags,
+    SymbolKind, SymbolScope,
+};
 
 mod any;
 pub use any::*;
@@ -91,6 +94,7 @@ pub struct Symbol<'data> {
     section: SymbolSection,
     weak: bool,
     scope: SymbolScope,
+    flags: SymbolFlags<SectionIndex>,
 }
 
 impl<'data> Symbol<'data> {
@@ -152,6 +156,12 @@ impl<'data> Symbol<'data> {
     #[inline]
     pub fn scope(&self) -> SymbolScope {
         self.scope
+    }
+
+    /// Symbol flags that are specific to each file format.
+    #[inline]
+    pub fn flags(&self) -> SymbolFlags<SectionIndex> {
+        self.flags
     }
 
     /// The name of the symbol.

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -5,8 +5,9 @@ use std::{cmp, iter, slice};
 use target_lexicon::Architecture;
 
 use crate::read::{
-    self, Object, ObjectSection, ObjectSegment, Relocation, SectionIndex, SectionKind, Symbol,
-    SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
+    self, FileFlags, Object, ObjectSection, ObjectSegment, Relocation, SectionFlags, SectionIndex,
+    SectionKind, Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolScope,
+    SymbolSection,
 };
 
 /// A PE object file.
@@ -142,6 +143,12 @@ where
 
     fn entry(&self) -> u64 {
         self.pe.entry as u64
+    }
+
+    fn flags(&self) -> FileFlags {
+        FileFlags::Coff {
+            characteristics: self.pe.header.coff_header.characteristics,
+        }
     }
 }
 
@@ -334,6 +341,12 @@ impl<'data, 'file> ObjectSection<'data> for PeSection<'data, 'file> {
     fn relocations(&self) -> PeRelocationIterator {
         PeRelocationIterator
     }
+
+    fn flags(&self) -> SectionFlags {
+        SectionFlags::Coff {
+            characteristics: self.section.characteristics,
+        }
+    }
 }
 
 /// An iterator over the symbols of a `PeFile`.
@@ -365,6 +378,7 @@ impl<'data, 'file> Iterator for PeSymbolIterator<'data, 'file> {
                     section: SymbolSection::Unknown,
                     weak: false,
                     scope: SymbolScope::Dynamic,
+                    flags: SymbolFlags::None,
                 },
             ));
         }
@@ -385,6 +399,7 @@ impl<'data, 'file> Iterator for PeSymbolIterator<'data, 'file> {
                     section: SymbolSection::Undefined,
                     weak: false,
                     scope: SymbolScope::Dynamic,
+                    flags: SymbolFlags::None,
                 },
             ));
         }

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -1,5 +1,7 @@
 use crate::alloc::borrow::Cow;
-use crate::{Relocation, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap};
+use crate::{
+    FileFlags, Relocation, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap,
+};
 use target_lexicon::{Architecture, Endianness};
 use uuid::Uuid;
 
@@ -135,6 +137,9 @@ pub trait Object<'data, 'file> {
     fn gnu_debuglink(&self) -> Option<(&'data [u8], u32)> {
         None
     }
+
+    /// File flags that are specific to each file format.
+    fn flags(&self) -> FileFlags;
 }
 
 /// A loadable segment defined in an object file.
@@ -217,4 +222,7 @@ pub trait ObjectSection<'data> {
 
     /// Get the relocations for this section.
     fn relocations(&self) -> Self::RelocationIterator;
+
+    /// Section flags that are specific to each file format.
+    fn flags(&self) -> SectionFlags;
 }

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -5,8 +5,8 @@ use std::{iter, slice};
 use target_lexicon::Architecture;
 
 use crate::read::{
-    Object, ObjectSection, ObjectSegment, Relocation, SectionIndex, SectionKind, Symbol,
-    SymbolIndex, SymbolMap,
+    FileFlags, Object, ObjectSection, ObjectSegment, Relocation, SectionFlags, SectionIndex,
+    SectionKind, Symbol, SymbolIndex, SymbolMap,
 };
 
 /// A WebAssembly object file.
@@ -105,6 +105,10 @@ impl<'file> Object<'static, 'file> for WasmFile {
             elements::Section::Custom(ref c) => c.name().starts_with(".debug_"),
             _ => false,
         })
+    }
+
+    fn flags(&self) -> FileFlags {
+        FileFlags::None
     }
 }
 
@@ -285,6 +289,10 @@ impl<'file> ObjectSection<'static> for WasmSection<'file> {
 
     fn relocations(&self) -> WasmRelocationIterator {
         WasmRelocationIterator
+    }
+
+    fn flags(&self) -> SectionFlags {
+        SectionFlags::None
     }
 }
 

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -93,7 +93,7 @@ impl Object {
             Architecture::X86_64 => match relocation.kind {
                 RelocationKind::Relative => {
                     // IMAGE_REL_AMD64_REL32 through to IMAGE_REL_AMD64_REL32_5
-                    if relocation.addend >= -4 && relocation.addend <= -9 {
+                    if relocation.addend <= -4 && relocation.addend >= -9 {
                         0
                     } else {
                         relocation.addend + 4

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -309,13 +309,9 @@ impl Object {
             let mut coff_section = coff::SectionTable {
                 name: [0; 8],
                 real_name: None,
-                virtual_size: if section.data.is_empty() {
-                    section.size as u32
-                } else {
-                    0
-                },
+                virtual_size: 0,
                 virtual_address: 0,
-                size_of_raw_data: section.data.len() as u32,
+                size_of_raw_data: section.size as u32,
                 pointer_to_raw_data: if section.data.is_empty() {
                     0
                 } else {
@@ -492,7 +488,7 @@ impl Object {
                     buffer
                         .iowrite_with(
                             coff::AuxSectionDefinition {
-                                length: section.data.len() as u32,
+                                length: section.size as u32,
                                 number_of_relocations: section.relocations.len() as u16,
                                 number_of_line_numbers: 0,
                                 checksum: checksum(&section.data),

--- a/tests/bss.rs
+++ b/tests/bss.rs
@@ -1,0 +1,254 @@
+#![cfg(all(feature = "read", feature = "write"))]
+
+use object::read::{Object, ObjectSection};
+use object::{read, write};
+use object::{SectionKind, SymbolFlags, SymbolKind, SymbolScope};
+use target_lexicon::{Architecture, BinaryFormat};
+
+#[test]
+fn coff_x86_64_bss() {
+    let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+
+    let section = object.section_id(write::StandardSection::UninitializedData);
+
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"v1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    object.add_symbol_bss(symbol, section, 18, 4);
+
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"v2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    object.add_symbol_bss(symbol, section, 34, 8);
+
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"bss.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Coff);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut sections = object.sections();
+
+    let bss = sections.next().unwrap();
+    println!("{:?}", bss);
+    let bss_index = bss.index();
+    assert_eq!(bss.name(), Some(".bss"));
+    assert_eq!(bss.kind(), SectionKind::UninitializedData);
+    assert_eq!(bss.size(), 58);
+    assert_eq!(&*bss.data(), &[]);
+
+    let section = sections.next();
+    assert!(
+        section.is_none(),
+        format!("unexpected section {:?}", section)
+    );
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 24);
+
+    let symbol = symbols.next();
+    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+}
+
+#[test]
+fn elf_x86_64_bss() {
+    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+
+    let section = object.section_id(write::StandardSection::UninitializedData);
+
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"v1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    object.add_symbol_bss(symbol, section, 18, 4);
+
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"v2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    object.add_symbol_bss(symbol, section, 34, 8);
+
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"bss.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Elf);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut sections = object.sections();
+
+    let section = sections.next().unwrap();
+    println!("{:?}", section);
+    assert_eq!(section.name(), Some(""));
+    assert_eq!(section.kind(), SectionKind::Metadata);
+    assert_eq!(section.address(), 0);
+    assert_eq!(section.size(), 0);
+
+    let bss = sections.next().unwrap();
+    println!("{:?}", bss);
+    let bss_index = bss.index();
+    assert_eq!(bss.name(), Some(".bss"));
+    assert_eq!(bss.kind(), SectionKind::UninitializedData);
+    assert_eq!(bss.size(), 58);
+    assert_eq!(&*bss.data(), &[]);
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some(""));
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 18);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 24);
+    assert_eq!(symbol.size(), 34);
+
+    let symbol = symbols.next();
+    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+}
+
+#[test]
+fn macho_x86_64_bss() {
+    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+
+    let section = object.section_id(write::StandardSection::UninitializedData);
+
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"v1".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    object.add_symbol_bss(symbol, section, 18, 4);
+
+    let symbol = object.add_symbol(write::Symbol {
+        name: b"v2".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    object.add_symbol_bss(symbol, section, 34, 8);
+
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"bss.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let mut sections = object.sections();
+
+    let bss = sections.next().unwrap();
+    println!("{:?}", bss);
+    let bss_index = bss.index();
+    assert_eq!(bss.name(), Some("__bss"));
+    assert_eq!(bss.segment_name(), Some("__DATA"));
+    assert_eq!(bss.kind(), SectionKind::UninitializedData);
+    assert_eq!(bss.size(), 58);
+    assert_eq!(&*bss.data(), &[]);
+
+    let section = sections.next();
+    assert!(
+        section.is_none(),
+        format!("unexpected section {:?}", section)
+    );
+
+    let mut symbols = object.symbols();
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_v1"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 0);
+
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("_v2"));
+    assert_eq!(symbol.kind(), SymbolKind::Data);
+    assert_eq!(symbol.section_index(), Some(bss_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+    assert_eq!(symbol.address(), 24);
+
+    let symbol = symbols.next();
+    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,7 +2,7 @@
 
 use object::read::{Object, ObjectSection};
 use object::{read, write};
-use object::{SectionKind, SymbolKind, SymbolScope};
+use object::{SectionKind, SymbolFlags, SymbolKind, SymbolScope};
 use target_lexicon::{Architecture, BinaryFormat};
 
 #[test]
@@ -17,6 +17,7 @@ fn coff_x86_64_common() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     };
     object.add_common_symbol(symbol, 4, 4);
 
@@ -28,6 +29,7 @@ fn coff_x86_64_common() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     };
     object.add_common_symbol(symbol, 8, 8);
 
@@ -79,6 +81,7 @@ fn elf_x86_64_common() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     };
     object.add_common_symbol(symbol, 4, 4);
 
@@ -90,6 +93,7 @@ fn elf_x86_64_common() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     };
     object.add_common_symbol(symbol, 8, 8);
 
@@ -145,6 +149,7 @@ fn macho_x86_64_common() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     };
     object.add_common_symbol(symbol, 4, 4);
 
@@ -156,6 +161,7 @@ fn macho_x86_64_common() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     };
     object.add_common_symbol(symbol, 8, 8);
 

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -2,7 +2,9 @@
 
 use object::read::{Object, ObjectSection};
 use object::{read, write};
-use object::{RelocationEncoding, RelocationKind, SectionKind, SymbolKind, SymbolScope};
+use object::{
+    RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+};
 use target_lexicon::{Architecture, BinaryFormat};
 
 #[test]
@@ -22,6 +24,7 @@ fn coff_x86_64() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Section(text),
+        flags: SymbolFlags::None,
     });
     object
         .add_relocation(
@@ -98,6 +101,7 @@ fn elf_x86_64() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Section(text),
+        flags: SymbolFlags::None,
     });
     object
         .add_relocation(
@@ -191,6 +195,7 @@ fn macho_x86_64() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Section(text),
+        flags: SymbolFlags::None,
     });
     object
         .add_relocation(

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -2,7 +2,9 @@
 
 use object::read::{Object, ObjectSection};
 use object::{read, write};
-use object::{RelocationEncoding, RelocationKind, SectionKind, SymbolKind, SymbolScope};
+use object::{
+    RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+};
 use target_lexicon::{Architecture, BinaryFormat};
 
 #[test]
@@ -18,6 +20,7 @@ fn macho_x86_64_tls() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     });
     object.add_symbol_data(symbol, section, &[1; 30], 4);
 
@@ -30,6 +33,7 @@ fn macho_x86_64_tls() {
         scope: SymbolScope::Linkage,
         weak: false,
         section: write::SymbolSection::Undefined,
+        flags: SymbolFlags::None,
     });
     object.add_symbol_bss(symbol, section, 31, 4);
 


### PR DESCRIPTION
Also a couple of COFF write fixes.

Fixes #159, fixes #160 

WIP: there's probably more non-COFF flags that still need to be copied, but probably worth testing if it really does fix #159, cc @jayvdb 