### PR TITLE
Use SymbolSection::None for file symbols

### DIFF
--- a/examples/nm.rs
+++ b/examples/nm.rs
@@ -58,7 +58,7 @@ fn print_symbol(symbol: &Symbol<'_>, section_kinds: &HashMap<SectionIndex, Secti
     }
 
     let mut kind = match symbol.section() {
-        SymbolSection::Unknown => '?',
+        SymbolSection::Unknown | SymbolSection::None => '?',
         SymbolSection::Undefined => 'U',
         SymbolSection::Absolute => 'A',
         SymbolSection::Common => 'C',

--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -70,6 +70,7 @@ fn main() {
         }
         let (section, value) = match in_symbol.section() {
             SymbolSection::Unknown => panic!("unknown symbol section for {:?}", in_symbol),
+            SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
             SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),
             SymbolSection::Absolute => (write::SymbolSection::Absolute, in_symbol.address()),
             SymbolSection::Common => (write::SymbolSection::Common, in_symbol.address()),

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -482,7 +482,13 @@ fn parse_symbol<'data>(
             }
         }
         pe::symbol::IMAGE_SYM_ABSOLUTE => SymbolSection::Absolute,
-        pe::symbol::IMAGE_SYM_DEBUG => SymbolSection::Undefined,
+        pe::symbol::IMAGE_SYM_DEBUG => {
+            if symbol.storage_class == pe::symbol::IMAGE_SYM_CLASS_FILE {
+                SymbolSection::None
+            } else {
+                SymbolSection::Unknown
+            }
+        }
         index if index > 0 => SymbolSection::Section(SectionIndex(index as usize - 1)),
         _ => SymbolSection::Unknown,
     };

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -747,7 +747,13 @@ fn parse_symbol<'data, Elf: FileHeader>(
     };
     let section = match symbol.st_shndx(endian) {
         elf::SHN_UNDEF => SymbolSection::Undefined,
-        elf::SHN_ABS => SymbolSection::Absolute,
+        elf::SHN_ABS => {
+            if kind == SymbolKind::File {
+                SymbolSection::None
+            } else {
+                SymbolSection::Absolute
+            }
+        }
         elf::SHN_COMMON => SymbolSection::Common,
         elf::SHN_XINDEX => match shndx {
             Some(index) => SymbolSection::Section(SectionIndex(index as usize)),

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -66,9 +66,9 @@ pub struct SymbolIndex(pub usize);
 pub enum SymbolSection {
     /// The section is unknown.
     Unknown,
+    /// The section is not applicable for this symbol (such as file symbols).
+    None,
     /// The symbol is undefined.
-    ///
-    /// May also include symbols for which a section is not applicable (such as file symbols).
     Undefined,
     /// The symbol has an absolute value.
     Absolute,

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -440,12 +440,11 @@ impl Object {
             } else {
                 elf::STV_DEFAULT
             };
-            let section = if symbol.kind == SymbolKind::File {
-                SymbolSection::Absolute
-            } else {
-                symbol.section
-            };
-            let (st_shndx, xindex) = match section {
+            let (st_shndx, xindex) = match symbol.section {
+                SymbolSection::None => {
+                    debug_assert_eq!(symbol.kind, SymbolKind::File);
+                    (elf::SHN_ABS, 0)
+                }
                 SymbolSection::Undefined => (elf::SHN_UNDEF, 0),
                 SymbolSection::Absolute => (elf::SHN_ABS, 0),
                 SymbolSection::Common => (elf::SHN_COMMON, 0),

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -430,10 +430,10 @@ impl Object {
             let (mut n_type, n_sect) = match symbol.section {
                 SymbolSection::Undefined => (macho::N_UNDF | macho::N_EXT, 0),
                 SymbolSection::Absolute => (macho::N_ABS, 0),
-                SymbolSection::Common => {
+                SymbolSection::Section(id) => (macho::N_SECT, id.0 + 1),
+                SymbolSection::None | SymbolSection::Common => {
                     return Err(format!("unimplemented symbol.section {:?}", symbol.section))
                 }
-                SymbolSection::Section(id) => (macho::N_SECT, id.0 + 1),
             };
             match symbol.scope {
                 SymbolScope::Unknown | SymbolScope::Compilation => {}

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -312,7 +312,7 @@ impl Object {
             kind: SymbolKind::File,
             scope: SymbolScope::Compilation,
             weak: false,
-            section: SymbolSection::Undefined,
+            section: SymbolSection::None,
             flags: SymbolFlags::None,
         })
     }
@@ -628,6 +628,8 @@ impl Section {
 /// The section where a symbol is defined.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SymbolSection {
+    /// The section is not applicable for this symbol (such as file symbols).
+    None,
     /// The symbol is undefined.
     Undefined,
     /// The symbol has an absolute value.

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -4,6 +4,7 @@ use object::read::{Object, ObjectSection};
 use object::{read, write};
 use object::{
     RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+    SymbolSection,
 };
 use target_lexicon::{Architecture, BinaryFormat};
 
@@ -15,6 +16,8 @@ mod tls;
 #[test]
 fn coff_x86_64() {
     let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+
+    object.add_file_symbol(b"file.c".to_vec());
 
     let text = object.section_id(write::StandardSection::Text);
     object.append_section_data(text, &[1; 30], 4);
@@ -64,6 +67,15 @@ fn coff_x86_64() {
 
     let mut symbols = object.symbols();
 
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("file.c"));
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.kind(), SymbolKind::File);
+    assert_eq!(symbol.section(), SymbolSection::None);
+    assert_eq!(symbol.scope(), SymbolScope::Compilation);
+    assert_eq!(symbol.is_weak(), false);
+
     let (func1_symbol, symbol) = symbols.next().unwrap();
     println!("{:?}", symbol);
     assert_eq!(symbol.name(), Some("func1"));
@@ -92,6 +104,8 @@ fn coff_x86_64() {
 #[test]
 fn elf_x86_64() {
     let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+
+    object.add_file_symbol(b"file.c".to_vec());
 
     let text = object.section_id(write::StandardSection::Text);
     object.append_section_data(text, &[1; 30], 4);
@@ -158,6 +172,15 @@ fn elf_x86_64() {
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), true);
 
+    let (_, symbol) = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Some("file.c"));
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.kind(), SymbolKind::File);
+    assert_eq!(symbol.section(), SymbolSection::None);
+    assert_eq!(symbol.scope(), SymbolScope::Compilation);
+    assert_eq!(symbol.is_weak(), false);
+
     let (func1_symbol, symbol) = symbols.next().unwrap();
     println!("{:?}", symbol);
     assert_eq!(symbol.name(), Some("func1"));
@@ -186,6 +209,8 @@ fn elf_x86_64() {
 #[test]
 fn macho_x86_64() {
     let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+
+    object.add_file_symbol(b"file.c".to_vec());
 
     let text = object.section_id(write::StandardSection::Text);
     object.append_section_data(text, &[1; 30], 4);


### PR DESCRIPTION
For ELF, file symbols were being emitted with `STB_GLOBAL` instead
of `STB_LOCAL`. This was because their section was set to `Undefined`,
which overrode the symbol scope.

Fix by using a new `SymbolSection::None` in `add_file_symbol`.

This also changes the section to `None` when reading, which makes our
round trips consistent.

Fixes #179 