### PR TITLE
read/wasm: avoid copying data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,6 @@ flate2 = { version = "1", optional = true }
 crc32fast = { version = "1.2", optional = true }
 indexmap = { version = "1.1", optional = true }
 
-[dependencies.parity-wasm]
-version = "0.41.0"
-optional = true
-
 [dev-dependencies]
 memmap = "0.7"
 
@@ -32,7 +28,7 @@ read = []
 write = ["crc32fast", "indexmap", "std"]
 std = []
 compression = ["flate2"]
-wasm = ["std", "parity-wasm"]
+wasm = []
 default = ["read", "std", "compression", "wasm"]
 
 [[example]]

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -54,8 +54,8 @@ fn main() {
             println!("{:?}", segment);
         }
 
-        for (index, section) in file.sections().enumerate() {
-            println!("{}: {:?}", index, section);
+        for section in file.sections() {
+            println!("{}: {:?}", section.index().0, section);
         }
 
         for (index, symbol) in file.symbols() {

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -116,7 +116,7 @@ enum FileInternal<'data> {
     Pe32(pe::PeFile32<'data>),
     Pe64(pe::PeFile64<'data>),
     #[cfg(feature = "wasm")]
-    Wasm(wasm::WasmFile),
+    Wasm(wasm::WasmFile<'data>),
 }
 
 impl<'data> File<'data> {
@@ -302,7 +302,7 @@ where
     Pe32(pe::PeSegmentIterator32<'data, 'file>),
     Pe64(pe::PeSegmentIterator64<'data, 'file>),
     #[cfg(feature = "wasm")]
-    Wasm(wasm::WasmSegmentIterator<'file>),
+    Wasm(wasm::WasmSegmentIterator<'data, 'file>),
 }
 
 impl<'data, 'file> Iterator for SegmentIterator<'data, 'file> {
@@ -335,7 +335,7 @@ where
     Pe32(pe::PeSegment32<'data, 'file>),
     Pe64(pe::PeSegment64<'data, 'file>),
     #[cfg(feature = "wasm")]
-    Wasm(wasm::WasmSegment<'file>),
+    Wasm(wasm::WasmSegment<'data, 'file>),
 }
 
 impl<'data, 'file> fmt::Debug for Segment<'data, 'file> {
@@ -402,7 +402,7 @@ where
     Pe32(pe::PeSectionIterator32<'data, 'file>),
     Pe64(pe::PeSectionIterator64<'data, 'file>),
     #[cfg(feature = "wasm")]
-    Wasm(wasm::WasmSectionIterator<'file>),
+    Wasm(wasm::WasmSectionIterator<'data, 'file>),
 }
 
 impl<'data, 'file> Iterator for SectionIterator<'data, 'file> {
@@ -434,7 +434,7 @@ where
     Pe32(pe::PeSection32<'data, 'file>),
     Pe64(pe::PeSection64<'data, 'file>),
     #[cfg(feature = "wasm")]
-    Wasm(wasm::WasmSection<'file>),
+    Wasm(wasm::WasmSection<'data, 'file>),
 }
 
 impl<'data, 'file> fmt::Debug for Section<'data, 'file> {
@@ -475,7 +475,7 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
         with_inner!(self.inner, SectionInternal, |x| x.file_range())
     }
 
-    fn data(&self) -> Cow<'data, [u8]> {
+    fn data(&self) -> &'data [u8] {
         with_inner!(self.inner, SectionInternal, |x| x.data())
     }
 
@@ -537,7 +537,7 @@ where
     Pe32(coff::CoffSymbolIterator<'data, 'file>),
     Pe64(coff::CoffSymbolIterator<'data, 'file>),
     #[cfg(feature = "wasm")]
-    Wasm(wasm::WasmSymbolIterator<'file>),
+    Wasm(wasm::WasmSymbolIterator<'data, 'file>),
 }
 
 impl<'data, 'file> Iterator for SymbolIterator<'data, 'file> {

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -340,8 +340,8 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
         }
     }
 
-    fn data(&self) -> Cow<'data, [u8]> {
-        Cow::from(self.raw_data())
+    fn data(&self) -> &'data [u8] {
+        self.raw_data()
     }
 
     fn data_range(&self, address: u64, size: u64) -> Option<&'data [u8]> {
@@ -350,7 +350,7 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
 
     #[inline]
     fn uncompressed_data(&self) -> Cow<'data, [u8]> {
-        self.data()
+        Cow::from(self.data())
     }
 
     #[inline]

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -593,8 +593,8 @@ impl<'data, 'file, Elf: FileHeader> ObjectSection<'data> for ElfSection<'data, '
     }
 
     #[inline]
-    fn data(&self) -> Cow<'data, [u8]> {
-        Cow::from(self.raw_data())
+    fn data(&self) -> &'data [u8] {
+        self.raw_data()
     }
 
     fn data_range(&self, address: u64, size: u64) -> Option<&'data [u8]> {
@@ -603,15 +603,17 @@ impl<'data, 'file, Elf: FileHeader> ObjectSection<'data> for ElfSection<'data, '
 
     #[cfg(feature = "compression")]
     fn uncompressed_data(&self) -> Cow<'data, [u8]> {
+        // TODO: return an error if decompression fails
         self.maybe_decompress_data()
             .or_else(|| self.maybe_decompress_data_gnu())
-            .unwrap_or_else(|| self.data())
+            .unwrap_or_else(|| Cow::from(self.data()))
     }
 
+    // TODO: remove this method completely if compression is not configured
     #[cfg(not(feature = "compression"))]
     #[inline]
     fn uncompressed_data(&self) -> Cow<'data, [u8]> {
-        self.data()
+        Cow::from(self.data())
     }
 
     fn name(&self) -> Option<&str> {

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -464,8 +464,8 @@ impl<'data, 'file, Mach: MachHeader> ObjectSection<'data> for MachOSection<'data
     }
 
     #[inline]
-    fn data(&self) -> Cow<'data, [u8]> {
-        Cow::from(self.raw_data())
+    fn data(&self) -> &'data [u8] {
+        self.raw_data()
     }
 
     fn data_range(&self, address: u64, size: u64) -> Option<&'data [u8]> {
@@ -474,7 +474,7 @@ impl<'data, 'file, Mach: MachHeader> ObjectSection<'data> for MachOSection<'data
 
     #[inline]
     fn uncompressed_data(&self) -> Cow<'data, [u8]> {
-        self.data()
+        Cow::from(self.data())
     }
 
     #[inline]

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -402,8 +402,8 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
         ))
     }
 
-    fn data(&self) -> Cow<'data, [u8]> {
-        Cow::from(self.raw_data())
+    fn data(&self) -> &'data [u8] {
+        self.raw_data()
     }
 
     fn data_range(&self, address: u64, size: u64) -> Option<&'data [u8]> {
@@ -412,8 +412,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
 
     #[inline]
     fn uncompressed_data(&self) -> Cow<'data, [u8]> {
-        // TODO: does PE support compression?
-        self.data()
+        Cow::from(self.data())
     }
 
     #[inline]

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -199,7 +199,7 @@ pub trait ObjectSection<'data> {
     /// section in memory.
     ///
     /// This does not do any decompression.
-    fn data(&self) -> Cow<'data, [u8]>;
+    fn data(&self) -> &'data [u8];
 
     /// Return the raw contents of the section data in the given range.
     ///


### PR DESCRIPTION
This means we don't need to force `ObjectSection::data` to return `Cow` for all file formats. This makes it clear that no allocation occurs, even if it previously didn't.

Also implements returning the "name" section as symbols.

I investigated using `wasmparser`, but its API didn't really seem better for this either. At least the parsing we need can be done with little code.