### PR TITLE
Derive Clone for Symbol

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -95,7 +95,7 @@ impl SymbolSection {
 }
 
 /// A symbol table entry.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Symbol<'data> {
     name: Option<&'data str>,
     address: u64,


### PR DESCRIPTION
I want to return a symbol without having to borrow the cached list of symbols for a object file.