### PR TITLE
Fix compression feature

### DIFF
--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -57,7 +57,7 @@ fn main() {
         if out_section.is_bss() {
             out_section.append_bss(in_section.size(), in_section.align());
         } else {
-            out_section.set_data(in_section.uncompressed_data().into(), in_section.align());
+            out_section.set_data(in_section.data().into(), in_section.align());
         }
         out_section.flags = in_section.flags();
         out_sections.insert(in_section.index(), section_id);

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides `CoffFile` and related types which implement the `Object` trait.
 
+#[cfg(feature = "compression")]
 use alloc::borrow::Cow;
 use alloc::fmt;
 use alloc::vec::Vec;
@@ -56,6 +57,8 @@ impl<'data> CoffFile<'data> {
         })
     }
 }
+
+impl<'data> read::private::Sealed for CoffFile<'data> {}
 
 impl<'data, 'file> Object<'data, 'file> for CoffFile<'data>
 where
@@ -202,6 +205,8 @@ impl<'data, 'file> CoffSegment<'data, 'file> {
     }
 }
 
+impl<'data, 'file> read::private::Sealed for CoffSegment<'data, 'file> {}
+
 impl<'data, 'file> ObjectSegment<'data> for CoffSegment<'data, 'file> {
     #[inline]
     fn address(&self) -> u64 {
@@ -279,6 +284,8 @@ impl<'data, 'file> CoffSection<'data, 'file> {
     }
 }
 
+impl<'data, 'file> read::private::Sealed for CoffSection<'data, 'file> {}
+
 impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
     type RelocationIterator = CoffRelocationIterator<'data, 'file>;
 
@@ -317,9 +324,10 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
         read::data_range(self.bytes(), self.address(), address, size)
     }
 
+    #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Cow<'data, [u8]> {
-        Cow::from(self.data())
+    fn uncompressed_data(&self) -> Option<Cow<'data, [u8]>> {
+        Some(Cow::from(self.data()))
     }
 
     #[inline]

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -32,6 +32,10 @@ pub use traits::*;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+mod private {
+    pub trait Sealed {}
+}
+
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "linux", target_pointer_width = "32", feature = "elf"))]
 pub type NativeFile<'data> = elf::ElfFile32<'data>;

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -5,6 +5,7 @@
 //!
 //! Also provides `PeFile` and related types which implement the `Object` trait.
 
+#[cfg(feature = "compression")]
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -114,6 +115,8 @@ impl<'data, Pe: ImageNtHeaders> PeFile<'data, Pe> {
         u64::from(self.nt_headers.optional_header().section_alignment())
     }
 }
+
+impl<'data, Pe: ImageNtHeaders> read::private::Sealed for PeFile<'data, Pe> {}
 
 impl<'data, 'file, Pe> Object<'data, 'file> for PeFile<'data, Pe>
 where
@@ -273,6 +276,8 @@ impl<'data, 'file, Pe: ImageNtHeaders> PeSegment<'data, 'file, Pe> {
     }
 }
 
+impl<'data, 'file, Pe: ImageNtHeaders> read::private::Sealed for PeSegment<'data, 'file, Pe> {}
+
 impl<'data, 'file, Pe: ImageNtHeaders> ObjectSegment<'data> for PeSegment<'data, 'file, Pe> {
     #[inline]
     fn address(&self) -> u64 {
@@ -360,6 +365,8 @@ impl<'data, 'file, Pe: ImageNtHeaders> PeSection<'data, 'file, Pe> {
     }
 }
 
+impl<'data, 'file, Pe: ImageNtHeaders> read::private::Sealed for PeSection<'data, 'file, Pe> {}
+
 impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data, 'file, Pe> {
     type RelocationIterator = PeRelocationIterator<'data, 'file>;
 
@@ -401,9 +408,10 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
         read::data_range(self.bytes(), self.address(), address, size)
     }
 
+    #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Cow<'data, [u8]> {
-        Cow::from(self.data())
+    fn uncompressed_data(&self) -> Option<Cow<'data, [u8]>> {
+        Some(Cow::from(self.data()))
     }
 
     #[inline]


### PR DESCRIPTION
The behaviour of methods should not depend on a cargo feature.
So we give `ObjectSection::uncompressed_data` fixed behaviour,
but make its presence depend on the feature.

This requires making the traits sealed, which we probably should
do anyway.

Also make it possible to handle decompression errors.
If the user wants to ignore errors then they should do that
themselves.
