### PR TITLE
read: change `Bytes` methods to return `Result`

### DIFF
--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -199,10 +199,10 @@ impl<'data> File<'data> {
             [b'M', b'Z', _, _, _] => {
                 // `optional_header_magic` doesn't care if it's `PeFile32` and `PeFile64`.
                 match pe::PeFile64::optional_header_magic(data) {
-                    Some(crate::pe::IMAGE_NT_OPTIONAL_HDR32_MAGIC) => {
+                    Ok(crate::pe::IMAGE_NT_OPTIONAL_HDR32_MAGIC) => {
                         FileInternal::Pe32(pe::PeFile32::parse(data)?)
                     }
-                    Some(crate::pe::IMAGE_NT_OPTIONAL_HDR64_MAGIC) => {
+                    Ok(crate::pe::IMAGE_NT_OPTIONAL_HDR64_MAGIC) => {
                         FileInternal::Pe64(pe::PeFile64::parse(data)?)
                     }
                     _ => return Err("Unknown MS-DOS file"),

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -314,8 +314,8 @@ impl Relocation {
     }
 }
 
-fn data_range(data: Bytes, data_address: u64, range_address: u64, size: u64) -> Option<&[u8]> {
-    let offset = range_address.checked_sub(data_address)?;
+fn data_range(data: Bytes, data_address: u64, range_address: u64, size: u64) -> Result<&[u8], ()> {
+    let offset = range_address.checked_sub(data_address).ok_or(())?;
     let data = data.read_bytes_at(offset as usize, size as usize)?;
-    Some(data.0)
+    Ok(data.0)
 }

--- a/src/read/util.rs
+++ b/src/read/util.rs
@@ -11,7 +11,7 @@ pub(crate) struct StringTable<'data> {
 }
 
 impl<'data> StringTable<'data> {
-    pub fn get(&self, offset: u32) -> Option<&'data [u8]> {
+    pub fn get(&self, offset: u32) -> Result<&'data [u8], ()> {
         self.data.read_string_at(offset as usize)
     }
 }


### PR DESCRIPTION
Also use `Result` more in internal APIs. No change to external API yet.