### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ all-features = true
 
 [dependencies]
 target-lexicon = { version = "0.10" }
-uuid = { version = "0.8", default-features = false }
 flate2 = { version = "1", optional = true }
 crc32fast = { version = "1.2", optional = true }
 indexmap = { version = "1.1", optional = true }

--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -49,8 +49,13 @@ fn main() {
             continue;
         }
         let section_id = out_object.add_section(
-            in_section.segment_name().unwrap_or("").as_bytes().to_vec(),
-            in_section.name().unwrap_or("").as_bytes().to_vec(),
+            in_section
+                .segment_name()
+                .unwrap()
+                .unwrap_or("")
+                .as_bytes()
+                .to_vec(),
+            in_section.name().unwrap().as_bytes().to_vec(),
             in_section.kind(),
         );
         let out_section = out_object.section_mut(section_id);

--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -57,7 +57,7 @@ fn main() {
         if out_section.is_bss() {
             out_section.append_bss(in_section.size(), in_section.align());
         } else {
-            out_section.set_data(in_section.data().into(), in_section.align());
+            out_section.set_data(in_section.data().unwrap().into(), in_section.align());
         }
         out_section.flags = in_section.flags();
         out_sections.insert(in_section.index(), section_id);

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -46,12 +46,14 @@ fn main() {
             Ok(None) => {}
             Err(e) => println!("Failed to parse build ID: {}", e),
         }
-        if let Some((filename, crc)) = file.gnu_debuglink() {
-            println!(
+        match file.gnu_debuglink() {
+            Ok(Some((filename, crc))) => println!(
                 "GNU debug link: {} CRC: {:08x}",
                 String::from_utf8_lossy(filename),
-                crc
-            );
+                crc,
+            ),
+            Ok(None) => {}
+            Err(e) => println!("Failed to parse GNU debug link: {}", e),
         }
 
         for segment in file.segments() {

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -41,8 +41,10 @@ fn main() {
             Ok(None) => {}
             Err(e) => println!("Failed to parse Mach UUID: {}", e),
         }
-        if let Some(build_id) = file.build_id() {
-            println!("Build ID: {:x?}", build_id);
+        match file.build_id() {
+            Ok(Some(build_id)) => println!("Build ID: {:x?}", build_id),
+            Ok(None) => {}
+            Err(e) => println!("Failed to parse build ID: {}", e),
         }
         if let Some((filename, crc)) = file.gnu_debuglink() {
             println!(

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -36,8 +36,10 @@ fn main() {
             }
         };
 
-        if let Some(uuid) = file.mach_uuid() {
-            println!("Mach UUID: {}", uuid);
+        match file.mach_uuid() {
+            Ok(Some(uuid)) => println!("Mach UUID: {:x?}", uuid),
+            Ok(None) => {}
+            Err(e) => println!("Failed to parse Mach UUID: {}", e),
         }
         if let Some(build_id) = file.build_id() {
             println!("Build ID: {:x?}", build_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ extern crate std;
 
 // Re-export since these are used in public signatures.
 pub use target_lexicon;
-pub use uuid;
 
 mod common;
 pub use common::*;

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -2,7 +2,6 @@
 use alloc::borrow::Cow;
 use alloc::fmt;
 use target_lexicon::{Architecture, BinaryFormat};
-use uuid::Uuid;
 
 #[cfg(feature = "coff")]
 use crate::read::coff;
@@ -313,7 +312,7 @@ where
     }
 
     #[inline]
-    fn mach_uuid(&self) -> Option<Uuid> {
+    fn mach_uuid(&self) -> Result<Option<[u8; 16]>> {
         with_inner!(self.inner, FileInternal, |x| x.mach_uuid())
     }
 

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -317,7 +317,7 @@ where
     }
 
     #[inline]
-    fn build_id(&self) -> Option<&'data [u8]> {
+    fn build_id(&self) -> Result<Option<&'data [u8]>> {
         with_inner!(self.inner, FileInternal, |x| x.build_id())
     }
 

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -322,7 +322,7 @@ where
     }
 
     #[inline]
-    fn gnu_debuglink(&self) -> Option<(&'data [u8], u32)> {
+    fn gnu_debuglink(&self) -> Result<Option<(&'data [u8], u32)>> {
         with_inner!(self.inner, FileInternal, |x| x.gnu_debuglink())
     }
 

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -286,7 +286,7 @@ where
         }
     }
 
-    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>> {
+    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Symbol<'data>> {
         with_inner!(self.inner, FileInternal, |x| x.symbol_by_index(index))
     }
 

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -273,7 +273,7 @@ where
         .map(|inner| Section { inner })
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Option<Section<'data, 'file>> {
+    fn section_by_index(&'file self, index: SectionIndex) -> Result<Section<'data, 'file>> {
         map_inner_option!(self.inner, FileInternal, SectionInternal, |x| x
             .section_by_index(index))
         .map(|inner| Section { inner })

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -413,7 +413,7 @@ impl<'data, 'file> fmt::Debug for Segment<'data, 'file> {
         f.debug_struct("Segment")
             .field("name", &self.name().unwrap_or("<unnamed>"))
             .field("address", &self.address())
-            .field("size", &self.data().len())
+            .field("size", &self.size())
             .finish()
     }
 }
@@ -437,11 +437,11 @@ impl<'data, 'file> ObjectSegment<'data> for Segment<'data, 'file> {
         with_inner!(self.inner, SegmentInternal, |x| x.file_range())
     }
 
-    fn data(&self) -> &'data [u8] {
+    fn data(&self) -> Result<&'data [u8]> {
         with_inner!(self.inner, SegmentInternal, |x| x.data())
     }
 
-    fn data_range(&self, address: u64, size: u64) -> Option<&'data [u8]> {
+    fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>> {
         with_inner!(self.inner, SegmentInternal, |x| x.data_range(address, size))
     }
 
@@ -562,16 +562,16 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
         with_inner!(self.inner, SectionInternal, |x| x.file_range())
     }
 
-    fn data(&self) -> &'data [u8] {
+    fn data(&self) -> Result<&'data [u8]> {
         with_inner!(self.inner, SectionInternal, |x| x.data())
     }
 
-    fn data_range(&self, address: u64, size: u64) -> Option<&'data [u8]> {
+    fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>> {
         with_inner!(self.inner, SectionInternal, |x| x.data_range(address, size))
     }
 
     #[cfg(feature = "compression")]
-    fn uncompressed_data(&self) -> Option<Cow<'data, [u8]>> {
+    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
         with_inner!(self.inner, SectionInternal, |x| x.uncompressed_data())
     }
 

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -120,12 +120,12 @@ where
         }
     }
 
-    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>> {
-        Some(parse_symbol(
-            &self.symbols,
-            index.0,
-            self.symbols.get(index.0)?,
-        ))
+    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Symbol<'data>> {
+        let symbol = self
+            .symbols
+            .get(index.0)
+            .read_error("Invalid COFF symbol index")?;
+        Ok(parse_symbol(&self.symbols, index.0, symbol))
     }
 
     fn symbols(&'file self) -> CoffSymbolIterator<'data, 'file> {

--- a/src/read/coff.rs
+++ b/src/read/coff.rs
@@ -101,8 +101,16 @@ where
             .find(|section| section.name() == Some(section_name))
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Option<CoffSection<'data, 'file>> {
-        self.sections().find(|section| section.index() == index)
+    fn section_by_index(&'file self, index: SectionIndex) -> Result<CoffSection<'data, 'file>> {
+        let section = self
+            .sections
+            .get(index.0)
+            .read_error("Invalid COFF section index")?;
+        Ok(CoffSection {
+            file: self,
+            index,
+            section,
+        })
     }
 
     fn sections(&'file self) -> CoffSectionIterator<'data, 'file> {

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -281,11 +281,20 @@ where
         }
     }
 
-    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>> {
+    fn symbol_by_index(&self, index: SymbolIndex) -> read::Result<Symbol<'data>> {
+        let symbol = self
+            .symbols
+            .symbols
+            .get(index.0)
+            .read_error("Invalid ELF symbol index")?;
         let shndx = self.symbols.shndx.get(index.0).cloned();
-        self.symbols.symbols.get(index.0).map(|symbol| {
-            parse_symbol::<Elf>(self.endian, index.0, symbol, self.symbols.strings, shndx)
-        })
+        Ok(parse_symbol::<Elf>(
+            self.endian,
+            index.0,
+            symbol,
+            self.symbols.strings,
+            shndx,
+        ))
     }
 
     fn symbols(&'file self) -> ElfSymbolIterator<'data, 'file, Elf> {

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -259,8 +259,15 @@ where
             .or_else(|| self.zdebug_section_by_name(section_name))
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Option<ElfSection<'data, 'file, Elf>> {
-        self.sections.get(index.0).map(|section| ElfSection {
+    fn section_by_index(
+        &'file self,
+        index: SectionIndex,
+    ) -> read::Result<ElfSection<'data, 'file, Elf>> {
+        let section = self
+            .sections
+            .get(index.0)
+            .read_error("Invalid ELF section index")?;
+        Ok(ElfSection {
             file: self,
             index,
             section,

--- a/src/read/elf.rs
+++ b/src/read/elf.rs
@@ -21,9 +21,9 @@ use crate::endian::{self, Endian, RunTimeEndian, U32};
 use crate::pod::{Bytes, Pod};
 use crate::read::util::{self, StringTable};
 use crate::read::{
-    self, FileFlags, Object, ObjectSection, ObjectSegment, Relocation, RelocationEncoding,
-    RelocationKind, RelocationTarget, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags,
-    SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
+    self, Error, FileFlags, Object, ObjectSection, ObjectSegment, ReadError, Relocation,
+    RelocationEncoding, RelocationKind, RelocationTarget, SectionFlags, SectionIndex, SectionKind,
+    Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
 };
 
 /// A 32-bit ELF object file.
@@ -49,35 +49,29 @@ pub struct ElfFile<'data, Elf: FileHeader> {
 
 impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
     /// Parse the raw ELF file data.
-    pub fn parse(data: &'data [u8]) -> Result<Self, &'static str> {
+    pub fn parse(data: &'data [u8]) -> read::Result<Self> {
         let data = Bytes(data);
         let header = data
             .read_at::<Elf>(0)
-            .map_err(|()| "Invalid ELF header size or alignment")?;
+            .read_error("Invalid ELF header size or alignment")?;
         if !header.is_supported() {
-            return Err("Unsupported ELF header");
+            return Err(Error("Unsupported ELF header"));
         }
 
         // TODO: Check self.e_ehsize?
 
-        let endian = header.endian().ok_or("Unsupported endian")?;
-        let segments = header
-            .program_headers(endian, data)
-            .map_err(|()| "Invalid program headers")?;
-        let sections = header
-            .section_headers(endian, data)
-            .map_err(|()| "Invalid section headers")?;
+        let endian = header.endian()?;
+        let segments = header.program_headers(endian, data)?;
+        let sections = header.section_headers(endian, data)?;
 
         let section_string_data = if !sections.is_empty() {
-            let index = header
-                .shstrndx(endian, data)
-                .map_err(|()| "Missing section header strtab index")?;
+            let index = header.shstrndx(endian, data)?;
             let shstrtab_section = sections
                 .get(index as usize)
-                .ok_or("Invalid section header strtab index")?;
+                .read_error("Invalid ELF section header strtab index")?;
             shstrtab_section
                 .data(endian, data)
-                .map_err(|()| "Invalid section header strtab data")?
+                .read_error("Invalid ELF section header strtab data")?
         } else {
             Bytes(&[])
         };
@@ -98,13 +92,13 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
                     if dynamic_symbols.is_empty() {
                         dynamic_symbols = section
                             .data_as_array(endian, data)
-                            .map_err(|()| "Invalid symtab data")?;
+                            .read_error("Invalid ELF dynsym data")?;
                         let strtab_section = sections
                             .get(section.sh_link(endian) as usize)
-                            .ok_or("Invalid strtab section index")?;
+                            .read_error("Invalid ELF dynstr section index")?;
                         dynamic_symbol_string_data = strtab_section
                             .data(endian, data)
-                            .map_err(|()| "Invalid strtab")?;
+                            .read_error("Invalid ELF dynstr data")?;
                     }
                 }
                 elf::SHT_SYMTAB => {
@@ -112,20 +106,20 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
                         symbol_section = Some(index);
                         symbols = section
                             .data_as_array(endian, data)
-                            .map_err(|()| "Invalid symtab data")?;
+                            .read_error("Invalid ELF symtab data")?;
                         let strtab_section = sections
                             .get(section.sh_link(endian) as usize)
-                            .ok_or("Invalid strtab section index")?;
+                            .read_error("Invalid ELF strtab section index")?;
                         symbol_string_data = strtab_section
                             .data(endian, data)
-                            .map_err(|()| "Invalid strtab")?;
+                            .read_error("Invalid ELF strtab data")?;
                     }
                 }
                 elf::SHT_SYMTAB_SHNDX => {
                     if symbol_shndx.is_empty() {
                         symbol_shndx = section
                             .data_as_array(endian, data)
-                            .map_err(|()| "Invalid symtab_shndx data")?;
+                            .read_error("Invalid ELF symtab_shndx data")?;
                     }
                 }
                 _ => {}
@@ -530,16 +524,21 @@ impl<'data, 'file, Elf: FileHeader> ElfSection<'data, 'file, Elf> {
     }
 
     #[cfg(feature = "compression")]
-    fn maybe_decompress_data(&self) -> Result<Option<Cow<'data, [u8]>>, ()> {
+    fn maybe_decompress_data(&self) -> read::Result<Option<Cow<'data, [u8]>>> {
         let endian = self.file.endian;
         if (self.section.sh_flags(endian).into() & u64::from(elf::SHF_COMPRESSED)) == 0 {
             return Ok(None);
         }
 
-        let mut data = self.section.data(endian, self.file.data)?;
-        let header = data.read::<Elf::CompressionHeader>()?;
+        let mut data = self
+            .section
+            .data(endian, self.file.data)
+            .read_error("Invalid ELF compressed section offset or size")?;
+        let header = data
+            .read::<Elf::CompressionHeader>()
+            .read_error("Invalid ELF compression header size or alignment")?;
         if header.ch_type(endian) != elf::ELFCOMPRESS_ZLIB {
-            return Err(());
+            return Err(Error("Unsupported ELF compression type"));
         }
 
         let uncompressed_size: u64 = header.ch_size(endian).into();
@@ -549,14 +548,14 @@ impl<'data, 'file, Elf: FileHeader> ElfSection<'data, 'file, Elf> {
             .decompress_vec(data.0, &mut decompressed, FlushDecompress::Finish)
             .is_err()
         {
-            return Err(());
+            return Err(Error("Invalid ELF compressed data"));
         }
         Ok(Some(Cow::Owned(decompressed)))
     }
 
     /// Try GNU-style "ZLIB" header decompression.
     #[cfg(feature = "compression")]
-    fn maybe_decompress_data_gnu(&self) -> Result<Option<Cow<'data, [u8]>>, ()> {
+    fn maybe_decompress_data_gnu(&self) -> read::Result<Option<Cow<'data, [u8]>>> {
         let name = match self.name() {
             Some(name) => name,
             None => return Ok(None),
@@ -568,17 +567,25 @@ impl<'data, 'file, Elf: FileHeader> ElfSection<'data, 'file, Elf> {
         // Assume ZLIB-style uncompressed data is no more than 4GB to avoid accidentally
         // huge allocations. This also reduces the chance of accidentally matching on a
         // .debug_str that happens to start with "ZLIB".
-        if data.read_bytes(8)?.0 != b"ZLIB\0\0\0\0" {
-            return Err(());
+        if data
+            .read_bytes(8)
+            .read_error("ELF GNU compressed section is too short")?
+            .0
+            != b"ZLIB\0\0\0\0"
+        {
+            return Err(Error("Invalid ELF GNU compressed section header"));
         }
-        let uncompressed_size = data.read::<U32<_>>()?.get(endian::BigEndian);
+        let uncompressed_size = data
+            .read::<U32<_>>()
+            .read_error("ELF GNU compressed section is too short")?
+            .get(endian::BigEndian);
         let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
         let mut decompress = Decompress::new(true);
         if decompress
             .decompress_vec(data.0, &mut decompressed, FlushDecompress::Finish)
             .is_err()
         {
-            return Err(());
+            return Err(Error("Invalid ELF GNU compressed data"));
         }
         Ok(Some(Cow::Owned(decompressed)))
     }
@@ -972,11 +979,11 @@ where
     Elf: FileHeader,
 {
     /// Returns `Err` if `align` is invalid.
-    fn new(endian: Elf::Endian, align: Elf::Word, data: Bytes<'data>) -> Result<Self, ()> {
+    fn new(endian: Elf::Endian, align: Elf::Word, data: Bytes<'data>) -> read::Result<Self> {
         let align = match align.into() {
             0u64..=4 => 4,
             8 => 8,
-            _ => return Err(()),
+            _ => return Err(Error("Invalid ELF note alignment")),
         };
         // TODO: check data alignment?
         Ok(ElfNoteIterator {
@@ -986,22 +993,31 @@ where
         })
     }
 
-    fn next(&mut self) -> Result<Option<ElfNote<'data, Elf>>, ()> {
+    fn next(&mut self) -> read::Result<Option<ElfNote<'data, Elf>>> {
         let mut data = self.data;
         if data.is_empty() {
             return Ok(None);
         }
 
-        let header = data.read::<Elf::NoteHeader>()?;
+        let header = data
+            .read::<Elf::NoteHeader>()
+            .read_error("ELF note is too short")?;
 
         let namesz = header.n_namesz(self.endian) as usize;
-        let name = data.read_bytes_at(0, namesz)?.0;
+        let name = data
+            .read_bytes_at(0, namesz)
+            .read_error("Invalid ELF note namesz")?
+            .0;
 
         // Skip both the name and the alignment padding.
-        data.skip(util::align(namesz, self.align))?;
+        data.skip(util::align(namesz, self.align))
+            .read_error("ELF note is too short")?;
 
         let descsz = header.n_descsz(self.endian) as usize;
-        let desc = data.read_bytes_at(0, descsz)?.0;
+        let desc = data
+            .read_bytes_at(0, descsz)
+            .read_error("Invalid ELF note descsz")?
+            .0;
 
         // Skip both the descriptor and the alignment padding (if any).
         if data.skip(util::align(descsz, self.align)).is_err() {
@@ -1134,8 +1150,8 @@ pub trait FileHeader: Debug + Pod {
         self.e_ident().data == elf::ELFDATA2MSB
     }
 
-    fn endian(&self) -> Option<Self::Endian> {
-        Self::Endian::from_big_endian(self.is_big_endian())
+    fn endian(&self) -> read::Result<Self::Endian> {
+        Self::Endian::from_big_endian(self.is_big_endian()).read_error("Unsupported ELF endian")
     }
 
     /// Return the first section header, if present.
@@ -1146,7 +1162,7 @@ pub trait FileHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: Bytes<'data>,
-    ) -> Result<Option<&'data Self::SectionHeader>, ()> {
+    ) -> read::Result<Option<&'data Self::SectionHeader>> {
         let shoff: u64 = self.e_shoff(endian).into();
         if shoff == 0 {
             // No section headers is ok.
@@ -1155,15 +1171,17 @@ pub trait FileHeader: Debug + Pod {
         let shentsize = self.e_shentsize(endian) as usize;
         if shentsize != mem::size_of::<Self::SectionHeader>() {
             // Section header size must match.
-            return Err(());
+            return Err(Error("Invalid ELF section header entry size"));
         }
-        data.read_at(shoff as usize).map(Some)
+        data.read_at(shoff as usize)
+            .map(Some)
+            .read_error("Invalid ELF section header offset or size")
     }
 
     /// Return the `e_phnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn phnum<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> Result<usize, ()> {
+    fn phnum<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> read::Result<usize> {
         let e_phnum = self.e_phnum(endian);
         if e_phnum < elf::PN_XNUM {
             Ok(e_phnum as usize)
@@ -1171,14 +1189,14 @@ pub trait FileHeader: Debug + Pod {
             Ok(section_0.sh_info(endian) as usize)
         } else {
             // Section 0 must exist if e_phnum overflows.
-            Err(())
+            Err(Error("Missing ELF section headers for e_phnum overflow"))
         }
     }
 
     /// Return the `e_shnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn shnum<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> Result<usize, ()> {
+    fn shnum<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> read::Result<usize> {
         let e_shnum = self.e_shnum(endian);
         if e_shnum > 0 {
             Ok(e_shnum as usize)
@@ -1194,7 +1212,7 @@ pub trait FileHeader: Debug + Pod {
     /// Return the `e_shstrndx` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values (including if the index is 0).
-    fn shstrndx<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> Result<u32, ()> {
+    fn shstrndx<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> read::Result<u32> {
         let e_shstrndx = self.e_shstrndx(endian);
         let index = if e_shstrndx != elf::SHN_XINDEX {
             e_shstrndx.into()
@@ -1202,13 +1220,12 @@ pub trait FileHeader: Debug + Pod {
             section_0.sh_link(endian)
         } else {
             // Section 0 must exist if we're trying to read e_shstrndx.
-            return Err(());
+            return Err(Error("Missing ELF section headers for e_shstrndx overflow"));
         };
-        if index != 0 {
-            Ok(index)
-        } else {
-            Err(())
+        if index == 0 {
+            return Err(Error("Missing ELF e_shstrndx"));
         }
+        Ok(index)
     }
 
     /// Return the slice of program headers.
@@ -1219,7 +1236,7 @@ pub trait FileHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: Bytes<'data>,
-    ) -> Result<&'data [Self::ProgramHeader], ()> {
+    ) -> read::Result<&'data [Self::ProgramHeader]> {
         let phoff: u64 = self.e_phoff(endian).into();
         if phoff == 0 {
             // No program headers is ok.
@@ -1233,9 +1250,10 @@ pub trait FileHeader: Debug + Pod {
         let phentsize = self.e_phentsize(endian) as usize;
         if phentsize != mem::size_of::<Self::ProgramHeader>() {
             // Program header size must match.
-            return Err(());
+            return Err(Error("Invalid ELF program header entry size"));
         }
         data.read_slice_at(phoff as usize, phnum)
+            .read_error("Invalid ELF program header size or alignment")
     }
 
     /// Return the slice of section headers.
@@ -1246,7 +1264,7 @@ pub trait FileHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: Bytes<'data>,
-    ) -> Result<&'data [Self::SectionHeader], ()> {
+    ) -> read::Result<&'data [Self::SectionHeader]> {
         let shoff: u64 = self.e_shoff(endian).into();
         if shoff == 0 {
             // No section headers is ok.
@@ -1260,9 +1278,10 @@ pub trait FileHeader: Debug + Pod {
         let shentsize = self.e_shentsize(endian) as usize;
         if shentsize != mem::size_of::<Self::SectionHeader>() {
             // Section header size must match.
-            return Err(());
+            return Err(Error("Invalid ELF section header entry size"));
         }
         data.read_slice_at(shoff as usize, shnum)
+            .read_error("Invalid ELF section header offset/size/alignment")
     }
 }
 
@@ -1303,9 +1322,10 @@ pub trait ProgramHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: Bytes<'data>,
-    ) -> Result<ElfNoteIterator<'data, Self::Elf>, ()> {
+    ) -> read::Result<ElfNoteIterator<'data, Self::Elf>> {
         let data = if self.p_type(endian) == elf::PT_NOTE {
-            self.data(endian, data)?
+            self.data(endian, data)
+                .read_error("Invalid ELF note segment offset or size")?
         } else {
             Bytes(&[])
         };
@@ -1376,9 +1396,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: Bytes<'data>,
-    ) -> Result<ElfNoteIterator<'data, Self::Elf>, ()> {
+    ) -> read::Result<ElfNoteIterator<'data, Self::Elf>> {
         let data = if self.sh_type(endian) == elf::SHT_NOTE {
-            self.data(endian, data)?
+            self.data(endian, data)
+                .read_error("Invalid ELF note section offset or size")?
         } else {
             Bytes(&[])
         };

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -1026,7 +1026,7 @@ pub trait Segment: Debug + Pod {
 
     /// Get the array of sections from the data following the segment command.
     ///
-    /// Returns `None` for invalid values.
+    /// Returns `Err` for invalid values.
     fn sections<'data>(
         &self,
         endian: Self::Endian,
@@ -1099,7 +1099,7 @@ pub trait Section: Debug + Pod {
 
     /// Return the relocation array.
     ///
-    /// Returns `None` for invalid values.
+    /// Returns `Err` for invalid values.
     fn relocations<'data>(
         &self,
         endian: Self::Endian,

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -191,9 +191,14 @@ where
         }
     }
 
-    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>> {
-        let nlist = self.symbols.symbols.get(index.0)?;
+    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Symbol<'data>> {
+        let nlist = self
+            .symbols
+            .symbols
+            .get(index.0)
+            .read_error("Invalid Mach-O symbol index")?;
         parse_symbol(self, nlist, self.symbols.strings)
+            .read_error("Unsupported Mach-O symbol index")
     }
 
     fn symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach> {

--- a/src/read/macho.rs
+++ b/src/read/macho.rs
@@ -388,8 +388,12 @@ impl<'data, 'file, Mach: MachHeader> ObjectSegment<'data> for MachOSegment<'data
     }
 
     #[inline]
-    fn name(&self) -> Option<&str> {
-        str::from_utf8(self.segment.name()).ok()
+    fn name(&self) -> Result<Option<&str>> {
+        Ok(Some(
+            str::from_utf8(self.segment.name())
+                .ok()
+                .read_error("Non UTF-8 Mach-O segment name")?,
+        ))
     }
 }
 
@@ -506,13 +510,19 @@ impl<'data, 'file, Mach: MachHeader> ObjectSection<'data> for MachOSection<'data
     }
 
     #[inline]
-    fn name(&self) -> Option<&str> {
-        str::from_utf8(self.internal.section.name()).ok()
+    fn name(&self) -> Result<&str> {
+        str::from_utf8(self.internal.section.name())
+            .ok()
+            .read_error("Non UTF-8 Mach-O section name")
     }
 
     #[inline]
-    fn segment_name(&self) -> Option<&str> {
-        str::from_utf8(self.internal.section.segment_name()).ok()
+    fn segment_name(&self) -> Result<Option<&str>> {
+        Ok(Some(
+            str::from_utf8(self.internal.section.segment_name())
+                .ok()
+                .read_error("Non UTF-8 Mach-O segment name")?,
+        ))
     }
 
     fn kind(&self) -> SectionKind {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -37,7 +37,7 @@ mod private {
 }
 
 /// The error type used within the read module.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Error(&'static str);
 
 impl fmt::Display for Error {
@@ -347,13 +347,8 @@ impl Relocation {
     }
 }
 
-fn data_range(
-    data: Bytes,
-    data_address: u64,
-    range_address: u64,
-    size: u64,
-) -> result::Result<&[u8], ()> {
-    let offset = range_address.checked_sub(data_address).ok_or(())?;
-    let data = data.read_bytes_at(offset as usize, size as usize)?;
-    Ok(data.0)
+fn data_range(data: Bytes, data_address: u64, range_address: u64, size: u64) -> Option<&[u8]> {
+    let offset = range_address.checked_sub(data_address)?;
+    let data = data.read_bytes_at(offset as usize, size as usize).ok()?;
+    Some(data.0)
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1,7 +1,7 @@
 //! Interface for reading object files.
 
 use alloc::vec::Vec;
-use core::cmp;
+use core::{cmp, fmt, result};
 
 use crate::common::{
     FileFlags, RelocationEncoding, RelocationKind, SectionFlags, SectionKind, SymbolFlags,
@@ -34,6 +34,39 @@ pub mod wasm;
 
 mod private {
     pub trait Sealed {}
+}
+
+/// The error type used within the read module.
+#[derive(Debug, Clone, Copy)]
+pub struct Error(&'static str);
+
+impl fmt::Display for Error {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+/// The result type used within the read module.
+pub type Result<T> = result::Result<T, Error>;
+
+trait ReadError<T> {
+    fn read_error(self, error: &'static str) -> Result<T>;
+}
+
+impl<T> ReadError<T> for result::Result<T, ()> {
+    fn read_error(self, error: &'static str) -> Result<T> {
+        self.map_err(|()| Error(error))
+    }
+}
+
+impl<T> ReadError<T> for Option<T> {
+    fn read_error(self, error: &'static str) -> Result<T> {
+        self.ok_or(Error(error))
+    }
 }
 
 /// The native executable file for the target platform.
@@ -314,7 +347,12 @@ impl Relocation {
     }
 }
 
-fn data_range(data: Bytes, data_address: u64, range_address: u64, size: u64) -> Result<&[u8], ()> {
+fn data_range(
+    data: Bytes,
+    data_address: u64,
+    range_address: u64,
+    size: u64,
+) -> result::Result<&[u8], ()> {
     let offset = range_address.checked_sub(data_address).ok_or(())?;
     let data = data.read_bytes_at(offset as usize, size as usize)?;
     Ok(data.0)

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -184,12 +184,12 @@ where
         }
     }
 
-    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>> {
-        Some(parse_symbol(
-            &self.symbols,
-            index.0,
-            self.symbols.get(index.0)?,
-        ))
+    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Symbol<'data>> {
+        let symbol = self
+            .symbols
+            .get(index.0)
+            .read_error("Invalid PE symbol index")?;
+        Ok(parse_symbol(&self.symbols, index.0, symbol))
     }
 
     fn symbols(&'file self) -> CoffSymbolIterator<'data, 'file> {

--- a/src/read/pe.rs
+++ b/src/read/pe.rs
@@ -165,8 +165,16 @@ where
             .find(|section| section.name() == Some(section_name))
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Option<PeSection<'data, 'file, Pe>> {
-        self.sections().find(|section| section.index() == index)
+    fn section_by_index(&'file self, index: SectionIndex) -> Result<PeSection<'data, 'file, Pe>> {
+        let section = self
+            .sections
+            .get(index.0)
+            .read_error("Invalid PE section index")?;
+        Ok(PeSection {
+            file: self,
+            index,
+            section,
+        })
     }
 
     fn sections(&'file self) -> PeSectionIterator<'data, 'file, Pe> {

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -175,7 +175,7 @@ pub trait ObjectSegment<'data>: read::private::Sealed {
     fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>>;
 
     /// Returns the name of the segment.
-    fn name(&self) -> Option<&str>;
+    fn name(&self) -> Result<Option<&str>>;
 }
 
 /// A section defined in an object file.
@@ -227,10 +227,10 @@ pub trait ObjectSection<'data>: read::private::Sealed {
     fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>>;
 
     /// Returns the name of the section.
-    fn name(&self) -> Option<&str>;
+    fn name(&self) -> Result<&str>;
 
     /// Returns the name of the segment for this section.
-    fn segment_name(&self) -> Option<&str>;
+    fn segment_name(&self) -> Result<Option<&str>>;
 
     /// Return the kind of this section.
     fn kind(&self) -> SectionKind;

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -128,8 +128,8 @@ pub trait Object<'data, 'file>: read::private::Sealed {
 
     /// The build ID from an ELF `NT_GNU_BUILD_ID` note.
     #[inline]
-    fn build_id(&self) -> Option<&'data [u8]> {
-        None
+    fn build_id(&self) -> Result<Option<&'data [u8]>> {
+        Ok(None)
     }
 
     /// The filename and CRC from a `.gnu_debuglink` section.

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "compression")]
 use alloc::borrow::Cow;
 use target_lexicon::{Architecture, Endianness};
-use uuid::Uuid;
 
 use crate::read::{self, Result};
 use crate::{
@@ -123,8 +122,8 @@ pub trait Object<'data, 'file>: read::private::Sealed {
 
     /// The UUID from a Mach-O `LC_UUID` load command.
     #[inline]
-    fn mach_uuid(&self) -> Option<Uuid> {
-        None
+    fn mach_uuid(&self) -> Result<Option<[u8; 16]>> {
+        Ok(None)
     }
 
     /// The build ID from an ELF `NT_GNU_BUILD_ID` note.

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -80,9 +80,10 @@ pub trait Object<'data, 'file>: read::private::Sealed {
 
     /// Get the debugging symbol at the given index.
     ///
-    /// This is similar to `self.symbols().nth(index)`, except that
-    /// the index will take into account malformed or unsupported symbols.
-    fn symbol_by_index(&self, index: SymbolIndex) -> Option<Symbol<'data>>;
+    /// The meaning of the index depends on the object file.
+    ///
+    /// Returns an error if the index is invalid.
+    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Symbol<'data>>;
 
     /// Get an iterator over the debugging symbols in the file.
     ///

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -134,8 +134,8 @@ pub trait Object<'data, 'file>: read::private::Sealed {
 
     /// The filename and CRC from a `.gnu_debuglink` section.
     #[inline]
-    fn gnu_debuglink(&self) -> Option<(&'data [u8], u32)> {
-        None
+    fn gnu_debuglink(&self) -> Result<Option<(&'data [u8], u32)>> {
+        Ok(None)
     }
 
     /// File flags that are specific to each file format.

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -13,9 +13,9 @@ use target_lexicon::Architecture;
 use wasmparser as wp;
 
 use crate::read::{
-    self, FileFlags, Object, ObjectSection, ObjectSegment, Relocation, SectionFlags, SectionIndex,
-    SectionKind, Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolScope,
-    SymbolSection,
+    self, Error, FileFlags, Object, ObjectSection, ObjectSegment, Relocation, Result, SectionFlags,
+    SectionIndex, SectionKind, Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap,
+    SymbolScope, SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;
@@ -49,13 +49,13 @@ pub struct WasmFile<'data> {
 
 impl<'data> WasmFile<'data> {
     /// Parse the raw wasm data.
-    pub fn parse(data: &'data [u8]) -> Result<Self, &'static str> {
-        let module = wp::ModuleReader::new(data).map_err(|_| "Invalid WASM header")?;
+    pub fn parse(data: &'data [u8]) -> Result<Self> {
+        let module = wp::ModuleReader::new(data).map_err(|_| Error("Invalid WASM header"))?;
 
         let mut file = WasmFile::default();
 
         for section in module {
-            let section = section.map_err(|_| "Invalid section header")?;
+            let section = section.map_err(|_| Error("Invalid WASM section header"))?;
 
             match section.code {
                 wp::SectionCode::Custom { kind, name } => {

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -13,7 +13,7 @@ use target_lexicon::Architecture;
 use wasmparser as wp;
 
 use crate::read::{
-    self, FileFlags, Object, ObjectSection, ObjectSegment, ReadError, Relocation, Result,
+    self, Error, FileFlags, Object, ObjectSection, ObjectSegment, ReadError, Relocation, Result,
     SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags, SymbolIndex, SymbolKind,
     SymbolMap, SymbolScope, SymbolSection,
 };
@@ -140,9 +140,9 @@ where
     }
 
     #[inline]
-    fn symbol_by_index(&self, _index: SymbolIndex) -> Option<Symbol<'data>> {
+    fn symbol_by_index(&self, _index: SymbolIndex) -> Result<Symbol<'data>> {
         // Wasm doesn't need or support looking up symbols by index.
-        None
+        Err(Error("Unsupported Wasm symbol index"))
     }
 
     fn symbols(&'file self) -> Self::SymbolIterator {

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -119,7 +119,7 @@ where
 
     fn section_by_name(&'file self, section_name: &str) -> Option<WasmSection<'data, 'file>> {
         self.sections()
-            .find(|section| section.name() == Some(section_name))
+            .find(|section| section.name() == Ok(section_name))
     }
 
     fn section_by_index(&'file self, index: SectionIndex) -> Result<WasmSection<'data, 'file>> {
@@ -241,7 +241,7 @@ impl<'data, 'file> ObjectSegment<'data> for WasmSegment<'data, 'file> {
     }
 
     #[inline]
-    fn name(&self) -> Option<&str> {
+    fn name(&self) -> Result<Option<&str>> {
         unreachable!()
     }
 }
@@ -320,8 +320,8 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
     }
 
     #[inline]
-    fn name(&self) -> Option<&str> {
-        Some(match self.section.code {
+    fn name(&self) -> Result<&str> {
+        Ok(match self.section.code {
             wp::SectionCode::Custom { name, .. } => name,
             wp::SectionCode::Type => "<type>",
             wp::SectionCode::Import => "<import>",
@@ -339,8 +339,8 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
     }
 
     #[inline]
-    fn segment_name(&self) -> Option<&str> {
-        None
+    fn segment_name(&self) -> Result<Option<&str>> {
+        Ok(None)
     }
 
     #[inline]

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -232,11 +232,11 @@ impl<'data, 'file> ObjectSegment<'data> for WasmSegment<'data, 'file> {
         unreachable!()
     }
 
-    fn data(&self) -> &'data [u8] {
+    fn data(&self) -> Result<&'data [u8]> {
         unreachable!()
     }
 
-    fn data_range(&self, _address: u64, _size: u64) -> Option<&'data [u8]> {
+    fn data_range(&self, _address: u64, _size: u64) -> Result<Option<&'data [u8]>> {
         unreachable!()
     }
 
@@ -302,21 +302,21 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
     }
 
     #[inline]
-    fn data(&self) -> &'data [u8] {
+    fn data(&self) -> Result<&'data [u8]> {
         let mut reader = self.section.get_binary_reader();
         // TODO: raise a feature request upstream to be able
         // to get remaining slice from a BinaryReader directly.
-        reader.read_bytes(reader.bytes_remaining()).unwrap()
+        Ok(reader.read_bytes(reader.bytes_remaining()).unwrap())
     }
 
-    fn data_range(&self, _address: u64, _size: u64) -> Option<&'data [u8]> {
+    fn data_range(&self, _address: u64, _size: u64) -> Result<Option<&'data [u8]>> {
         unimplemented!()
     }
 
     #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Option<Cow<'data, [u8]>> {
-        Some(Cow::from(self.data()))
+    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
+        Ok(Cow::from(self.data()?))
     }
 
     #[inline]

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -143,7 +143,7 @@ impl Object {
         self.add_relocation(
             section,
             Relocation {
-                offset: offset,
+                offset,
                 size: pointer_width * 8,
                 kind: RelocationKind::Absolute,
                 encoding: RelocationEncoding::Generic,

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -1,5 +1,4 @@
 use std::mem;
-use std::string::String;
 use std::vec::Vec;
 
 use crate::endian::*;
@@ -186,7 +185,7 @@ impl Object {
         constant
     }
 
-    pub(crate) fn macho_write(&self) -> Result<Vec<u8>, String> {
+    pub(crate) fn macho_write(&self) -> Result<Vec<u8>> {
         let (is_32, pointer_align) = match self.architecture.pointer_width().unwrap() {
             PointerWidth::U16 | PointerWidth::U32 => (true, 4),
             PointerWidth::U64 => (false, 8),
@@ -268,18 +267,18 @@ impl Object {
                 SymbolKind::File | SymbolKind::Section => continue,
                 SymbolKind::Unknown => {
                     if symbol.section != SymbolSection::Undefined {
-                        return Err(format!(
+                        return Err(Error(format!(
                             "defined symbol `{}` with unknown kind",
                             symbol.name().unwrap_or(""),
-                        ));
+                        )));
                     }
                 }
                 SymbolKind::Null | SymbolKind::Label => {
-                    return Err(format!(
+                    return Err(Error(format!(
                         "unimplemented symbol `{}` kind {:?}",
                         symbol.name().unwrap_or(""),
                         symbol.kind
-                    ));
+                    )));
                 }
             }
             symbol_offsets[index].emit = true;
@@ -325,10 +324,10 @@ impl Object {
             Architecture::I386 => (macho::CPU_TYPE_X86, macho::CPU_SUBTYPE_I386_ALL),
             Architecture::X86_64 => (macho::CPU_TYPE_X86_64, macho::CPU_SUBTYPE_X86_64_ALL),
             _ => {
-                return Err(format!(
+                return Err(Error(format!(
                     "unimplemented architecture {:?}",
                     self.architecture
-                ))
+                )));
             }
         };
 
@@ -390,11 +389,11 @@ impl Object {
                     SectionKind::OtherString => macho::S_CSTRING_LITERALS,
                     SectionKind::Other | SectionKind::Linker | SectionKind::Metadata => 0,
                     SectionKind::Unknown => {
-                        return Err(format!(
+                        return Err(Error(format!(
                             "unimplemented section `{}` kind {:?}",
                             section.name().unwrap_or(""),
                             section.kind
-                        ));
+                        )));
                     }
                 }
             };
@@ -450,11 +449,11 @@ impl Object {
                 SymbolSection::Absolute => (macho::N_ABS, 0),
                 SymbolSection::Section(id) => (macho::N_SECT, id.0 + 1),
                 SymbolSection::None | SymbolSection::Common => {
-                    return Err(format!(
+                    return Err(Error(format!(
                         "unimplemented symbol `{}` section {:?}",
                         symbol.name().unwrap_or(""),
                         symbol.section
-                    ))
+                    )));
                 }
             };
             match symbol.scope {
@@ -528,12 +527,14 @@ impl Object {
                         16 => 1,
                         32 => 2,
                         64 => 3,
-                        _ => return Err(format!("unimplemented reloc size {:?}", reloc)),
+                        _ => return Err(Error(format!("unimplemented reloc size {:?}", reloc))),
                     };
                     let (r_pcrel, r_type) = match self.architecture {
                         Architecture::I386 => match reloc.kind {
                             RelocationKind::Absolute => (false, macho::GENERIC_RELOC_VANILLA),
-                            _ => return Err(format!("unimplemented relocation {:?}", reloc)),
+                            _ => {
+                                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                            }
                         },
                         Architecture::X86_64 => match (reloc.kind, reloc.encoding, reloc.addend) {
                             (RelocationKind::Absolute, RelocationEncoding::Generic, 0) => {
@@ -560,13 +561,15 @@ impl Object {
                                 -4,
                             ) => (true, macho::X86_64_RELOC_GOT_LOAD),
                             (RelocationKind::MachO { value, relative }, _, _) => (relative, value),
-                            _ => return Err(format!("unimplemented relocation {:?}", reloc)),
+                            _ => {
+                                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                            }
                         },
                         _ => {
-                            return Err(format!(
+                            return Err(Error(format!(
                                 "unimplemented architecture {:?}",
                                 self.architecture
-                            ))
+                            )));
                         }
                     };
                     let reloc_info = macho::RelocationInfo {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -1,8 +1,10 @@
 //! Interface for writing object files.
 
-#![allow(clippy::collapsible_if)]
 #![allow(clippy::cognitive_complexity)]
-#![allow(clippy::module_inception)]
+#![allow(clippy::collapsible_if)]
+#![allow(clippy::comparison_chain)]
+#![allow(clippy::single_match)]
+#![allow(clippy::useless_let_if_seq)]
 
 use std::collections::HashMap;
 use std::string::String;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -5,9 +5,9 @@
 #![allow(clippy::module_inception)]
 
 use std::collections::HashMap;
-use std::str;
 use std::string::String;
 use std::vec::Vec;
+use std::{error, fmt, result, str};
 
 use crate::endian::{RunTimeEndian, U32, U64};
 use crate::pod::BytesMut;
@@ -25,6 +25,22 @@ mod elf;
 mod macho;
 mod string;
 mod util;
+
+/// The error type used within the write module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error(String);
+
+impl fmt::Display for Error {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl error::Error for Error {}
+
+/// The result type used within the write module.
+pub type Result<T> = result::Result<T, Error>;
 
 /// A writable object file.
 #[derive(Debug)]
@@ -79,7 +95,7 @@ impl Object {
         self.mangling
     }
 
-    /// Return the current mangling setting.
+    /// Specify the mangling setting.
     #[inline]
     pub fn set_mangling(&mut self, mangling: Mangling) {
         self.mangling = mangling;
@@ -420,30 +436,23 @@ impl Object {
 
     /// Convert a symbol to a section symbol and offset.
     ///
-    /// Returns an error if the symbol is not defined.
-    pub fn symbol_section_and_offset(
-        &mut self,
-        symbol_id: SymbolId,
-    ) -> Result<(SymbolId, u64), ()> {
+    /// Returns `None` if the symbol does not have a section.
+    pub fn symbol_section_and_offset(&mut self, symbol_id: SymbolId) -> Option<(SymbolId, u64)> {
         let symbol = self.symbol(symbol_id);
         if symbol.kind == SymbolKind::Section {
-            return Ok((symbol_id, 0));
+            return Some((symbol_id, 0));
         }
         let symbol_offset = symbol.value;
-        let section = symbol.section.id().ok_or(())?;
+        let section = symbol.section.id()?;
         let section_symbol = self.section_symbol(section);
-        Ok((section_symbol, symbol_offset))
+        Some((section_symbol, symbol_offset))
     }
 
     /// Add a relocation to a section.
     ///
     /// Relocations must only be added after the referenced symbols have been added
     /// and defined (if applicable).
-    pub fn add_relocation(
-        &mut self,
-        section: SectionId,
-        mut relocation: Relocation,
-    ) -> Result<(), String> {
+    pub fn add_relocation(&mut self, section: SectionId, mut relocation: Relocation) -> Result<()> {
         let addend = match self.format {
             #[cfg(feature = "coff")]
             BinaryFormat::Coff => self.coff_fixup_relocation(&mut relocation),
@@ -465,7 +474,7 @@ impl Object {
         section: SectionId,
         relocation: &Relocation,
         addend: i64,
-    ) -> Result<(), String> {
+    ) -> Result<()> {
         let endian = match self.architecture.endianness().unwrap() {
             Endianness::Little => RunTimeEndian::Little,
             Endianness::Big => RunTimeEndian::Big,
@@ -476,20 +485,25 @@ impl Object {
         match relocation.size {
             32 => data.write_at(offset, &U32::new(endian, addend as u32)),
             64 => data.write_at(offset, &U64::new(endian, addend as u64)),
-            _ => return Err(format!("unimplemented relocation addend {:?}", relocation)),
+            _ => {
+                return Err(Error(format!(
+                    "unimplemented relocation addend {:?}",
+                    relocation
+                )));
+            }
         }
         .map_err(|_| {
-            format!(
+            Error(format!(
                 "invalid relocation offset {}+{} (max {})",
                 relocation.offset,
                 relocation.size,
                 data.len()
-            )
+            ))
         })
     }
 
     /// Write the object to a `Vec`.
-    pub fn write(&self) -> Result<Vec<u8>, String> {
+    pub fn write(&self) -> Result<Vec<u8>> {
         match self.format {
             #[cfg(feature = "coff")]
             BinaryFormat::Coff => self.coff_write(),

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -48,7 +48,7 @@ fn coff_x86_64_bss() {
     let bss = sections.next().unwrap();
     println!("{:?}", bss);
     let bss_index = bss.index();
-    assert_eq!(bss.name(), Some(".bss"));
+    assert_eq!(bss.name(), Ok(".bss"));
     assert_eq!(bss.kind(), SectionKind::UninitializedData);
     assert_eq!(bss.size(), 58);
     assert_eq!(bss.data(), Ok(&[][..]));
@@ -127,7 +127,7 @@ fn elf_x86_64_bss() {
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
-    assert_eq!(section.name(), Some(""));
+    assert_eq!(section.name(), Ok(""));
     assert_eq!(section.kind(), SectionKind::Metadata);
     assert_eq!(section.address(), 0);
     assert_eq!(section.size(), 0);
@@ -135,7 +135,7 @@ fn elf_x86_64_bss() {
     let bss = sections.next().unwrap();
     println!("{:?}", bss);
     let bss_index = bss.index();
-    assert_eq!(bss.name(), Some(".bss"));
+    assert_eq!(bss.name(), Ok(".bss"));
     assert_eq!(bss.kind(), SectionKind::UninitializedData);
     assert_eq!(bss.size(), 58);
     assert_eq!(bss.data(), Ok(&[][..]));
@@ -215,8 +215,8 @@ fn macho_x86_64_bss() {
     let bss = sections.next().unwrap();
     println!("{:?}", bss);
     let bss_index = bss.index();
-    assert_eq!(bss.name(), Some("__bss"));
-    assert_eq!(bss.segment_name(), Some("__DATA"));
+    assert_eq!(bss.name(), Ok("__bss"));
+    assert_eq!(bss.segment_name(), Ok(Some("__DATA")));
     assert_eq!(bss.kind(), SectionKind::UninitializedData);
     assert_eq!(bss.size(), 58);
     assert_eq!(bss.data(), Ok(&[][..]));

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -51,7 +51,7 @@ fn coff_x86_64_bss() {
     assert_eq!(bss.name(), Some(".bss"));
     assert_eq!(bss.kind(), SectionKind::UninitializedData);
     assert_eq!(bss.size(), 58);
-    assert_eq!(&*bss.data(), &[]);
+    assert_eq!(bss.data(), Ok(&[][..]));
 
     let section = sections.next();
     assert!(
@@ -138,7 +138,7 @@ fn elf_x86_64_bss() {
     assert_eq!(bss.name(), Some(".bss"));
     assert_eq!(bss.kind(), SectionKind::UninitializedData);
     assert_eq!(bss.size(), 58);
-    assert_eq!(&*bss.data(), &[]);
+    assert_eq!(bss.data(), Ok(&[][..]));
 
     let mut symbols = object.symbols();
 
@@ -219,7 +219,7 @@ fn macho_x86_64_bss() {
     assert_eq!(bss.segment_name(), Some("__DATA"));
     assert_eq!(bss.kind(), SectionKind::UninitializedData);
     assert_eq!(bss.size(), 58);
-    assert_eq!(&*bss.data(), &[]);
+    assert_eq!(bss.data(), Ok(&[][..]));
 
     let section = sections.next();
     assert!(

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -182,7 +182,7 @@ fn macho_x86_64_common() {
     assert_eq!(common.segment_name(), Some("__DATA"));
     assert_eq!(common.kind(), SectionKind::Common);
     assert_eq!(common.size(), 16);
-    assert_eq!(&*common.data(), &[]);
+    assert_eq!(common.data(), Ok(&[][..]));
 
     let section = sections.next();
     assert!(

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -178,8 +178,8 @@ fn macho_x86_64_common() {
     let common = sections.next().unwrap();
     println!("{:?}", common);
     let common_index = common.index();
-    assert_eq!(common.name(), Some("__common"));
-    assert_eq!(common.segment_name(), Some("__DATA"));
+    assert_eq!(common.name(), Ok("__common"));
+    assert_eq!(common.segment_name(), Ok(Some("__DATA")));
     assert_eq!(common.kind(), SectionKind::Common);
     assert_eq!(common.size(), 16);
     assert_eq!(common.data(), Ok(&[][..]));

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -62,8 +62,8 @@ fn coff_x86_64() {
     assert_eq!(text.kind(), SectionKind::Text);
     assert_eq!(text.address(), 0);
     assert_eq!(text.size(), 62);
-    assert_eq!(&text.data()[..30], &[1; 30]);
-    assert_eq!(&text.data()[32..62], &[1; 30]);
+    assert_eq!(&text.data().unwrap()[..30], &[1; 30]);
+    assert_eq!(&text.data().unwrap()[32..62], &[1; 30]);
 
     let mut symbols = object.symbols();
 
@@ -157,8 +157,8 @@ fn elf_x86_64() {
     assert_eq!(text.kind(), SectionKind::Text);
     assert_eq!(text.address(), 0);
     assert_eq!(text.size(), 62);
-    assert_eq!(&text.data()[..30], &[1; 30]);
-    assert_eq!(&text.data()[32..62], &[1; 30]);
+    assert_eq!(&text.data().unwrap()[..30], &[1; 30]);
+    assert_eq!(&text.data().unwrap()[32..62], &[1; 30]);
 
     let mut symbols = object.symbols();
 
@@ -269,8 +269,8 @@ fn macho_x86_64() {
     assert_eq!(text.kind(), SectionKind::Text);
     assert_eq!(text.address(), 0);
     assert_eq!(text.size(), 62);
-    assert_eq!(&text.data()[..30], &[1; 30]);
-    assert_eq!(&text.data()[32..62], &[1; 30]);
+    assert_eq!(&text.data().unwrap()[..30], &[1; 30]);
+    assert_eq!(&text.data().unwrap()[32..62], &[1; 30]);
 
     let mut symbols = object.symbols();
 

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -58,7 +58,7 @@ fn coff_x86_64() {
     let text = sections.next().unwrap();
     println!("{:?}", text);
     let text_index = text.index();
-    assert_eq!(text.name(), Some(".text"));
+    assert_eq!(text.name(), Ok(".text"));
     assert_eq!(text.kind(), SectionKind::Text);
     assert_eq!(text.address(), 0);
     assert_eq!(text.size(), 62);
@@ -145,7 +145,7 @@ fn elf_x86_64() {
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
-    assert_eq!(section.name(), Some(""));
+    assert_eq!(section.name(), Ok(""));
     assert_eq!(section.kind(), SectionKind::Metadata);
     assert_eq!(section.address(), 0);
     assert_eq!(section.size(), 0);
@@ -153,7 +153,7 @@ fn elf_x86_64() {
     let text = sections.next().unwrap();
     println!("{:?}", text);
     let text_index = text.index();
-    assert_eq!(text.name(), Some(".text"));
+    assert_eq!(text.name(), Ok(".text"));
     assert_eq!(text.kind(), SectionKind::Text);
     assert_eq!(text.address(), 0);
     assert_eq!(text.size(), 62);
@@ -264,8 +264,8 @@ fn macho_x86_64() {
     let text = sections.next().unwrap();
     println!("{:?}", text);
     let text_index = text.index();
-    assert_eq!(text.name(), Some("__text"));
-    assert_eq!(text.segment_name(), Some("__TEXT"));
+    assert_eq!(text.name(), Ok("__text"));
+    assert_eq!(text.segment_name(), Ok(Some("__TEXT")));
     assert_eq!(text.kind(), SectionKind::Text);
     assert_eq!(text.address(), 0);
     assert_eq!(text.size(), 62);

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -40,7 +40,7 @@ fn coff_x86_64_tls() {
     assert_eq!(section.name(), Some(".tls$"));
     assert_eq!(section.kind(), SectionKind::Data);
     assert_eq!(section.size(), 30);
-    assert_eq!(&section.data()[..], &[1; 30]);
+    assert_eq!(&section.data().unwrap()[..], &[1; 30]);
 
     let mut symbols = object.symbols();
 
@@ -104,7 +104,7 @@ fn elf_x86_64_tls() {
     assert_eq!(section.name(), Some(".tdata"));
     assert_eq!(section.kind(), SectionKind::Tls);
     assert_eq!(section.size(), 30);
-    assert_eq!(&section.data()[..], &[1; 30]);
+    assert_eq!(&section.data().unwrap()[..], &[1; 30]);
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
@@ -112,7 +112,7 @@ fn elf_x86_64_tls() {
     assert_eq!(section.name(), Some(".tbss"));
     assert_eq!(section.kind(), SectionKind::UninitializedTls);
     assert_eq!(section.size(), 31);
-    assert_eq!(&section.data()[..], &[]);
+    assert_eq!(&section.data().unwrap()[..], &[]);
 
     let mut symbols = object.symbols();
 
@@ -188,7 +188,7 @@ fn macho_x86_64_tls() {
     assert_eq!(thread_data.segment_name(), Some("__DATA"));
     assert_eq!(thread_data.kind(), SectionKind::Tls);
     assert_eq!(thread_data.size(), 30);
-    assert_eq!(&thread_data.data()[..], &[1; 30]);
+    assert_eq!(&thread_data.data().unwrap()[..], &[1; 30]);
 
     let thread_vars = sections.next().unwrap();
     println!("{:?}", thread_vars);
@@ -197,7 +197,7 @@ fn macho_x86_64_tls() {
     assert_eq!(thread_vars.segment_name(), Some("__DATA"));
     assert_eq!(thread_vars.kind(), SectionKind::TlsVariables);
     assert_eq!(thread_vars.size(), 2 * 3 * 8);
-    assert_eq!(&thread_vars.data()[..], &[0; 48][..]);
+    assert_eq!(&thread_vars.data().unwrap()[..], &[0; 48][..]);
 
     let thread_bss = sections.next().unwrap();
     println!("{:?}", thread_bss);
@@ -206,7 +206,7 @@ fn macho_x86_64_tls() {
     assert_eq!(thread_bss.segment_name(), Some("__DATA"));
     assert_eq!(thread_bss.kind(), SectionKind::UninitializedTls);
     assert_eq!(thread_bss.size(), 31);
-    assert_eq!(&thread_bss.data()[..], &[]);
+    assert_eq!(thread_bss.data(), Ok(&[][..]));
 
     let mut symbols = object.symbols();
 

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -37,7 +37,7 @@ fn coff_x86_64_tls() {
     let section = sections.next().unwrap();
     println!("{:?}", section);
     let tls_index = section.index();
-    assert_eq!(section.name(), Some(".tls$"));
+    assert_eq!(section.name(), Ok(".tls$"));
     assert_eq!(section.kind(), SectionKind::Data);
     assert_eq!(section.size(), 30);
     assert_eq!(&section.data().unwrap()[..], &[1; 30]);
@@ -96,12 +96,12 @@ fn elf_x86_64_tls() {
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
-    assert_eq!(section.name(), Some(""));
+    assert_eq!(section.name(), Ok(""));
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
     let tdata_index = section.index();
-    assert_eq!(section.name(), Some(".tdata"));
+    assert_eq!(section.name(), Ok(".tdata"));
     assert_eq!(section.kind(), SectionKind::Tls);
     assert_eq!(section.size(), 30);
     assert_eq!(&section.data().unwrap()[..], &[1; 30]);
@@ -109,7 +109,7 @@ fn elf_x86_64_tls() {
     let section = sections.next().unwrap();
     println!("{:?}", section);
     let tbss_index = section.index();
-    assert_eq!(section.name(), Some(".tbss"));
+    assert_eq!(section.name(), Ok(".tbss"));
     assert_eq!(section.kind(), SectionKind::UninitializedTls);
     assert_eq!(section.size(), 31);
     assert_eq!(&section.data().unwrap()[..], &[]);
@@ -184,8 +184,8 @@ fn macho_x86_64_tls() {
     let thread_data = sections.next().unwrap();
     println!("{:?}", thread_data);
     let thread_data_index = thread_data.index();
-    assert_eq!(thread_data.name(), Some("__thread_data"));
-    assert_eq!(thread_data.segment_name(), Some("__DATA"));
+    assert_eq!(thread_data.name(), Ok("__thread_data"));
+    assert_eq!(thread_data.segment_name(), Ok(Some("__DATA")));
     assert_eq!(thread_data.kind(), SectionKind::Tls);
     assert_eq!(thread_data.size(), 30);
     assert_eq!(&thread_data.data().unwrap()[..], &[1; 30]);
@@ -193,8 +193,8 @@ fn macho_x86_64_tls() {
     let thread_vars = sections.next().unwrap();
     println!("{:?}", thread_vars);
     let thread_vars_index = thread_vars.index();
-    assert_eq!(thread_vars.name(), Some("__thread_vars"));
-    assert_eq!(thread_vars.segment_name(), Some("__DATA"));
+    assert_eq!(thread_vars.name(), Ok("__thread_vars"));
+    assert_eq!(thread_vars.segment_name(), Ok(Some("__DATA")));
     assert_eq!(thread_vars.kind(), SectionKind::TlsVariables);
     assert_eq!(thread_vars.size(), 2 * 3 * 8);
     assert_eq!(&thread_vars.data().unwrap()[..], &[0; 48][..]);
@@ -202,8 +202,8 @@ fn macho_x86_64_tls() {
     let thread_bss = sections.next().unwrap();
     println!("{:?}", thread_bss);
     let thread_bss_index = thread_bss.index();
-    assert_eq!(thread_bss.name(), Some("__thread_bss"));
-    assert_eq!(thread_bss.segment_name(), Some("__DATA"));
+    assert_eq!(thread_bss.name(), Ok("__thread_bss"));
+    assert_eq!(thread_bss.segment_name(), Ok(Some("__DATA")));
     assert_eq!(thread_bss.kind(), SectionKind::UninitializedTls);
     assert_eq!(thread_bss.size(), 31);
     assert_eq!(thread_bss.data(), Ok(&[][..]));


### PR DESCRIPTION
Add new-types for errors, and return errors from trait methods where appropriate.

Still need better error handling for `read::Symbol` methods, but that can be done when it is converted to a trait too.

Fixes #194 

@fitzgen review as much as you feel like :)