### PR TITLE
Enhance Wasm symbol reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crc32fast = { version = "1.2", optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
 target-lexicon = { version = "0.10" }
-wasmparser = { version = "0.51.0", optional = true }
+wasmparser = { version = "0.52", optional = true }
 
 [dev-dependencies]
 memmap = "0.7"


### PR DESCRIPTION
Add support for:
 - Symbols for imports (with Dynamic scope).
 - "Virtual" file symbols to delimit imports from main file.
 - Symbols for local functions (with Compilation scope and real address and size).
 - Symbols for exports.
 - Text (functions) and Data (everything else) symbol kinds.
 - Start section converted to an entry address.
 - Symbols for local functions.
 - Predefined section kinds based on the section code.

Note that if a function is exported, then it will appear under its exported names with a Dynamic scope. Otherwise it's a local function and will appear with its debug name from the "names" section and a Compilation scope.

Also note that this adds support for fully built Wasm modules, but not for dynamic linking yet. That one will require adding more code for parsing relocation info and can be done in future in a separate PR.

Fixes #196.