### PR TITLE
write/elf: fix elf_has_relocation_addend for Aarch64

### DIFF
--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -65,7 +65,7 @@ impl Object {
     fn elf_has_relocation_addend(&self) -> Result<bool> {
         Ok(match self.architecture {
             Architecture::Arm(_) => false,
-            Architecture::Aarch64(_) => false,
+            Architecture::Aarch64(_) => true,
             Architecture::I386 => false,
             Architecture::X86_64 => true,
             _ => {


### PR DESCRIPTION
This is the fix for the problems I had at https://bytecodealliance.zulipchat.com/#narrow/stream/225524-cranelift-new-backend/topic/cg_clif-integration/near/194042579