### PR TITLE
read: start exposing lower level parsing API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,11 @@ pub use common::*;
 
 #[macro_use]
 pub mod endian;
+pub use endian::*;
 
 #[macro_use]
-mod pod;
-// This isn't really intended for users yet, but other traits required it.
-#[doc(hidden)]
-pub use pod::Pod;
+pub mod pod;
+pub use pod::*;
 
 #[cfg(feature = "read_core")]
 pub mod read;

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -74,16 +74,23 @@ impl<'data> fmt::Debug for Bytes<'data> {
 }
 
 impl<'data> Bytes<'data> {
+    /// Return the length of the byte slice.
     #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Return true if the byte slice is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Skip over the given number of bytes at the start of the byte slice.
+    ///
+    /// Modifies the byte slice to start after the bytes.
+    ///
+    /// Returns an error if there are too few bytes.
     #[inline]
     pub fn skip(&mut self, offset: usize) -> Result<()> {
         match self.0.get(offset..) {
@@ -98,6 +105,11 @@ impl<'data> Bytes<'data> {
         }
     }
 
+    /// Return a reference to the given number of bytes at the start of the byte slice.
+    ///
+    /// Modifies the byte slice to start after the bytes.
+    ///
+    /// Returns an error if there are too few bytes.
     #[inline]
     pub fn read_bytes(&mut self, count: usize) -> Result<Bytes<'data>> {
         match (self.0.get(..count), self.0.get(count..)) {
@@ -112,12 +124,20 @@ impl<'data> Bytes<'data> {
         }
     }
 
+    /// Return a reference to the given number of bytes at the given offset of the byte slice.
+    ///
+    /// Returns an error if the offset is invalid or there are too few bytes.
     #[inline]
     pub fn read_bytes_at(mut self, offset: usize, count: usize) -> Result<Bytes<'data>> {
         self.skip(offset)?;
         self.read_bytes(count)
     }
 
+    /// Return a reference to a `Pod` struct at the start of the byte slice.
+    ///
+    /// Modifies the byte slice to start after the bytes.
+    ///
+    /// Returns an error if there are too few bytes or the slice is incorrectly aligned.
     #[inline]
     pub fn read<T: Pod>(&mut self) -> Result<&'data T> {
         match from_bytes(self.0) {
@@ -132,12 +152,20 @@ impl<'data> Bytes<'data> {
         }
     }
 
+    /// Return a reference to a `Pod` struct at the given offset of the byte slice.
+    ///
+    /// Returns an error if there are too few bytes or the offset is incorrectly aligned.
     #[inline]
     pub fn read_at<T: Pod>(mut self, offset: usize) -> Result<&'data T> {
         self.skip(offset)?;
         self.read()
     }
 
+    /// Return a reference to a slice of `Pod` structs at the start of the byte slice.
+    ///
+    /// Modifies the byte slice to start after the bytes.
+    ///
+    /// Returns an error if there are too few bytes or the offset is incorrectly aligned.
     #[inline]
     pub fn read_slice<T: Pod>(&mut self, count: usize) -> Result<&'data [T]> {
         match slice_from_bytes(self.0, count) {
@@ -152,6 +180,9 @@ impl<'data> Bytes<'data> {
         }
     }
 
+    /// Return a reference to a slice of `Pod` structs at the given offset of the byte slice.
+    ///
+    /// Returns an error if there are too few bytes or the offset is incorrectly aligned.
     #[inline]
     pub fn read_slice_at<T: Pod>(mut self, offset: usize, count: usize) -> Result<&'data [T]> {
         self.skip(offset)?;

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -127,7 +127,7 @@ where
         CoffSymbolIterator {
             symbols: &self.symbols,
             // Hack: don't return any.
-            index: self.symbols.symbols.len(),
+            index: self.symbols.len(),
         }
     }
 

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -155,7 +155,7 @@ impl<'data, 'file> ObjectSegment<'data> for CoffSegment<'data, 'file> {
 
     #[inline]
     fn name(&self) -> Result<Option<&str>> {
-        let name = self.section.name(self.file.symbols.strings)?;
+        let name = self.section.name(self.file.symbols.strings())?;
         Ok(Some(
             str::from_utf8(name)
                 .ok()
@@ -258,7 +258,7 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
 
     #[inline]
     fn name(&self) -> Result<&str> {
-        let name = self.section.name(self.file.symbols.strings)?;
+        let name = self.section.name(self.file.symbols.strings())?;
         str::from_utf8(name)
             .ok()
             .read_error("Non UTF-8 COFF section name")

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -44,7 +44,7 @@ impl<'data> SymbolTable<'data> {
 
         Ok(SymbolTable {
             symbols,
-            strings: StringTable { data: strings },
+            strings: StringTable::new(strings),
         })
     }
 

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -11,13 +11,17 @@ use crate::read::{
     SymbolSection,
 };
 
+/// A table of symbol entries in a COFF or PE file.
+///
+/// Also includes the string table used for the symbol names.
 #[derive(Debug)]
-pub(crate) struct SymbolTable<'data> {
-    pub symbols: &'data [pe::ImageSymbolBytes],
-    pub strings: StringTable<'data>,
+pub struct SymbolTable<'data> {
+    symbols: &'data [pe::ImageSymbolBytes],
+    strings: StringTable<'data>,
 }
 
 impl<'data> SymbolTable<'data> {
+    /// Read the symbol table.
     pub fn parse(header: &pe::ImageFileHeader, mut data: Bytes<'data>) -> Result<Self> {
         // The symbol table may not be present.
         let symbol_offset = header.pointer_to_symbol_table.get(LE) as usize;
@@ -48,9 +52,55 @@ impl<'data> SymbolTable<'data> {
         })
     }
 
+    /// Return the string table used for the symbol names.
+    #[inline]
+    pub fn strings(&self) -> StringTable<'data> {
+        self.strings
+    }
+
+    /// Return true if the symbol table is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+
+    /// The number of symbols.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.symbols.len()
+    }
+
+    /// Return the symbol table entry at the given index.
+    #[inline]
+    pub fn symbol(&self, index: usize) -> Option<&'data pe::ImageSymbol> {
+        self.get::<pe::ImageSymbol>(index)
+    }
+
+    /// Return the symbol table entry or auxilliary record at the given index.
     pub fn get<T: Pod>(&self, index: usize) -> Option<&'data T> {
         let bytes = self.symbols.get(index)?;
         Bytes(&bytes.0[..]).read().ok()
+    }
+}
+
+impl pe::ImageSymbol {
+    /// Parse a COFF symbol name.
+    ///
+    /// `strings` must be the string table used for symbols names.
+    pub fn name<'data>(&'data self, strings: StringTable<'data>) -> Result<&'data [u8]> {
+        if self.name[0] == 0 {
+            // If the name starts with 0 then the last 4 bytes are a string table offset.
+            let offset = u32::from_le_bytes(self.name[4..8].try_into().unwrap());
+            strings
+                .get(offset)
+                .read_error("Invalid COFF symbol name offset")
+        } else {
+            // The name is inline and padded with nulls.
+            Ok(match self.name.iter().position(|&x| x == 0) {
+                Some(end) => &self.name[..end],
+                None => &self.name[..],
+            })
+        }
     }
 }
 
@@ -104,16 +154,8 @@ pub(crate) fn parse_symbol<'data>(
         } else {
             None
         }
-    } else if symbol.name[0] == 0 {
-        // If the name starts with 0 then the last 4 bytes are a string table offset.
-        let offset = u32::from_le_bytes(symbol.name[4..8].try_into().unwrap());
-        symbols.strings.get(offset).ok()
     } else {
-        // The name is inline and padded with nulls.
-        Some(match symbol.name.iter().position(|&x| x == 0) {
-            Some(end) => &symbol.name[..end],
-            None => &symbol.name[..],
-        })
+        symbol.name(symbols.strings()).ok()
     };
     let name = name.and_then(|s| str::from_utf8(s).ok());
 

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -68,9 +68,7 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
         } else {
             Bytes(&[])
         };
-        let section_strings = StringTable {
-            data: section_string_data,
-        };
+        let section_strings = StringTable::new(section_string_data);
 
         let mut symbol_section = None;
         let mut symbols = &[][..];
@@ -118,17 +116,13 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
                 _ => {}
             }
         }
-        let symbol_strings = StringTable {
-            data: symbol_string_data,
-        };
+        let symbol_strings = StringTable::new(symbol_string_data);
         let symbols = SymbolTable {
             symbols,
             strings: symbol_strings,
             shndx: symbol_shndx,
         };
-        let dynamic_symbol_strings = StringTable {
-            data: dynamic_symbol_string_data,
-        };
+        let dynamic_symbol_strings = StringTable::new(dynamic_symbol_string_data);
         let dynamic_symbols = SymbolTable {
             symbols: dynamic_symbols,
             strings: dynamic_symbol_strings,

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -127,7 +127,7 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfRelocationIterator<'data, 'f
             if self.section_index == 0 {
                 return None;
             }
-            let section = self.file.sections.get(self.section_index)?;
+            let section = self.file.sections.section(self.section_index).ok()?;
             match section.sh_type(endian) {
                 elf::SHT_REL => {
                     if let Ok(relocations) = section.data_as_array(endian, self.file.data) {

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -10,7 +10,7 @@ use crate::read::{
     self, ObjectSection, ReadError, SectionFlags, SectionIndex, SectionKind, StringTable,
 };
 
-use super::{ElfFile, ElfNoteIterator, ElfRelocationIterator, FileHeader};
+use super::{ElfFile, ElfNoteIterator, ElfRelocationIterator, FileHeader, SymbolTable};
 
 /// The table of section headers in an ELF file.
 ///
@@ -76,6 +76,19 @@ impl<'data, Elf: FileHeader> SectionTable<'data, Elf> {
         self.strings
             .get(section.sh_name(endian))
             .read_error("Invalid ELF section name offset")
+    }
+
+    /// Return the symbol table of the given section type.
+    ///
+    /// Returns an empty symbol table if the symbol table does not exist.
+    #[inline]
+    pub fn symbols(
+        &self,
+        endian: Elf::Endian,
+        data: Bytes<'data>,
+        sh_type: u32,
+    ) -> read::Result<SymbolTable<'data, Elf>> {
+        SymbolTable::parse(endian, data, self, sh_type)
     }
 }
 

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -10,7 +10,9 @@ use crate::read::{
     self, ObjectSection, ReadError, SectionFlags, SectionIndex, SectionKind, StringTable,
 };
 
-use super::{ElfFile, ElfNoteIterator, ElfRelocationIterator, FileHeader, SymbolTable};
+use super::{
+    ElfFile, ElfNoteIterator, ElfRelocationIterator, FileHeader, RelocationSections, SymbolTable,
+};
 
 /// The table of section headers in an ELF file.
 ///
@@ -89,6 +91,16 @@ impl<'data, Elf: FileHeader> SectionTable<'data, Elf> {
         sh_type: u32,
     ) -> read::Result<SymbolTable<'data, Elf>> {
         SymbolTable::parse(endian, data, self, sh_type)
+    }
+
+    /// Create a mapping from section index to associated relocation sections.
+    #[inline]
+    pub fn relocation_sections(
+        &self,
+        endian: Elf::Endian,
+        symbol_section: usize,
+    ) -> read::Result<RelocationSections> {
+        RelocationSections::parse(endian, self, symbol_section)
     }
 }
 
@@ -265,7 +277,7 @@ impl<'data, 'file, Elf: FileHeader> ObjectSection<'data> for ElfSection<'data, '
 
     fn relocations(&self) -> ElfRelocationIterator<'data, 'file, Elf> {
         ElfRelocationIterator {
-            section_index: self.file.relocations[self.index.0],
+            section_index: self.index.0,
             file: self.file,
             relocations: None,
         }

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -76,7 +76,7 @@ impl<'data, Mach: MachHeader> MachOFile<'data, Mach> {
             }
         }
 
-        let strings = StringTable { data: strings };
+        let strings = StringTable::new(strings);
         let symbols = SymbolTable { symbols, strings };
 
         Ok(MachOFile {

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -3,7 +3,8 @@ use core::marker::PhantomData;
 use crate::endian::Endian;
 use crate::macho;
 use crate::pod::Bytes;
-use crate::read::{ReadError, Result};
+use crate::read::macho::{MachHeader, SymbolTable};
+use crate::read::{ReadError, Result, StringTable};
 
 /// An iterator over the load commands of a `MachHeader`.
 #[derive(Debug, Default, Clone, Copy)]
@@ -124,5 +125,29 @@ impl<'data, E: Endian> MachOLoadCommand<'data, E> {
         } else {
             Ok(None)
         }
+    }
+}
+
+impl<E: Endian> macho::SymtabCommand<E> {
+    /// Return the symbol table that this command references.
+    pub fn symbols<'data, Mach: MachHeader<Endian = E>>(
+        &self,
+        endian: E,
+        data: Bytes<'data>,
+    ) -> Result<SymbolTable<'data, Mach>> {
+        let symbols = data
+            .read_slice_at(
+                self.symoff.get(endian) as usize,
+                self.nsyms.get(endian) as usize,
+            )
+            .read_error("Invalid Mach-O symbol table offset or size")?;
+        let strings = data
+            .read_bytes_at(
+                self.stroff.get(endian) as usize,
+                self.strsize.get(endian) as usize,
+            )
+            .read_error("Invalid Mach-O string table offset or size")?;
+        let strings = StringTable::new(strings);
+        Ok(SymbolTable::new(symbols, strings))
     }
 }

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -23,7 +23,8 @@ impl<'data, E: Endian> MachOLoadCommandIterator<'data, E> {
         }
     }
 
-    pub(super) fn next(&mut self) -> Result<Option<MachOLoadCommand<'data, E>>> {
+    /// Return the next load command.
+    pub fn next(&mut self) -> Result<Option<MachOLoadCommand<'data, E>>> {
         if self.ncmds == 0 {
             return Ok(None);
         }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -10,6 +10,7 @@ use crate::common::{
 use crate::pod::Bytes;
 
 mod util;
+pub use util::StringTable;
 
 mod any;
 pub use any::*;

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -252,9 +252,37 @@ pub trait ImageNtHeaders: Debug + Pod {
 /// A trait for generic access to `ImageOptionalHeader32` and `ImageOptionalHeader64`.
 #[allow(missing_docs)]
 pub trait ImageOptionalHeader: Debug + Pod {
+    // Standard fields.
     fn magic(&self) -> u16;
+    fn major_linker_version(&self) -> u8;
+    fn minor_linker_version(&self) -> u8;
+    fn size_of_code(&self) -> u32;
+    fn size_of_initialized_data(&self) -> u32;
+    fn size_of_uninitialized_data(&self) -> u32;
     fn address_of_entry_point(&self) -> u32;
+    fn base_of_code(&self) -> u32;
+
+    // NT additional fields.
+    fn image_base(&self) -> u64;
     fn section_alignment(&self) -> u32;
+    fn file_alignment(&self) -> u32;
+    fn major_operating_system_version(&self) -> u16;
+    fn minor_operating_system_version(&self) -> u16;
+    fn major_image_version(&self) -> u16;
+    fn minor_image_version(&self) -> u16;
+    fn major_subsystem_version(&self) -> u16;
+    fn minor_subsystem_version(&self) -> u16;
+    fn win32_version_value(&self) -> u32;
+    fn size_of_image(&self) -> u32;
+    fn size_of_headers(&self) -> u32;
+    fn check_sum(&self) -> u32;
+    fn subsystem(&self) -> u16;
+    fn dll_characteristics(&self) -> u16;
+    fn size_of_stack_reserve(&self) -> u64;
+    fn size_of_stack_commit(&self) -> u64;
+    fn size_of_heap_reserve(&self) -> u64;
+    fn size_of_heap_commit(&self) -> u64;
+    fn loader_flags(&self) -> u32;
     fn number_of_rva_and_sizes(&self) -> u32;
 }
 
@@ -294,13 +322,138 @@ impl ImageOptionalHeader for pe::ImageOptionalHeader32 {
     }
 
     #[inline]
+    fn major_linker_version(&self) -> u8 {
+        self.major_linker_version
+    }
+
+    #[inline]
+    fn minor_linker_version(&self) -> u8 {
+        self.minor_linker_version
+    }
+
+    #[inline]
+    fn size_of_code(&self) -> u32 {
+        self.size_of_code.get(LE)
+    }
+
+    #[inline]
+    fn size_of_initialized_data(&self) -> u32 {
+        self.size_of_initialized_data.get(LE)
+    }
+
+    #[inline]
+    fn size_of_uninitialized_data(&self) -> u32 {
+        self.size_of_uninitialized_data.get(LE)
+    }
+
+    #[inline]
     fn address_of_entry_point(&self) -> u32 {
         self.address_of_entry_point.get(LE)
     }
 
     #[inline]
+    fn base_of_code(&self) -> u32 {
+        self.base_of_code.get(LE)
+    }
+
+    #[inline]
+    fn image_base(&self) -> u64 {
+        self.image_base.get(LE).into()
+    }
+
+    #[inline]
     fn section_alignment(&self) -> u32 {
         self.section_alignment.get(LE)
+    }
+
+    #[inline]
+    fn file_alignment(&self) -> u32 {
+        self.file_alignment.get(LE)
+    }
+
+    #[inline]
+    fn major_operating_system_version(&self) -> u16 {
+        self.major_operating_system_version.get(LE)
+    }
+
+    #[inline]
+    fn minor_operating_system_version(&self) -> u16 {
+        self.minor_operating_system_version.get(LE)
+    }
+
+    #[inline]
+    fn major_image_version(&self) -> u16 {
+        self.major_image_version.get(LE)
+    }
+
+    #[inline]
+    fn minor_image_version(&self) -> u16 {
+        self.minor_image_version.get(LE)
+    }
+
+    #[inline]
+    fn major_subsystem_version(&self) -> u16 {
+        self.major_subsystem_version.get(LE)
+    }
+
+    #[inline]
+    fn minor_subsystem_version(&self) -> u16 {
+        self.minor_subsystem_version.get(LE)
+    }
+
+    #[inline]
+    fn win32_version_value(&self) -> u32 {
+        self.win32_version_value.get(LE)
+    }
+
+    #[inline]
+    fn size_of_image(&self) -> u32 {
+        self.size_of_image.get(LE)
+    }
+
+    #[inline]
+    fn size_of_headers(&self) -> u32 {
+        self.size_of_headers.get(LE)
+    }
+
+    #[inline]
+    fn check_sum(&self) -> u32 {
+        self.check_sum.get(LE)
+    }
+
+    #[inline]
+    fn subsystem(&self) -> u16 {
+        self.subsystem.get(LE)
+    }
+
+    #[inline]
+    fn dll_characteristics(&self) -> u16 {
+        self.dll_characteristics.get(LE)
+    }
+
+    #[inline]
+    fn size_of_stack_reserve(&self) -> u64 {
+        self.size_of_stack_reserve.get(LE).into()
+    }
+
+    #[inline]
+    fn size_of_stack_commit(&self) -> u64 {
+        self.size_of_stack_commit.get(LE).into()
+    }
+
+    #[inline]
+    fn size_of_heap_reserve(&self) -> u64 {
+        self.size_of_heap_reserve.get(LE).into()
+    }
+
+    #[inline]
+    fn size_of_heap_commit(&self) -> u64 {
+        self.size_of_heap_commit.get(LE).into()
+    }
+
+    #[inline]
+    fn loader_flags(&self) -> u32 {
+        self.loader_flags.get(LE)
     }
 
     #[inline]
@@ -345,13 +498,138 @@ impl ImageOptionalHeader for pe::ImageOptionalHeader64 {
     }
 
     #[inline]
+    fn major_linker_version(&self) -> u8 {
+        self.major_linker_version
+    }
+
+    #[inline]
+    fn minor_linker_version(&self) -> u8 {
+        self.minor_linker_version
+    }
+
+    #[inline]
+    fn size_of_code(&self) -> u32 {
+        self.size_of_code.get(LE)
+    }
+
+    #[inline]
+    fn size_of_initialized_data(&self) -> u32 {
+        self.size_of_initialized_data.get(LE)
+    }
+
+    #[inline]
+    fn size_of_uninitialized_data(&self) -> u32 {
+        self.size_of_uninitialized_data.get(LE)
+    }
+
+    #[inline]
     fn address_of_entry_point(&self) -> u32 {
         self.address_of_entry_point.get(LE)
     }
 
     #[inline]
+    fn base_of_code(&self) -> u32 {
+        self.base_of_code.get(LE)
+    }
+
+    #[inline]
+    fn image_base(&self) -> u64 {
+        self.image_base.get(LE)
+    }
+
+    #[inline]
     fn section_alignment(&self) -> u32 {
         self.section_alignment.get(LE)
+    }
+
+    #[inline]
+    fn file_alignment(&self) -> u32 {
+        self.file_alignment.get(LE)
+    }
+
+    #[inline]
+    fn major_operating_system_version(&self) -> u16 {
+        self.major_operating_system_version.get(LE)
+    }
+
+    #[inline]
+    fn minor_operating_system_version(&self) -> u16 {
+        self.minor_operating_system_version.get(LE)
+    }
+
+    #[inline]
+    fn major_image_version(&self) -> u16 {
+        self.major_image_version.get(LE)
+    }
+
+    #[inline]
+    fn minor_image_version(&self) -> u16 {
+        self.minor_image_version.get(LE)
+    }
+
+    #[inline]
+    fn major_subsystem_version(&self) -> u16 {
+        self.major_subsystem_version.get(LE)
+    }
+
+    #[inline]
+    fn minor_subsystem_version(&self) -> u16 {
+        self.minor_subsystem_version.get(LE)
+    }
+
+    #[inline]
+    fn win32_version_value(&self) -> u32 {
+        self.win32_version_value.get(LE)
+    }
+
+    #[inline]
+    fn size_of_image(&self) -> u32 {
+        self.size_of_image.get(LE)
+    }
+
+    #[inline]
+    fn size_of_headers(&self) -> u32 {
+        self.size_of_headers.get(LE)
+    }
+
+    #[inline]
+    fn check_sum(&self) -> u32 {
+        self.check_sum.get(LE)
+    }
+
+    #[inline]
+    fn subsystem(&self) -> u16 {
+        self.subsystem.get(LE)
+    }
+
+    #[inline]
+    fn dll_characteristics(&self) -> u16 {
+        self.dll_characteristics.get(LE)
+    }
+
+    #[inline]
+    fn size_of_stack_reserve(&self) -> u64 {
+        self.size_of_stack_reserve.get(LE)
+    }
+
+    #[inline]
+    fn size_of_stack_commit(&self) -> u64 {
+        self.size_of_stack_commit.get(LE)
+    }
+
+    #[inline]
+    fn size_of_heap_reserve(&self) -> u64 {
+        self.size_of_heap_reserve.get(LE)
+    }
+
+    #[inline]
+    fn size_of_heap_commit(&self) -> u64 {
+        self.size_of_heap_commit.get(LE)
+    }
+
+    #[inline]
+    fn loader_flags(&self) -> u32 {
+        self.loader_flags.get(LE)
     }
 
     #[inline]

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -109,7 +109,7 @@ where
 
     fn section_by_name(&'file self, section_name: &str) -> Option<PeSection<'data, 'file, Pe>> {
         self.sections
-            .section_by_name(self.symbols.strings, section_name.as_bytes())
+            .section_by_name(self.symbols.strings(), section_name.as_bytes())
             .map(|(index, section)| PeSection {
                 file: self,
                 index: SectionIndex(index),
@@ -153,7 +153,7 @@ where
         CoffSymbolIterator {
             symbols: &self.symbols,
             // Hack: don't return any.
-            index: self.symbols.symbols.len(),
+            index: self.symbols.len(),
         }
     }
 

--- a/src/read/pe/mod.rs
+++ b/src/read/pe/mod.rs
@@ -12,3 +12,5 @@ pub use file::*;
 
 mod section;
 pub use section::*;
+
+pub use super::coff::SectionTable;

--- a/src/read/pe/mod.rs
+++ b/src/read/pe/mod.rs
@@ -13,4 +13,4 @@ pub use file::*;
 mod section;
 pub use section::*;
 
-pub use super::coff::SectionTable;
+pub use super::coff::{SectionTable, SymbolTable};

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -103,7 +103,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSegment<'data> for PeSegment<'data,
 
     #[inline]
     fn name(&self) -> Result<Option<&str>> {
-        let name = self.section.name(self.file.symbols.strings)?;
+        let name = self.section.name(self.file.symbols.strings())?;
         Ok(Some(
             str::from_utf8(name)
                 .ok()
@@ -221,7 +221,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
 
     #[inline]
     fn name(&self) -> Result<&str> {
-        let name = self.section.name(self.file.symbols.strings)?;
+        let name = self.section.name(self.file.symbols.strings())?;
         str::from_utf8(name)
             .ok()
             .read_error("Non UTF-8 PE section name")

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -134,7 +134,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeSectionIterator<'data, 'fi
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, section)| PeSection {
             file: self.file,
-            index: SectionIndex(index),
+            index: SectionIndex(index + 1),
             section,
         })
     }

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -59,7 +59,7 @@ where
 impl<'data, 'file, Pe: ImageNtHeaders> PeSegment<'data, 'file, Pe> {
     fn bytes(&self) -> Result<Bytes<'data>> {
         self.section
-            .pe_bytes(self.file.data)
+            .pe_data(self.file.data)
             .read_error("Invalid PE section offset or size")
     }
 }
@@ -160,7 +160,7 @@ where
 impl<'data, 'file, Pe: ImageNtHeaders> PeSection<'data, 'file, Pe> {
     fn bytes(&self) -> Result<Bytes<'data>> {
         self.section
-            .pe_bytes(self.file.data)
+            .pe_data(self.file.data)
             .read_error("Invalid PE section offset or size")
     }
 }
@@ -249,7 +249,6 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
 }
 
 impl pe::ImageSectionHeader {
-    // This is not `pub(crate)` because the COFF version is different.
     fn pe_file_range(&self) -> (u32, u32) {
         // Pointer and size will be zero for uninitialized data; we don't need to validate this.
         let offset = self.pointer_to_raw_data.get(LE);
@@ -257,7 +256,8 @@ impl pe::ImageSectionHeader {
         (offset, size)
     }
 
-    fn pe_bytes<'data>(&self, data: Bytes<'data>) -> result::Result<Bytes<'data>, ()> {
+    /// Return the data for a PE section.
+    pub fn pe_data<'data>(&self, data: Bytes<'data>) -> result::Result<Bytes<'data>, ()> {
         let (offset, size) = self.pe_file_range();
         data.read_bytes_at(offset as usize, size as usize)
     }

--- a/src/read/util.rs
+++ b/src/read/util.rs
@@ -5,12 +5,21 @@ pub(crate) fn align(offset: usize, size: usize) -> usize {
     (offset + (size - 1)) & !(size - 1)
 }
 
+/// A table of zero-terminated strings.
+///
+/// This is used for most file formats.
 #[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct StringTable<'data> {
-    pub data: Bytes<'data>,
+pub struct StringTable<'data> {
+    data: Bytes<'data>,
 }
 
 impl<'data> StringTable<'data> {
+    /// Interpret the given data as a string table.
+    pub fn new(data: Bytes<'data>) -> Self {
+        StringTable { data }
+    }
+
+    /// Return the string at the given offset.
     pub fn get(&self, offset: u32) -> Result<&'data [u8], ()> {
         self.data.read_string_at(offset as usize)
     }

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -554,16 +554,21 @@ impl Object {
                                 return Err(Error(format!("unimplemented relocation {:?}", reloc)));
                             }
                         },
-                        Architecture::Aarch64(_) => match (reloc.kind, reloc.encoding, reloc.size) {
-                            (RelocationKind::Absolute, RelocationEncoding::Generic, 32) => {
-                                elf::R_AARCH64_ABS32
-                            }
-                            (RelocationKind::Absolute, RelocationEncoding::Generic, 64) => {
-                                elf::R_AARCH64_ABS64
-                            }
-                            (RelocationKind::Elf(x), _, _) => x,
-                            _ => {
-                                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                        Architecture::Aarch64(_) => {
+                            match (reloc.kind, reloc.encoding, reloc.size) {
+                                (RelocationKind::Absolute, RelocationEncoding::Generic, 32) => {
+                                    elf::R_AARCH64_ABS32
+                                }
+                                (RelocationKind::Absolute, RelocationEncoding::Generic, 64) => {
+                                    elf::R_AARCH64_ABS64
+                                }
+                                (RelocationKind::Elf(x), _, _) => x,
+                                _ => {
+                                    return Err(Error(format!(
+                                        "unimplemented relocation {:?}",
+                                        reloc
+                                    )));
+                                }
                             }
                         }
                         _ => {


### PR DESCRIPTION
For some applications it is desirable to only parse the minimum needed, but currently the unified API has to parse everything that is required to implement the unified traits. This PR starts exposing the lower level parsing API. This API is necessarily specific to each file format. It is aimed at allowing access to symbols for use in backtraces.

Very little of this PR is new functionality, but notable changes are:
- elf: fix SHT_SYMTAB_SHNDX handling for dynamic symbols
- pe: fix section indices to be 1-based

Covers most of #215 (cc @alexcrichton)