### PR TITLE
Remove use of target-lexicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 crc32fast = { version = "1.2", optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
-target-lexicon = { version = "0.10" }
 wasmparser = { version = "0.52", optional = true }
 
 [dev-dependencies]

--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -39,7 +39,11 @@ fn main() {
         }
     };
 
-    let mut out_object = write::Object::new(in_object.format(), in_object.architecture());
+    let mut out_object = write::Object::new(
+        in_object.format(),
+        in_object.architecture(),
+        in_object.endianness(),
+    );
     out_object.mangling = write::Mangling::None;
     out_object.flags = in_object.flags();
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,63 @@
+/// A CPU architecture.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Architecture {
+    Unknown,
+    Aarch64,
+    Arm,
+    I386,
+    Mips,
+    Wasm32,
+    X86_64,
+}
+
+impl Architecture {
+    /// The size of an address value for this architecture.
+    ///
+    /// Returns `None` for unknown architectures.
+    pub fn address_size(self) -> Option<AddressSize> {
+        match self {
+            Architecture::Unknown => None,
+            Architecture::Aarch64 => Some(AddressSize::U64),
+            Architecture::Arm => Some(AddressSize::U32),
+            Architecture::I386 => Some(AddressSize::U32),
+            Architecture::Mips => Some(AddressSize::U32),
+            Architecture::Wasm32 => Some(AddressSize::U32),
+            Architecture::X86_64 => Some(AddressSize::U64),
+        }
+    }
+}
+
+/// The size of an address value for an architecture.
+///
+/// This may differ from the address size supported by the file format (such as for COFF).
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum AddressSize {
+    U32 = 4,
+    U64 = 8,
+}
+
+impl AddressSize {
+    /// The size in bytes of an address value.
+    #[inline]
+    pub fn bytes(self) -> u8 {
+        self as u8
+    }
+}
+
+/// A binary file format.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BinaryFormat {
+    Coff,
+    Elf,
+    MachO,
+    Pe,
+    Wasm,
+}
+
 /// The kind of a section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SectionKind {

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -215,40 +215,40 @@ pub trait Endian: Debug + Default + Clone + Copy + PartialEq + Eq + 'static {
 
 /// An endianness that is selectable at run-time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum RunTimeEndian {
+pub enum Endianness {
     /// Little endian byte order.
     Little,
     /// Big endian byte order.
     Big,
 }
 
-impl Default for RunTimeEndian {
+impl Default for Endianness {
     #[cfg(target_endian = "little")]
     #[inline]
-    fn default() -> RunTimeEndian {
-        RunTimeEndian::Little
+    fn default() -> Endianness {
+        Endianness::Little
     }
 
     #[cfg(target_endian = "big")]
     #[inline]
-    fn default() -> RunTimeEndian {
-        RunTimeEndian::Big
+    fn default() -> Endianness {
+        Endianness::Big
     }
 }
 
-impl Endian for RunTimeEndian {
+impl Endian for Endianness {
     #[inline]
     fn from_big_endian(big_endian: bool) -> Option<Self> {
         Some(if big_endian {
-            RunTimeEndian::Big
+            Endianness::Big
         } else {
-            RunTimeEndian::Little
+            Endianness::Little
         })
     }
 
     #[inline]
     fn is_big_endian(self) -> bool {
-        self != RunTimeEndian::Little
+        self != Endianness::Little
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,6 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-// Re-export since these are used in public signatures.
-pub use target_lexicon;
-
 mod common;
 pub use common::*;
 

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "compression")]
 use alloc::borrow::Cow;
 use alloc::fmt;
-use target_lexicon::{Architecture, BinaryFormat};
 
 #[cfg(feature = "coff")]
 use crate::read::coff;
@@ -14,8 +13,8 @@ use crate::read::pe;
 #[cfg(feature = "wasm")]
 use crate::read::wasm;
 use crate::read::{
-    self, Error, FileFlags, Object, ObjectSection, ObjectSegment, Relocation, Result, SectionFlags,
-    SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap,
+    self, Architecture, BinaryFormat, Error, FileFlags, Object, ObjectSection, ObjectSegment,
+    Relocation, Result, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap,
 };
 
 /// Evaluate an expression on the contents of a file format enum.
@@ -226,9 +225,9 @@ impl<'data> File<'data> {
             #[cfg(feature = "elf")]
             FileInternal::Elf32(_) | FileInternal::Elf64(_) => BinaryFormat::Elf,
             #[cfg(feature = "macho")]
-            FileInternal::MachO32(_) | FileInternal::MachO64(_) => BinaryFormat::Macho,
+            FileInternal::MachO32(_) | FileInternal::MachO64(_) => BinaryFormat::MachO,
             #[cfg(feature = "pe")]
-            FileInternal::Pe32(_) | FileInternal::Pe64(_) => BinaryFormat::Coff,
+            FileInternal::Pe32(_) | FileInternal::Pe64(_) => BinaryFormat::Pe,
             #[cfg(feature = "wasm")]
             FileInternal::Wasm(_) => BinaryFormat::Wasm,
         }

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -1,14 +1,11 @@
 use alloc::vec::Vec;
 use core::str;
-use target_lexicon::Architecture;
 
-use crate::endian::LittleEndian as LE;
-use crate::pe;
-use crate::pod::Bytes;
 use crate::read::{
-    self, FileFlags, Object, ObjectSection, ReadError, Result, SectionIndex, Symbol, SymbolIndex,
-    SymbolMap,
+    self, Architecture, FileFlags, Object, ObjectSection, ReadError, Result, SectionIndex, Symbol,
+    SymbolIndex, SymbolMap,
 };
+use crate::{pe, Bytes, LittleEndian as LE};
 
 use super::{
     parse_symbol, CoffSection, CoffSectionIterator, CoffSegment, CoffSegmentIterator,
@@ -69,6 +66,7 @@ where
 
     #[inline]
     fn is_64(&self) -> bool {
+        // Windows COFF is always 32-bit, even for 64-bit architectures. This could be confusing.
         false
     }
 

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -2,15 +2,11 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
 
-use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
-
-use crate::elf;
-use crate::endian::{self, Endian, RunTimeEndian, U32};
-use crate::pod::{Bytes, Pod};
-use crate::read::util::{self, StringTable};
 use crate::read::{
-    self, Error, FileFlags, Object, ReadError, SectionIndex, Symbol, SymbolIndex, SymbolMap,
+    self, util, Architecture, Error, FileFlags, Object, ReadError, SectionIndex, StringTable,
+    Symbol, SymbolIndex, SymbolMap,
 };
+use crate::{elf, endian, Bytes, Endian, Endianness, Pod, U32};
 
 use super::{
     parse_symbol, CompressionHeader, ElfSection, ElfSectionIterator, ElfSegment,
@@ -19,9 +15,9 @@ use super::{
 };
 
 /// A 32-bit ELF object file.
-pub type ElfFile32<'data, Endian = RunTimeEndian> = ElfFile<'data, elf::FileHeader32<Endian>>;
+pub type ElfFile32<'data, Endian = Endianness> = ElfFile<'data, elf::FileHeader32<Endian>>;
 /// A 64-bit ELF object file.
-pub type ElfFile64<'data, Endian = RunTimeEndian> = ElfFile<'data, elf::FileHeader64<Endian>>;
+pub type ElfFile64<'data, Endian = Endianness> = ElfFile<'data, elf::FileHeader64<Endian>>;
 
 /// A partially parsed ELF file.
 ///
@@ -112,8 +108,8 @@ where
 
     fn architecture(&self) -> Architecture {
         match self.header.e_machine(self.endian) {
-            elf::EM_ARM => Architecture::Arm(ArmArchitecture::Arm),
-            elf::EM_AARCH64 => Architecture::Aarch64(Aarch64Architecture::Aarch64),
+            elf::EM_ARM => Architecture::Arm,
+            elf::EM_AARCH64 => Architecture::Aarch64,
             elf::EM_386 => Architecture::I386,
             elf::EM_X86_64 => Architecture::X86_64,
             elf::EM_MIPS => Architecture::Mips,

--- a/src/read/elf/note.rs
+++ b/src/read/elf/note.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use crate::elf;
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::pod::{Bytes, Pod};
 use crate::read::util;
 use crate::read::{self, Error, ReadError};
@@ -80,9 +80,9 @@ where
 }
 
 /// A parsed `NoteHeader32`.
-pub type ElfNote32<'data, Endian = RunTimeEndian> = ElfNote<'data, elf::FileHeader32<Endian>>;
+pub type ElfNote32<'data, Endian = Endianness> = ElfNote<'data, elf::FileHeader32<Endian>>;
 /// A parsed `NoteHeader64`.
-pub type ElfNote64<'data, Endian = RunTimeEndian> = ElfNote<'data, elf::FileHeader64<Endian>>;
+pub type ElfNote64<'data, Endian = Endianness> = ElfNote<'data, elf::FileHeader64<Endian>>;
 
 /// A parsed `NoteHeader`.
 #[derive(Debug)]

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::slice;
 
 use crate::elf;
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::pod::Pod;
 use crate::read::{
     self, Error, Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex,
@@ -92,10 +92,10 @@ impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf> {
 }
 
 /// An iterator over the relocations for an `ElfSection32`.
-pub type ElfRelocationIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfRelocationIterator32<'data, 'file, Endian = Endianness> =
     ElfRelocationIterator<'data, 'file, elf::FileHeader32<Endian>>;
 /// An iterator over the relocations for an `ElfSection64`.
-pub type ElfRelocationIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfRelocationIterator64<'data, 'file, Endian = Endianness> =
     ElfRelocationIterator<'data, 'file, elf::FileHeader64<Endian>>;
 
 /// An iterator over the relocations for an `ElfSection`.

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::{iter, mem, slice, str};
 
 use crate::elf;
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::pod::{Bytes, Pod};
 use crate::read::{
     self, ObjectSection, ReadError, SectionFlags, SectionIndex, SectionKind, StringTable,
@@ -105,10 +105,10 @@ impl<'data, Elf: FileHeader> SectionTable<'data, Elf> {
 }
 
 /// An iterator over the sections of an `ElfFile32`.
-pub type ElfSectionIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSectionIterator32<'data, 'file, Endian = Endianness> =
     ElfSectionIterator<'data, 'file, elf::FileHeader32<Endian>>;
 /// An iterator over the sections of an `ElfFile64`.
-pub type ElfSectionIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSectionIterator64<'data, 'file, Endian = Endianness> =
     ElfSectionIterator<'data, 'file, elf::FileHeader64<Endian>>;
 
 /// An iterator over the sections of an `ElfFile`.
@@ -135,10 +135,10 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfSectionIterator<'data, 'file
 }
 
 /// A section of an `ElfFile32`.
-pub type ElfSection32<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSection32<'data, 'file, Endian = Endianness> =
     ElfSection<'data, 'file, elf::FileHeader32<Endian>>;
 /// A section of an `ElfFile64`.
-pub type ElfSection64<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSection64<'data, 'file, Endian = Endianness> =
     ElfSection<'data, 'file, elf::FileHeader64<Endian>>;
 
 /// A section of an `ElfFile`.

--- a/src/read/elf/segment.rs
+++ b/src/read/elf/segment.rs
@@ -2,17 +2,17 @@ use core::fmt::Debug;
 use core::{slice, str};
 
 use crate::elf;
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::pod::{Bytes, Pod};
 use crate::read::{self, ObjectSegment, ReadError};
 
 use super::{ElfFile, ElfNoteIterator, FileHeader};
 
 /// An iterator over the segments of an `ElfFile32`.
-pub type ElfSegmentIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSegmentIterator32<'data, 'file, Endian = Endianness> =
     ElfSegmentIterator<'data, 'file, elf::FileHeader32<Endian>>;
 /// An iterator over the segments of an `ElfFile64`.
-pub type ElfSegmentIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSegmentIterator64<'data, 'file, Endian = Endianness> =
     ElfSegmentIterator<'data, 'file, elf::FileHeader64<Endian>>;
 
 /// An iterator over the segments of an `ElfFile`.
@@ -43,10 +43,10 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfSegmentIterator<'data, 'file
 }
 
 /// A segment of an `ElfFile32`.
-pub type ElfSegment32<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSegment32<'data, 'file, Endian = Endianness> =
     ElfSegment<'data, 'file, elf::FileHeader32<Endian>>;
 /// A segment of an `ElfFile64`.
-pub type ElfSegment64<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSegment64<'data, 'file, Endian = Endianness> =
     ElfSegment<'data, 'file, elf::FileHeader64<Endian>>;
 
 /// A segment of an `ElfFile`.

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -4,7 +4,7 @@ use core::slice;
 use core::str;
 
 use crate::elf;
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::pod::{Bytes, Pod};
 use crate::read::util::StringTable;
 use crate::read::{
@@ -126,10 +126,10 @@ impl<'data, Elf: FileHeader> SymbolTable<'data, Elf> {
 }
 
 /// An iterator over the symbols of an `ElfFile32`.
-pub type ElfSymbolIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSymbolIterator32<'data, 'file, Endian = Endianness> =
     ElfSymbolIterator<'data, 'file, elf::FileHeader32<Endian>>;
 /// An iterator over the symbols of an `ElfFile64`.
-pub type ElfSymbolIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type ElfSymbolIterator64<'data, 'file, Endian = Endianness> =
     ElfSymbolIterator<'data, 'file, elf::FileHeader64<Endian>>;
 
 /// An iterator over the symbols of an `ElfFile`.

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -1,15 +1,12 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
-use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
 
-use crate::endian::{self, BigEndian, Endian, RunTimeEndian};
-use crate::macho;
-use crate::pod::{Bytes, Pod};
 use crate::read::{
-    self, Error, FileFlags, Object, ObjectSection, ReadError, Result, SectionIndex, Symbol,
-    SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
+    self, Architecture, Error, FileFlags, Object, ObjectSection, ReadError, Result, SectionIndex,
+    Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
 };
+use crate::{endian, macho, BigEndian, Bytes, Endian, Endianness, Pod};
 
 use super::{
     parse_symbol, MachOLoadCommandIterator, MachOSection, MachOSectionInternal,
@@ -18,9 +15,9 @@ use super::{
 };
 
 /// A 32-bit Mach-O object file.
-pub type MachOFile32<'data, Endian = RunTimeEndian> = MachOFile<'data, macho::MachHeader32<Endian>>;
+pub type MachOFile32<'data, Endian = Endianness> = MachOFile<'data, macho::MachHeader32<Endian>>;
 /// A 64-bit Mach-O object file.
-pub type MachOFile64<'data, Endian = RunTimeEndian> = MachOFile<'data, macho::MachHeader64<Endian>>;
+pub type MachOFile64<'data, Endian = Endianness> = MachOFile<'data, macho::MachHeader64<Endian>>;
 
 /// A partially parsed Mach-O file.
 ///
@@ -95,8 +92,8 @@ where
 
     fn architecture(&self) -> Architecture {
         match self.header.cputype(self.endian) {
-            macho::CPU_TYPE_ARM => Architecture::Arm(ArmArchitecture::Arm),
-            macho::CPU_TYPE_ARM64 => Architecture::Aarch64(Aarch64Architecture::Aarch64),
+            macho::CPU_TYPE_ARM => Architecture::Arm,
+            macho::CPU_TYPE_ARM64 => Architecture::Aarch64,
             macho::CPU_TYPE_X86 => Architecture::I386,
             macho::CPU_TYPE_X86_64 => Architecture::X86_64,
             macho::CPU_TYPE_MIPS => Architecture::Mips,

--- a/src/read/macho/relocation.rs
+++ b/src/read/macho/relocation.rs
@@ -1,6 +1,6 @@
 use core::{fmt, slice};
 
-use crate::endian::RunTimeEndian;
+use crate::endian::Endianness;
 use crate::macho;
 use crate::read::{
     Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SectionIndex, SymbolIndex,
@@ -9,10 +9,10 @@ use crate::read::{
 use super::{MachHeader, MachOFile};
 
 /// An iterator over the relocations in a `MachOSection32`.
-pub type MachORelocationIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type MachORelocationIterator32<'data, 'file, Endian = Endianness> =
     MachORelocationIterator<'data, 'file, macho::MachHeader32<Endian>>;
 /// An iterator over the relocations in a `MachOSection64`.
-pub type MachORelocationIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type MachORelocationIterator64<'data, 'file, Endian = Endianness> =
     MachORelocationIterator<'data, 'file, macho::MachHeader64<Endian>>;
 
 /// An iterator over the relocations in a `MachOSection`.

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -3,7 +3,7 @@ use alloc::borrow::Cow;
 use core::fmt::Debug;
 use core::{fmt, result, slice, str};
 
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::macho;
 use crate::pod::{Bytes, Pod};
 use crate::read::{
@@ -13,10 +13,10 @@ use crate::read::{
 use super::{MachHeader, MachOFile, MachORelocationIterator};
 
 /// An iterator over the sections of a `MachOFile32`.
-pub type MachOSectionIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSectionIterator32<'data, 'file, Endian = Endianness> =
     MachOSectionIterator<'data, 'file, macho::MachHeader32<Endian>>;
 /// An iterator over the sections of a `MachOFile64`.
-pub type MachOSectionIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSectionIterator64<'data, 'file, Endian = Endianness> =
     MachOSectionIterator<'data, 'file, macho::MachHeader64<Endian>>;
 
 /// An iterator over the sections of a `MachOFile`.
@@ -48,10 +48,10 @@ impl<'data, 'file, Mach: MachHeader> Iterator for MachOSectionIterator<'data, 'f
 }
 
 /// A section of a `MachOFile32`.
-pub type MachOSection32<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSection32<'data, 'file, Endian = Endianness> =
     MachOSection<'data, 'file, macho::MachHeader32<Endian>>;
 /// A section of a `MachOFile64`.
-pub type MachOSection64<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSection64<'data, 'file, Endian = Endianness> =
     MachOSection<'data, 'file, macho::MachHeader64<Endian>>;
 
 /// A section of a `MachOFile`.

--- a/src/read/macho/segment.rs
+++ b/src/read/macho/segment.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::{result, str};
 
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::macho;
 use crate::pod::{Bytes, Pod};
 use crate::read::{self, ObjectSegment, ReadError, Result};
@@ -9,10 +9,10 @@ use crate::read::{self, ObjectSegment, ReadError, Result};
 use super::{MachHeader, MachOFile, MachOLoadCommand, MachOLoadCommandIterator, Section};
 
 /// An iterator over the segments of a `MachOFile32`.
-pub type MachOSegmentIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSegmentIterator32<'data, 'file, Endian = Endianness> =
     MachOSegmentIterator<'data, 'file, macho::MachHeader32<Endian>>;
 /// An iterator over the segments of a `MachOFile64`.
-pub type MachOSegmentIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSegmentIterator64<'data, 'file, Endian = Endianness> =
     MachOSegmentIterator<'data, 'file, macho::MachHeader64<Endian>>;
 
 /// An iterator over the segments of a `MachOFile`.
@@ -43,10 +43,10 @@ impl<'data, 'file, Mach: MachHeader> Iterator for MachOSegmentIterator<'data, 'f
 }
 
 /// A segment of a `MachOFile32`.
-pub type MachOSegment32<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSegment32<'data, 'file, Endian = Endianness> =
     MachOSegment<'data, 'file, macho::MachHeader32<Endian>>;
 /// A segment of a `MachOFile64`.
-pub type MachOSegment64<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSegment64<'data, 'file, Endian = Endianness> =
     MachOSegment<'data, 'file, macho::MachHeader64<Endian>>;
 
 /// A segment of a `MachOFile`.

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::{fmt, slice, str};
 
-use crate::endian::{self, RunTimeEndian};
+use crate::endian::{self, Endianness};
 use crate::macho;
 use crate::pod::Pod;
 use crate::read::util::StringTable;
@@ -63,10 +63,10 @@ impl<'data, Mach: MachHeader> SymbolTable<'data, Mach> {
 }
 
 /// An iterator over the symbols of a `MachOFile32`.
-pub type MachOSymbolIterator32<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSymbolIterator32<'data, 'file, Endian = Endianness> =
     MachOSymbolIterator<'data, 'file, macho::MachHeader32<Endian>>;
 /// An iterator over the symbols of a `MachOFile64`.
-pub type MachOSymbolIterator64<'data, 'file, Endian = RunTimeEndian> =
+pub type MachOSymbolIterator64<'data, 'file, Endian = Endianness> =
     MachOSymbolIterator<'data, 'file, macho::MachHeader64<Endian>>;
 
 /// An iterator over the symbols of a `MachOFile`.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -3,11 +3,8 @@
 use alloc::vec::Vec;
 use core::{cmp, fmt, result};
 
-use crate::common::{
-    FileFlags, RelocationEncoding, RelocationKind, SectionFlags, SectionKind, SymbolFlags,
-    SymbolKind, SymbolScope,
-};
-use crate::pod::Bytes;
+use crate::common::*;
+use crate::Bytes;
 
 mod util;
 pub use util::StringTable;

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -1,15 +1,13 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
-use target_lexicon::Architecture;
 
-use crate::endian::LittleEndian as LE;
-use crate::pe;
-use crate::pod::{Bytes, Pod};
 use crate::read::coff::{parse_symbol, CoffSymbolIterator, SymbolTable};
 use crate::read::{
-    self, Error, FileFlags, Object, ReadError, Result, SectionIndex, Symbol, SymbolIndex, SymbolMap,
+    self, Architecture, Error, FileFlags, Object, ReadError, Result, SectionIndex, Symbol,
+    SymbolIndex, SymbolMap,
 };
+use crate::{pe, Bytes, LittleEndian as LE, Pod};
 
 use super::{PeSection, PeSectionIterator, PeSegment, PeSegmentIterator, SectionTable};
 

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "compression")]
 use alloc::borrow::Cow;
-use target_lexicon::{Architecture, Endianness};
 
-use crate::read::{self, Result};
-use crate::{
-    FileFlags, Relocation, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap,
+use crate::read::{
+    self, Architecture, FileFlags, Relocation, Result, SectionFlags, SectionIndex, SectionKind,
+    Symbol, SymbolIndex, SymbolMap,
 };
+use crate::Endianness;
 
 /// An object file.
 pub trait Object<'data, 'file>: read::private::Sealed {

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -9,13 +9,12 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::{slice, str};
-use target_lexicon::Architecture;
 use wasmparser as wp;
 
 use crate::read::{
-    self, Error, FileFlags, Object, ObjectSection, ObjectSegment, ReadError, Relocation, Result,
-    SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags, SymbolIndex, SymbolKind,
-    SymbolMap, SymbolScope, SymbolSection,
+    self, Architecture, Error, FileFlags, Object, ObjectSection, ObjectSegment, ReadError,
+    Relocation, Result, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags, SymbolIndex,
+    SymbolKind, SymbolMap, SymbolScope, SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -104,7 +104,7 @@ impl Object {
         if let Some(stub_id) = self.stub_symbols.get(&symbol_id) {
             return *stub_id;
         }
-        let stub_size = self.architecture.pointer_width().unwrap().bytes();
+        let stub_size = self.architecture.address_size().unwrap().bytes();
 
         let mut name = b".rdata$.refptr.".to_vec();
         name.extend(&self.symbols[symbol_id.0].name);

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -2,12 +2,14 @@
 
 use object::read::{Object, ObjectSection};
 use object::{read, write};
-use object::{SectionKind, SymbolFlags, SymbolKind, SymbolScope};
-use target_lexicon::{Architecture, BinaryFormat};
+use object::{
+    Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+};
 
 #[test]
 fn coff_x86_64_bss() {
-    let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Coff, Architecture::X86_64, Endianness::Little);
 
     let section = object.section_id(write::StandardSection::UninitializedData);
 
@@ -87,7 +89,8 @@ fn coff_x86_64_bss() {
 
 #[test]
 fn elf_x86_64_bss() {
-    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
 
     let section = object.section_id(write::StandardSection::UninitializedData);
 
@@ -174,7 +177,11 @@ fn elf_x86_64_bss() {
 
 #[test]
 fn macho_x86_64_bss() {
-    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+    let mut object = write::Object::new(
+        BinaryFormat::MachO,
+        Architecture::X86_64,
+        Endianness::Little,
+    );
 
     let section = object.section_id(write::StandardSection::UninitializedData);
 
@@ -207,7 +214,7 @@ fn macho_x86_64_bss() {
     //std::fs::write(&"bss.o", &bytes).unwrap();
 
     let object = read::File::parse(&bytes).unwrap();
-    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut sections = object.sections();

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -2,12 +2,14 @@
 
 use object::read::{Object, ObjectSection};
 use object::{read, write};
-use object::{SectionKind, SymbolFlags, SymbolKind, SymbolScope};
-use target_lexicon::{Architecture, BinaryFormat};
+use object::{
+    Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+};
 
 #[test]
 fn coff_x86_64_common() {
-    let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Coff, Architecture::X86_64, Endianness::Little);
 
     let symbol = write::Symbol {
         name: b"v1".to_vec(),
@@ -95,7 +97,8 @@ fn coff_x86_64_common() {
 
 #[test]
 fn elf_x86_64_common() {
-    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
 
     let symbol = write::Symbol {
         name: b"v1".to_vec(),
@@ -163,7 +166,11 @@ fn elf_x86_64_common() {
 
 #[test]
 fn macho_x86_64_common() {
-    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+    let mut object = write::Object::new(
+        BinaryFormat::MachO,
+        Architecture::X86_64,
+        Endianness::Little,
+    );
 
     let symbol = write::Symbol {
         name: b"v1".to_vec(),
@@ -194,7 +201,7 @@ fn macho_x86_64_common() {
     //std::fs::write(&"common.o", &bytes).unwrap();
 
     let object = read::File::parse(&bytes).unwrap();
-    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut sections = object.sections();

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -1,11 +1,14 @@
 use object::read::Object;
 use object::{read, write};
-use object::{SectionIndex, SymbolFlags, SymbolKind, SymbolScope, SymbolSection};
-use target_lexicon::{Architecture, BinaryFormat};
+use object::{
+    Architecture, BinaryFormat, Endianness, SectionIndex, SymbolFlags, SymbolKind, SymbolScope,
+    SymbolSection,
+};
 
 #[test]
 fn symtab_shndx() {
-    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
 
     for i in 0..0x10000 {
         let name = format!("func{}", i).into_bytes();

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -3,10 +3,9 @@
 use object::read::{Object, ObjectSection};
 use object::{read, write};
 use object::{
-    RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
-    SymbolSection,
+    Architecture, BinaryFormat, Endianness, RelocationEncoding, RelocationKind, SectionKind,
+    SymbolFlags, SymbolKind, SymbolScope, SymbolSection,
 };
-use target_lexicon::{Architecture, BinaryFormat};
 
 mod bss;
 mod common;
@@ -15,7 +14,8 @@ mod tls;
 
 #[test]
 fn coff_x86_64() {
-    let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Coff, Architecture::X86_64, Endianness::Little);
 
     object.add_file_symbol(b"file.c".to_vec());
 
@@ -52,6 +52,7 @@ fn coff_x86_64() {
     let object = read::File::parse(&bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Coff);
     assert_eq!(object.architecture(), Architecture::X86_64);
+    assert_eq!(object.endianness(), Endianness::Little);
 
     let mut sections = object.sections();
 
@@ -103,7 +104,8 @@ fn coff_x86_64() {
 
 #[test]
 fn elf_x86_64() {
-    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
 
     object.add_file_symbol(b"file.c".to_vec());
 
@@ -140,6 +142,7 @@ fn elf_x86_64() {
     let object = read::File::parse(&bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
+    assert_eq!(object.endianness(), Endianness::Little);
 
     let mut sections = object.sections();
 
@@ -208,7 +211,11 @@ fn elf_x86_64() {
 
 #[test]
 fn macho_x86_64() {
-    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+    let mut object = write::Object::new(
+        BinaryFormat::MachO,
+        Architecture::X86_64,
+        Endianness::Little,
+    );
 
     object.add_file_symbol(b"file.c".to_vec());
 
@@ -256,8 +263,9 @@ fn macho_x86_64() {
 
     let bytes = object.write().unwrap();
     let object = read::File::parse(&bytes).unwrap();
-    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
+    assert_eq!(object.endianness(), Endianness::Little);
 
     let mut sections = object.sections();
 

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -3,13 +3,14 @@
 use object::read::{Object, ObjectSection};
 use object::{read, write};
 use object::{
-    RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+    Architecture, BinaryFormat, Endianness, RelocationEncoding, RelocationKind, SectionKind,
+    SymbolFlags, SymbolKind, SymbolScope,
 };
-use target_lexicon::{Architecture, BinaryFormat};
 
 #[test]
 fn coff_x86_64_tls() {
-    let mut object = write::Object::new(BinaryFormat::Coff, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Coff, Architecture::X86_64, Endianness::Little);
 
     let section = object.section_id(write::StandardSection::Tls);
     let symbol = object.add_symbol(write::Symbol {
@@ -56,7 +57,8 @@ fn coff_x86_64_tls() {
 
 #[test]
 fn elf_x86_64_tls() {
-    let mut object = write::Object::new(BinaryFormat::Elf, Architecture::X86_64);
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
 
     let section = object.section_id(write::StandardSection::Tls);
     let symbol = object.add_symbol(write::Symbol {
@@ -143,7 +145,11 @@ fn elf_x86_64_tls() {
 
 #[test]
 fn macho_x86_64_tls() {
-    let mut object = write::Object::new(BinaryFormat::Macho, Architecture::X86_64);
+    let mut object = write::Object::new(
+        BinaryFormat::MachO,
+        Architecture::X86_64,
+        Endianness::Little,
+    );
 
     let section = object.section_id(write::StandardSection::Tls);
     let symbol = object.add_symbol(write::Symbol {
@@ -176,7 +182,7 @@ fn macho_x86_64_tls() {
     //std::fs::write(&"tls.o", &bytes).unwrap();
 
     let object = read::File::parse(&bytes).unwrap();
-    assert_eq!(object.format(), BinaryFormat::Macho);
+    assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut sections = object.sections();


### PR DESCRIPTION
Avoiding target-lexicon in the public API means that dependency
management for users of this crate is simpler. A breaking change
in target-lexicon no longer means that this crate has to be
updated first.

Reducing the number of dependencies is also desirable for some
users (e.g. backtrace-rs).