### PR TITLE
Make `target-lexicon` an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ script:
   - cargo build --no-default-features --features read_core,write_core,macho
   - cargo build --no-default-features --features read_core,pe
   - cargo build --no-default-features --features read_core,wasm
+  - cargo build --no-default-features --features read_core,coff,elf,pe,wasm,macho
+  - cargo build --no-default-features --features read_core,coff,elf,pe,wasm,macho,architecture
   - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$TRAVIS_RUST_VERSION" = stable ]; then
       rustup component add rustfmt;
       cargo fmt -- --check;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 crc32fast = { version = "1.2", optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
-target-lexicon = { version = "0.10" }
+target-lexicon = { version = "0.10", optional = true }
 wasmparser = { version = "0.52", optional = true }
 
 [dev-dependencies]
@@ -24,9 +24,10 @@ memmap = "0.7"
 
 [features]
 read_core = []
-read = ["read_core", "coff", "elf", "macho", "pe", "wasm"]
+read = ["read_core", "coff", "elf", "macho", "pe", "wasm", "architecture"]
 write_core = ["crc32fast", "indexmap", "std"]
 write = ["write_core", "coff", "elf", "macho"]
+architecture = ["target-lexicon"]
 
 std = []
 compression = ["flate2", "std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate alloc;
 extern crate std;
 
 // Re-export since these are used in public signatures.
+#[cfg(feature = "architecture")]
 pub use target_lexicon;
 
 mod common;

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "compression")]
 use alloc::borrow::Cow;
 use alloc::fmt;
-use target_lexicon::{Architecture, BinaryFormat};
 
 #[cfg(feature = "coff")]
 use crate::read::coff;
@@ -219,7 +218,9 @@ impl<'data> File<'data> {
     }
 
     /// Return the file format.
-    pub fn format(&self) -> BinaryFormat {
+    #[cfg(feature = "architecture")]
+    pub fn format(&self) -> target_lexicon::BinaryFormat {
+        use target_lexicon::BinaryFormat;
         match self.inner {
             #[cfg(feature = "coff")]
             FileInternal::Coff(_) => BinaryFormat::Coff,
@@ -247,7 +248,8 @@ where
     type SectionIterator = SectionIterator<'data, 'file>;
     type SymbolIterator = SymbolIterator<'data, 'file>;
 
-    fn architecture(&self) -> Architecture {
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture {
         with_inner!(self.inner, FileInternal, |x| x.architecture())
     }
 

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
 use core::str;
-use target_lexicon::Architecture;
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
@@ -54,7 +53,9 @@ where
     type SectionIterator = CoffSectionIterator<'data, 'file>;
     type SymbolIterator = CoffSymbolIterator<'data, 'file>;
 
-    fn architecture(&self) -> Architecture {
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture {
+        use target_lexicon::Architecture;
         match self.header.machine.get(LE) {
             pe::IMAGE_FILE_MACHINE_I386 => Architecture::I386,
             pe::IMAGE_FILE_MACHINE_AMD64 => Architecture::X86_64,

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -2,8 +2,6 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
 
-use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
-
 use crate::elf;
 use crate::endian::{self, Endian, RunTimeEndian, U32};
 use crate::pod::{Bytes, Pod};
@@ -110,7 +108,9 @@ where
     type SectionIterator = ElfSectionIterator<'data, 'file, Elf>;
     type SymbolIterator = ElfSymbolIterator<'data, 'file, Elf>;
 
-    fn architecture(&self) -> Architecture {
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture {
+        use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
         match self.header.e_machine(self.endian) {
             elf::EM_ARM => Architecture::Arm(ArmArchitecture::Arm),
             elf::EM_AARCH64 => Architecture::Aarch64(Aarch64Architecture::Aarch64),

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
-use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
 
 use crate::endian::{self, BigEndian, Endian, RunTimeEndian};
 use crate::macho;
@@ -93,7 +92,9 @@ where
     type SectionIterator = MachOSectionIterator<'data, 'file, Mach>;
     type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach>;
 
-    fn architecture(&self) -> Architecture {
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture {
+        use target_lexicon::{Aarch64Architecture, Architecture, ArmArchitecture};
         match self.header.cputype(self.endian) {
             macho::CPU_TYPE_ARM => Architecture::Arm(ArmArchitecture::Arm),
             macho::CPU_TYPE_ARM64 => Architecture::Aarch64(Aarch64Architecture::Aarch64),

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
-use target_lexicon::Architecture;
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
@@ -80,7 +79,9 @@ where
     type SectionIterator = PeSectionIterator<'data, 'file, Pe>;
     type SymbolIterator = CoffSymbolIterator<'data, 'file>;
 
-    fn architecture(&self) -> Architecture {
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture {
+        use target_lexicon::Architecture;
         match self.nt_headers.file_header().machine.get(LE) {
             // TODO: Arm/Arm64
             pe::IMAGE_FILE_MACHINE_I386 => Architecture::I386,

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "compression")]
 use alloc::borrow::Cow;
-use target_lexicon::{Architecture, Endianness};
 
 use crate::read::{self, Result};
 use crate::{
@@ -25,15 +24,17 @@ pub trait Object<'data, 'file>: read::private::Sealed {
     type SymbolIterator: Iterator<Item = (SymbolIndex, Symbol<'data>)>;
 
     /// Get the architecture type of the file.
-    fn architecture(&self) -> Architecture;
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture;
 
     /// Get the endianness of the file.
     #[inline]
-    fn endianness(&self) -> Endianness {
+    #[cfg(feature = "architecture")]
+    fn endianness(&self) -> target_lexicon::Endianness {
         if self.is_little_endian() {
-            Endianness::Little
+            target_lexicon::Endianness::Little
         } else {
-            Endianness::Big
+            target_lexicon::Endianness::Big
         }
     }
 

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -9,7 +9,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::{slice, str};
-use target_lexicon::Architecture;
 use wasmparser as wp;
 
 use crate::read::{
@@ -308,8 +307,9 @@ where
     type SymbolIterator = WasmSymbolIterator<'data, 'file>;
 
     #[inline]
-    fn architecture(&self) -> Architecture {
-        Architecture::Wasm32
+    #[cfg(feature = "architecture")]
+    fn architecture(&self) -> target_lexicon::Architecture {
+        target_lexicon::Architecture::Wasm32
     }
 
     #[inline]


### PR DESCRIPTION
This commit should finish out #215 by removing the dependencies of the
`object` crate if it's built with few enough features. While hopefully
not exercised by most users this should be enough for the `backtrace`
crate to depend on `object` and not pull in any transitive dependencies.
One step closer to moving into libstd!

Closes #215