### PR TITLE
read: improve compression APIs

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -737,7 +737,7 @@ pub const SHF_MASKPROC: u32 = 0xf000_0000;
 /// Section compression header.
 ///
 /// Used when `SHF_COMPRESSED` is set.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct CompressionHeader32<E: Endian> {
     /// Compression format. One of the `ELFCOMPRESS_*` values.
@@ -751,7 +751,7 @@ pub struct CompressionHeader32<E: Endian> {
 /// Section compression header.
 ///
 /// Used when `SHF_COMPRESSED` is set.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct CompressionHeader64<E: Endian> {
     /// Compression format. One of the `ELFCOMPRESS_*` values.

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -18,8 +18,11 @@ type Result<T> = result::Result<T, ()>;
 /// - have no padding
 pub unsafe trait Pod: Copy + 'static {}
 
+/// Cast a byte slice to a `Pod` type.
+///
+/// Returns the type and the tail of the slice.
 #[inline]
-pub(crate) fn from_bytes<T: Pod>(data: &[u8]) -> Result<(&T, &[u8])> {
+pub fn from_bytes<T: Pod>(data: &[u8]) -> Result<(&T, &[u8])> {
     let ptr = data.as_ptr();
     if (ptr as usize) % mem::align_of::<T>() != 0 {
         return Err(());
@@ -33,8 +36,11 @@ pub(crate) fn from_bytes<T: Pod>(data: &[u8]) -> Result<(&T, &[u8])> {
     Ok((val, tail))
 }
 
+/// Cast a byte slice to a slice of a `Pod` type.
+///
+/// Returns the type slice and the tail of the byte slice.
 #[inline]
-pub(crate) fn slice_from_bytes<T: Pod>(data: &[u8], count: usize) -> Result<(&[T], &[u8])> {
+pub fn slice_from_bytes<T: Pod>(data: &[u8], count: usize) -> Result<(&[T], &[u8])> {
     let ptr = data.as_ptr();
     if (ptr as usize) % mem::align_of::<T>() != 0 {
         return Err(());
@@ -48,8 +54,9 @@ pub(crate) fn slice_from_bytes<T: Pod>(data: &[u8], count: usize) -> Result<(&[T
     Ok((slice, tail))
 }
 
+/// Cast a `Pod` type to a byte slice.
 #[inline]
-pub(crate) fn bytes_of<T: Pod>(val: &T) -> &[u8] {
+pub fn bytes_of<T: Pod>(val: &T) -> &[u8] {
     let size = mem::size_of::<T>();
     // Safety:
     // Any alignment is allowed.

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "compression")]
-use alloc::borrow::Cow;
 use alloc::fmt;
 
 #[cfg(feature = "coff")]
@@ -13,8 +11,9 @@ use crate::read::pe;
 #[cfg(feature = "wasm")]
 use crate::read::wasm;
 use crate::read::{
-    self, Architecture, BinaryFormat, Error, FileFlags, Object, ObjectSection, ObjectSegment,
-    Relocation, Result, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolIndex, SymbolMap,
+    self, Architecture, BinaryFormat, CompressedData, Error, FileFlags, Object, ObjectSection,
+    ObjectSegment, Relocation, Result, SectionFlags, SectionIndex, SectionKind, Symbol,
+    SymbolIndex, SymbolMap,
 };
 
 /// Evaluate an expression on the contents of a file format enum.
@@ -583,9 +582,8 @@ impl<'data, 'file> ObjectSection<'data> for Section<'data, 'file> {
         with_inner!(self.inner, SectionInternal, |x| x.data_range(address, size))
     }
 
-    #[cfg(feature = "compression")]
-    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
-        with_inner!(self.inner, SectionInternal, |x| x.uncompressed_data())
+    fn compressed_data(&self) -> Result<CompressedData<'data>> {
+        with_inner!(self.inner, SectionInternal, |x| x.compressed_data())
     }
 
     fn name(&self) -> Result<&str> {

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "compression")]
-use alloc::borrow::Cow;
 use core::{iter, result, slice, str};
 
 use crate::endian::LittleEndian as LE;
@@ -7,8 +5,8 @@ use crate::pe;
 use crate::pod::Bytes;
 use crate::read::util::StringTable;
 use crate::read::{
-    self, Error, ObjectSection, ObjectSegment, ReadError, Result, SectionFlags, SectionIndex,
-    SectionKind,
+    self, CompressedData, Error, ObjectSection, ObjectSegment, ReadError, Result, SectionFlags,
+    SectionIndex, SectionKind,
 };
 
 use super::{CoffFile, CoffRelocationIterator};
@@ -250,10 +248,9 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
         ))
     }
 
-    #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
-        Ok(Cow::from(self.data()?))
+    fn compressed_data(&self) -> Result<CompressedData<'data>> {
+        self.data().map(CompressedData::none)
     }
 
     #[inline]

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -1,17 +1,17 @@
-#[cfg(feature = "compression")]
-use alloc::borrow::Cow;
 use core::fmt::Debug;
 use core::{iter, mem, slice, str};
 
 use crate::elf;
-use crate::endian::{self, Endianness};
+use crate::endian::{self, Endianness, U32Bytes};
 use crate::pod::{Bytes, Pod};
 use crate::read::{
-    self, ObjectSection, ReadError, SectionFlags, SectionIndex, SectionKind, StringTable,
+    self, CompressedData, CompressionFormat, Error, ObjectSection, ReadError, SectionFlags,
+    SectionIndex, SectionKind, StringTable,
 };
 
 use super::{
-    ElfFile, ElfNoteIterator, ElfRelocationIterator, FileHeader, RelocationSections, SymbolTable,
+    CompressionHeader, ElfFile, ElfNoteIterator, ElfRelocationIterator, FileHeader,
+    RelocationSections, SymbolTable,
 };
 
 /// The table of section headers in an ELF file.
@@ -159,6 +159,63 @@ impl<'data, 'file, Elf: FileHeader> ElfSection<'data, 'file, Elf> {
             .data(self.file.endian, self.file.data)
             .read_error("Invalid ELF section size or offset")
     }
+
+    fn maybe_compressed_data(&self) -> read::Result<Option<CompressedData<'data>>> {
+        let endian = self.file.endian;
+        if (self.section.sh_flags(endian).into() & u64::from(elf::SHF_COMPRESSED)) == 0 {
+            return Ok(None);
+        }
+
+        let mut data = self
+            .section
+            .data(endian, self.file.data)
+            .read_error("Invalid ELF compressed section offset or size")?;
+        let header = data
+            .read::<Elf::CompressionHeader>()
+            .read_error("Invalid ELF compression header size or alignment")?;
+        if header.ch_type(endian) != elf::ELFCOMPRESS_ZLIB {
+            return Err(Error("Unsupported ELF compression type"));
+        }
+        let uncompressed_size: u64 = header.ch_size(endian).into();
+        Ok(Some(CompressedData {
+            format: CompressionFormat::Zlib,
+            data: data.0,
+            uncompressed_size: uncompressed_size as usize,
+        }))
+    }
+
+    /// Try GNU-style "ZLIB" header decompression.
+    fn maybe_compressed_data_gnu(&self) -> read::Result<Option<CompressedData<'data>>> {
+        let name = match self.name() {
+            Ok(name) => name,
+            // I think it's ok to ignore this error?
+            Err(_) => return Ok(None),
+        };
+        if !name.starts_with(".zdebug_") {
+            return Ok(None);
+        }
+        let mut data = self.bytes()?;
+        // Assume ZLIB-style uncompressed data is no more than 4GB to avoid accidentally
+        // huge allocations. This also reduces the chance of accidentally matching on a
+        // .debug_str that happens to start with "ZLIB".
+        if data
+            .read_bytes(8)
+            .read_error("ELF GNU compressed section is too short")?
+            .0
+            != b"ZLIB\0\0\0\0"
+        {
+            return Err(Error("Invalid ELF GNU compressed section header"));
+        }
+        let uncompressed_size = data
+            .read::<U32Bytes<_>>()
+            .read_error("ELF GNU compressed section is too short")?
+            .get(endian::BigEndian);
+        Ok(Some(CompressedData {
+            format: CompressionFormat::Zlib,
+            data: data.0,
+            uncompressed_size: uncompressed_size as usize,
+        }))
+    }
 }
 
 impl<'data, 'file, Elf: FileHeader> read::private::Sealed for ElfSection<'data, 'file, Elf> {}
@@ -205,14 +262,13 @@ impl<'data, 'file, Elf: FileHeader> ObjectSection<'data> for ElfSection<'data, '
         ))
     }
 
-    #[cfg(feature = "compression")]
-    fn uncompressed_data(&self) -> read::Result<Cow<'data, [u8]>> {
-        Ok(if let Some(data) = self.maybe_decompress_data()? {
+    fn compressed_data(&self) -> read::Result<CompressedData<'data>> {
+        Ok(if let Some(data) = self.maybe_compressed_data()? {
             data
-        } else if let Some(data) = self.maybe_decompress_data_gnu()? {
+        } else if let Some(data) = self.maybe_compressed_data_gnu()? {
             data
         } else {
-            Cow::from(self.data()?)
+            CompressedData::none(self.data()?)
         })
     }
 
@@ -474,85 +530,5 @@ impl<Endian: endian::Endian> SectionHeader for elf::SectionHeader64<Endian> {
     #[inline]
     fn sh_entsize(&self, endian: Self::Endian) -> Self::Word {
         self.sh_entsize.get(endian)
-    }
-}
-
-#[cfg(feature = "compression")]
-mod compression {
-    use alloc::vec::Vec;
-    use flate2::{Decompress, FlushDecompress};
-
-    use crate::endian::U32;
-    use crate::read::elf::CompressionHeader;
-    use crate::read::Error;
-
-    use super::*;
-
-    impl<'data, 'file, Elf: FileHeader> ElfSection<'data, 'file, Elf> {
-        pub(super) fn maybe_decompress_data(&self) -> read::Result<Option<Cow<'data, [u8]>>> {
-            let endian = self.file.endian;
-            if (self.section.sh_flags(endian).into() & u64::from(elf::SHF_COMPRESSED)) == 0 {
-                return Ok(None);
-            }
-
-            let mut data = self
-                .section
-                .data(endian, self.file.data)
-                .read_error("Invalid ELF compressed section offset or size")?;
-            let header = data
-                .read::<Elf::CompressionHeader>()
-                .read_error("Invalid ELF compression header size or alignment")?;
-            if header.ch_type(endian) != elf::ELFCOMPRESS_ZLIB {
-                return Err(Error("Unsupported ELF compression type"));
-            }
-
-            let uncompressed_size: u64 = header.ch_size(endian).into();
-            let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
-            let mut decompress = Decompress::new(true);
-            if decompress
-                .decompress_vec(data.0, &mut decompressed, FlushDecompress::Finish)
-                .is_err()
-            {
-                return Err(Error("Invalid ELF compressed data"));
-            }
-            Ok(Some(Cow::Owned(decompressed)))
-        }
-
-        /// Try GNU-style "ZLIB" header decompression.
-        pub(super) fn maybe_decompress_data_gnu(&self) -> read::Result<Option<Cow<'data, [u8]>>> {
-            let name = match self.name() {
-                Ok(name) => name,
-                // I think it's ok to ignore this error?
-                Err(_) => return Ok(None),
-            };
-            if !name.starts_with(".zdebug_") {
-                return Ok(None);
-            }
-            let mut data = self.bytes()?;
-            // Assume ZLIB-style uncompressed data is no more than 4GB to avoid accidentally
-            // huge allocations. This also reduces the chance of accidentally matching on a
-            // .debug_str that happens to start with "ZLIB".
-            if data
-                .read_bytes(8)
-                .read_error("ELF GNU compressed section is too short")?
-                .0
-                != b"ZLIB\0\0\0\0"
-            {
-                return Err(Error("Invalid ELF GNU compressed section header"));
-            }
-            let uncompressed_size = data
-                .read::<U32<_>>()
-                .read_error("ELF GNU compressed section is too short")?
-                .get(endian::BigEndian);
-            let mut decompressed = Vec::with_capacity(uncompressed_size as usize);
-            let mut decompress = Decompress::new(true);
-            if decompress
-                .decompress_vec(data.0, &mut decompressed, FlushDecompress::Finish)
-                .is_err()
-            {
-                return Err(Error("Invalid ELF GNU compressed data"));
-            }
-            Ok(Some(Cow::Owned(decompressed)))
-        }
     }
 }

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "compression")]
-use alloc::borrow::Cow;
 use core::fmt::Debug;
 use core::{fmt, result, slice, str};
 
@@ -7,7 +5,7 @@ use crate::endian::{self, Endianness};
 use crate::macho;
 use crate::pod::{Bytes, Pod};
 use crate::read::{
-    self, ObjectSection, ReadError, Result, SectionFlags, SectionIndex, SectionKind,
+    self, CompressedData, ObjectSection, ReadError, Result, SectionFlags, SectionIndex, SectionKind,
 };
 
 use super::{MachHeader, MachOFile, MachORelocationIterator};
@@ -118,10 +116,9 @@ impl<'data, 'file, Mach: MachHeader> ObjectSection<'data> for MachOSection<'data
         ))
     }
 
-    #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
-        Ok(Cow::from(self.data()?))
+    fn compressed_data(&self) -> Result<CompressedData<'data>> {
+        self.data().map(CompressedData::none)
     }
 
     #[inline]

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "compression")]
-use alloc::borrow::Cow;
 use core::marker::PhantomData;
 use core::{cmp, iter, result, slice, str};
 
@@ -7,8 +5,8 @@ use crate::endian::LittleEndian as LE;
 use crate::pe;
 use crate::pod::Bytes;
 use crate::read::{
-    self, ObjectSection, ObjectSegment, ReadError, Relocation, Result, SectionFlags, SectionIndex,
-    SectionKind,
+    self, CompressedData, ObjectSection, ObjectSegment, ReadError, Relocation, Result,
+    SectionFlags, SectionIndex, SectionKind,
 };
 
 use super::{ImageNtHeaders, PeFile};
@@ -213,10 +211,9 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
         ))
     }
 
-    #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
-        Ok(Cow::from(self.data()?))
+    fn compressed_data(&self) -> Result<CompressedData<'data>> {
+        self.data().map(CompressedData::none)
     }
 
     #[inline]

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -3,8 +3,6 @@
 //! Provides `WasmFile` and related types which implement the `Object` trait.
 //!
 //! Currently implements the minimum required to access DWARF debugging information.
-#[cfg(feature = "compression")]
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -12,9 +10,9 @@ use core::{slice, str};
 use wasmparser as wp;
 
 use crate::read::{
-    self, Architecture, Error, FileFlags, Object, ObjectSection, ObjectSegment, ReadError,
-    Relocation, Result, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags, SymbolIndex,
-    SymbolKind, SymbolMap, SymbolScope, SymbolSection,
+    self, Architecture, CompressedData, Error, FileFlags, Object, ObjectSection, ObjectSegment,
+    ReadError, Relocation, Result, SectionFlags, SectionIndex, SectionKind, Symbol, SymbolFlags,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolScope, SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;
@@ -513,10 +511,9 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
         unimplemented!()
     }
 
-    #[cfg(feature = "compression")]
     #[inline]
-    fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {
-        Ok(Cow::from(self.data()?))
+    fn compressed_data(&self) -> Result<CompressedData<'data>> {
+        self.data().map(CompressedData::none)
     }
 
     #[inline]

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -40,3 +40,85 @@ fn symtab_shndx() {
         );
     }
 }
+
+#[cfg(feature = "compression")]
+#[test]
+fn compression_zlib() {
+    use object::read::ObjectSection;
+    use object::LittleEndian as LE;
+    use std::io::Write;
+
+    let data = b"test data data data";
+    let len = data.len() as u64;
+
+    let mut ch = object::elf::CompressionHeader64::<LE>::default();
+    ch.ch_type.set(LE, object::elf::ELFCOMPRESS_ZLIB);
+    ch.ch_size.set(LE, len);
+    ch.ch_addralign.set(LE, 1);
+
+    let mut buf = Vec::new();
+    buf.write(object::bytes_of(&ch)).unwrap();
+    let mut encoder = flate2::write::ZlibEncoder::new(buf, flate2::Compression::default());
+    encoder.write_all(data).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+    let section = object.add_section(
+        Vec::new(),
+        b".debug_info".to_vec(),
+        object::SectionKind::Other,
+    );
+    object.section_mut(section).set_data(compressed, 1);
+    object.section_mut(section).flags = object::SectionFlags::Elf {
+        sh_flags: object::elf::SHF_COMPRESSED.into(),
+    };
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"compression.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Elf);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let section = object.section_by_name(".debug_info").unwrap();
+    let uncompressed = section.uncompressed_data().unwrap();
+    assert_eq!(data, &*uncompressed);
+}
+
+#[cfg(feature = "compression")]
+#[test]
+fn compression_gnu() {
+    use object::read::ObjectSection;
+    use std::io::Write;
+
+    let data = b"test data data data";
+    let len = data.len() as u32;
+
+    let mut buf = Vec::new();
+    buf.write_all(b"ZLIB\0\0\0\0").unwrap();
+    buf.write_all(&len.to_be_bytes()).unwrap();
+    let mut encoder = flate2::write::ZlibEncoder::new(buf, flate2::Compression::default());
+    encoder.write_all(data).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+    let section = object.add_section(
+        Vec::new(),
+        b".zdebug_info".to_vec(),
+        object::SectionKind::Other,
+    );
+    object.section_mut(section).set_data(compressed, 1);
+    let bytes = object.write().unwrap();
+
+    //std::fs::write(&"compression.o", &bytes).unwrap();
+
+    let object = read::File::parse(&bytes).unwrap();
+    assert_eq!(object.format(), BinaryFormat::Elf);
+    assert_eq!(object.architecture(), Architecture::X86_64);
+
+    let section = object.section_by_name(".zdebug_info").unwrap();
+    let uncompressed = section.uncompressed_data().unwrap();
+    assert_eq!(data, &*uncompressed);
+}


### PR DESCRIPTION
Changed `Object::uncompressed_data` to always be present, but return an error
if the data is compressed and the `compression` feature is disabled.

Added `Object::compressed_data` to return information about the compression
method, allowing users to implement their own decompression.

Also fix decompression of unaligned GNU ZLIB sections.