### PR TITLE
Prepare for inclusion into libstd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
     - libssl-dev
 
 script:
-  - cargo build --all-features && cargo test --all-features && cargo doc --all-features
+  - cargo build --features all && cargo test --features all && cargo doc --features all
   - cargo build --no-default-features --features read
   - cargo build --no-default-features --features write
   - cargo build --no-default-features --features read_core,write_core,coff
@@ -41,5 +41,5 @@ script:
 after_success:
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo install -f cargo-tarpaulin;
-      cargo tarpaulin --all-features --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
+      cargo tarpaulin --features all --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,19 @@ repository = "https://github.com/gimli-rs/object"
 description = "A unified interface for reading and writing object file formats."
 
 [package.metadata.docs.rs]
-all-features = true
+features = ['all']
 
 [dependencies]
 crc32fast = { version = "1.2", optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
 wasmparser = { version = "0.54", optional = true }
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = '0.1.2', optional = true }
+alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
 
 [dev-dependencies]
 memmap = "0.7"
@@ -37,6 +43,14 @@ pe = ["coff"]
 wasm = ["wasmparser"]
 
 default = ["read", "compression"]
+
+# Umbrella feature for enabling all user-facing features of this crate. Does not
+# enable internal features like `rustc-dep-of-std`.
+all = ["read", "write", "std", "compression", "default"]
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc']
 
 [[example]]
 name = "nm"


### PR DESCRIPTION
This applies the same change as gimli-rs/gimli#503 to this crate.

(also see https://github.com/rust-lang/backtrace-rs/issues/328 for some context)