### PR TITLE
Add `unaligned` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,15 @@ memmap = "0.7"
 
 [features]
 read_core = []
-read = ["read_core", "coff", "elf", "macho", "pe", "wasm"]
+read = ["read_core", "coff", "elf", "macho", "pe", "wasm", "unaligned"]
 write_core = ["crc32fast", "indexmap", "std"]
 write = ["write_core", "coff", "elf", "macho"]
 
 std = []
 compression = ["flate2", "std"]
+# Treat all types as unaligned. May be useful to enable when processing files
+# for architectures that have no alignment constraints.
+unaligned = []
 
 coff = []
 elf = []


### PR DESCRIPTION
While the structs defined in this crate have the alignment required by the specifications, some toolchains violate these requirements. Add an `unaligned` feature that allows these files to be processed, at the cost of potentially slower code.

Fixes #230 

I've kept this out of the `all` feature for now. I'm not sure if this should be enabled by default. @alexcrichton What are your thoughts on what `backtrace-rs` will want for this? I'm not sure how much the performance of this matters, and whether you want to selectively enable it for some architectures (most likely x86-64).