### PR TITLE
Add support for s390x

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -7,6 +7,7 @@ pub enum Architecture {
     Arm,
     I386,
     Mips,
+    S390x,
     Wasm32,
     X86_64,
 }
@@ -22,6 +23,7 @@ impl Architecture {
             Architecture::Arm => Some(AddressSize::U32),
             Architecture::I386 => Some(AddressSize::U32),
             Architecture::Mips => Some(AddressSize::U32),
+            Architecture::S390x => Some(AddressSize::U64),
             Architecture::Wasm32 => Some(AddressSize::U32),
             Architecture::X86_64 => Some(AddressSize::U64),
         }
@@ -291,6 +293,11 @@ pub enum RelocationEncoding {
     ///
     /// The `RelocationKind` must be PC relative.
     X86Branch,
+
+    /// s390x PC-relative offset shifted right by one bit.
+    ///
+    /// The `RelocationKind` must be PC relative.
+    S390xDbl,
 }
 
 /// File flags that are specific to each file format.

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -115,6 +115,15 @@ where
             elf::EM_386 => Architecture::I386,
             elf::EM_X86_64 => Architecture::X86_64,
             elf::EM_MIPS => Architecture::Mips,
+            elf::EM_S390 => {
+                // This is either s390 or s390x, depending on the ELF class.
+                // We only support the 64-bit variant s390x here.
+                if self.is_64() {
+                    Architecture::S390x
+                } else {
+                    Architecture::Unknown
+                }
+            }
             _ => Architecture::Unknown,
         }
     }

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -163,6 +163,47 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfRelocationIterator<'data, 'f
                             elf::R_X86_64_PC8 => (RelocationKind::Relative, 8),
                             r_type => (RelocationKind::Elf(r_type), 0),
                         },
+                        elf::EM_S390 => match reloc.r_type(endian) {
+                            elf::R_390_8 => (RelocationKind::Absolute, 8),
+                            elf::R_390_16 => (RelocationKind::Absolute, 16),
+                            elf::R_390_32 => (RelocationKind::Absolute, 32),
+                            elf::R_390_64 => (RelocationKind::Absolute, 64),
+                            elf::R_390_PC16 => (RelocationKind::Relative, 16),
+                            elf::R_390_PC32 => (RelocationKind::Relative, 32),
+                            elf::R_390_PC64 => (RelocationKind::Relative, 64),
+                            elf::R_390_PC16DBL => {
+                                encoding = RelocationEncoding::S390xDbl;
+                                (RelocationKind::Relative, 16)
+                            }
+                            elf::R_390_PC32DBL => {
+                                encoding = RelocationEncoding::S390xDbl;
+                                (RelocationKind::Relative, 32)
+                            }
+                            elf::R_390_PLT16DBL => {
+                                encoding = RelocationEncoding::S390xDbl;
+                                (RelocationKind::PltRelative, 16)
+                            }
+                            elf::R_390_PLT32DBL => {
+                                encoding = RelocationEncoding::S390xDbl;
+                                (RelocationKind::PltRelative, 32)
+                            }
+                            elf::R_390_GOT16 => (RelocationKind::Got, 16),
+                            elf::R_390_GOT32 => (RelocationKind::Got, 32),
+                            elf::R_390_GOT64 => (RelocationKind::Got, 64),
+                            elf::R_390_GOTENT => {
+                                encoding = RelocationEncoding::S390xDbl;
+                                (RelocationKind::GotRelative, 32)
+                            }
+                            elf::R_390_GOTOFF16 => (RelocationKind::GotBaseOffset, 16),
+                            elf::R_390_GOTOFF32 => (RelocationKind::GotBaseOffset, 32),
+                            elf::R_390_GOTOFF64 => (RelocationKind::GotBaseOffset, 64),
+                            elf::R_390_GOTPC => (RelocationKind::GotBaseRelative, 64),
+                            elf::R_390_GOTPCDBL => {
+                                encoding = RelocationEncoding::S390xDbl;
+                                (RelocationKind::GotBaseRelative, 32)
+                            }
+                            r_type => (RelocationKind::Elf(r_type), 0),
+                        },
                         _ => (RelocationKind::Elf(reloc.r_type(endian)), 0),
                     };
                     let target =

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -75,6 +75,7 @@ impl Object {
             Architecture::Aarch64 => true,
             Architecture::I386 => false,
             Architecture::X86_64 => true,
+            Architecture::S390x => true,
             _ => {
                 return Err(Error(format!(
                     "unimplemented architecture {:?}",
@@ -345,6 +346,7 @@ impl Object {
             Architecture::Aarch64 => elf::EM_AARCH64,
             Architecture::I386 => elf::EM_386,
             Architecture::X86_64 => elf::EM_X86_64,
+            Architecture::S390x => elf::EM_S390,
             _ => {
                 return Err(Error(format!(
                     "unimplemented architecture {:?}",
@@ -596,6 +598,72 @@ impl Object {
                             }
                             (RelocationKind::Absolute, RelocationEncoding::Generic, 64) => {
                                 elf::R_AARCH64_ABS64
+                            }
+                            (RelocationKind::Elf(x), _, _) => x,
+                            _ => {
+                                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                            }
+                        },
+                        Architecture::S390x => match (reloc.kind, reloc.encoding, reloc.size) {
+                            (RelocationKind::Absolute, RelocationEncoding::Generic, 8) => {
+                                elf::R_390_8
+                            }
+                            (RelocationKind::Absolute, RelocationEncoding::Generic, 16) => {
+                                elf::R_390_16
+                            }
+                            (RelocationKind::Absolute, RelocationEncoding::Generic, 32) => {
+                                elf::R_390_32
+                            }
+                            (RelocationKind::Absolute, RelocationEncoding::Generic, 64) => {
+                                elf::R_390_64
+                            }
+                            (RelocationKind::Relative, RelocationEncoding::Generic, 16) => {
+                                elf::R_390_PC16
+                            }
+                            (RelocationKind::Relative, RelocationEncoding::Generic, 32) => {
+                                elf::R_390_PC32
+                            }
+                            (RelocationKind::Relative, RelocationEncoding::Generic, 64) => {
+                                elf::R_390_PC64
+                            }
+                            (RelocationKind::Relative, RelocationEncoding::S390xDbl, 16) => {
+                                elf::R_390_PC16DBL
+                            }
+                            (RelocationKind::Relative, RelocationEncoding::S390xDbl, 32) => {
+                                elf::R_390_PC32DBL
+                            }
+                            (RelocationKind::PltRelative, RelocationEncoding::S390xDbl, 16) => {
+                                elf::R_390_PLT16DBL
+                            }
+                            (RelocationKind::PltRelative, RelocationEncoding::S390xDbl, 32) => {
+                                elf::R_390_PLT32DBL
+                            }
+                            (RelocationKind::Got, RelocationEncoding::Generic, 16) => {
+                                elf::R_390_GOT16
+                            }
+                            (RelocationKind::Got, RelocationEncoding::Generic, 32) => {
+                                elf::R_390_GOT32
+                            }
+                            (RelocationKind::Got, RelocationEncoding::Generic, 64) => {
+                                elf::R_390_GOT64
+                            }
+                            (RelocationKind::GotRelative, RelocationEncoding::S390xDbl, 32) => {
+                                elf::R_390_GOTENT
+                            }
+                            (RelocationKind::GotBaseOffset, RelocationEncoding::Generic, 16) => {
+                                elf::R_390_GOTOFF16
+                            }
+                            (RelocationKind::GotBaseOffset, RelocationEncoding::Generic, 32) => {
+                                elf::R_390_GOTOFF32
+                            }
+                            (RelocationKind::GotBaseOffset, RelocationEncoding::Generic, 64) => {
+                                elf::R_390_GOTOFF64
+                            }
+                            (RelocationKind::GotBaseRelative, RelocationEncoding::Generic, 64) => {
+                                elf::R_390_GOTPC
+                            }
+                            (RelocationKind::GotBaseRelative, RelocationEncoding::S390xDbl, 32) => {
+                                elf::R_390_GOTPCDBL
                             }
                             (RelocationKind::Elf(x), _, _) => x,
                             _ => {


### PR DESCRIPTION
This adds basic support for the s390x architecture and its most common relocation types.
This is a prerequisite for adding s390x support to wasmtime.
