### PR TITLE
write/elf: Check symbol.weak before symbol.is_undefined()

### DIFF
--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -427,12 +427,12 @@ impl Object {
                         }
                     }
                 };
-                let st_bind = if symbol.is_undefined() {
+                let st_bind = if symbol.weak {
+                    elf::STB_WEAK
+                } else if symbol.is_undefined() {
                     elf::STB_GLOBAL
                 } else if symbol.is_local() {
                     elf::STB_LOCAL
-                } else if symbol.weak {
-                    elf::STB_WEAK
                 } else {
                     elf::STB_GLOBAL
                 };


### PR DESCRIPTION
This is necessary to support weak linkage on statics in cg_clif.