### PR TITLE
Replace `Symbol` with a trait

### DIFF
--- a/examples/nm.rs
+++ b/examples/nm.rs
@@ -1,4 +1,7 @@
-use object::{Object, ObjectSection, SectionIndex, SectionKind, Symbol, SymbolKind, SymbolSection};
+use object::{
+    Object, ObjectSection, ObjectSymbol, SectionIndex, SectionKind, Symbol, SymbolKind,
+    SymbolSection,
+};
 use std::collections::HashMap;
 use std::{env, fs, process};
 
@@ -40,19 +43,19 @@ fn main() {
         let section_kinds = file.sections().map(|s| (s.index(), s.kind())).collect();
 
         println!("Debugging symbols:");
-        for (_, symbol) in file.symbols() {
+        for symbol in file.symbols() {
             print_symbol(&symbol, &section_kinds);
         }
         println!();
 
         println!("Dynamic symbols:");
-        for (_, symbol) in file.dynamic_symbols() {
+        for symbol in file.dynamic_symbols() {
             print_symbol(&symbol, &section_kinds);
         }
     }
 }
 
-fn print_symbol(symbol: &Symbol<'_>, section_kinds: &HashMap<SectionIndex, SectionKind>) {
+fn print_symbol(symbol: &Symbol<'_, '_>, section_kinds: &HashMap<SectionIndex, SectionKind>) {
     if let SymbolKind::Section | SymbolKind::File = symbol.kind() {
         return;
     }

--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::{env, fs, process};
 
 use object::{
-    write, Object, ObjectComdat, ObjectSection, RelocationTarget, SectionKind, SymbolFlags,
-    SymbolKind, SymbolSection,
+    write, Object, ObjectComdat, ObjectSection, ObjectSymbol, RelocationTarget, SectionKind,
+    SymbolFlags, SymbolKind, SymbolSection,
 };
 
 fn main() {
@@ -73,7 +73,7 @@ fn main() {
     }
 
     let mut out_symbols = HashMap::new();
-    for (symbol_index, in_symbol) in in_object.symbols() {
+    for in_symbol in in_object.symbols() {
         if in_symbol.kind() == SymbolKind::Null {
             continue;
         }
@@ -123,7 +123,7 @@ fn main() {
             flags,
         };
         let symbol_id = out_object.add_symbol(out_symbol);
-        out_symbols.insert(symbol_index, symbol_id);
+        out_symbols.insert(in_symbol.index(), symbol_id);
     }
 
     for in_section in in_object.sections() {

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -1,4 +1,4 @@
-use object::{Object, ObjectComdat, ObjectSection};
+use object::{Object, ObjectComdat, ObjectSection, ObjectSymbol};
 use std::{env, fs, process};
 
 fn main() {
@@ -72,8 +72,8 @@ fn main() {
             println!();
         }
 
-        for (index, symbol) in file.symbols() {
-            println!("{}: {:?}", index.0, symbol);
+        for symbol in file.symbols() {
+            println!("{}: {:?}", symbol.index().0, symbol);
         }
 
         for section in file.sections() {

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -153,7 +153,7 @@ impl<'data, 'file> ObjectSegment<'data> for CoffSegment<'data, 'file> {
 
     #[inline]
     fn name(&self) -> Result<Option<&str>> {
-        let name = self.section.name(self.file.symbols.strings())?;
+        let name = self.section.name(self.file.common.symbols.strings())?;
         Ok(Some(
             str::from_utf8(name)
                 .ok()
@@ -255,7 +255,7 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
 
     #[inline]
     fn name(&self) -> Result<&str> {
-        let name = self.section.name(self.file.symbols.strings())?;
+        let name = self.section.name(self.file.common.symbols.strings())?;
         str::from_utf8(name)
             .ok()
             .read_error("Non UTF-8 COFF section name")

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -1,4 +1,5 @@
 use alloc::fmt;
+use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::slice;
 use core::str;
@@ -8,11 +9,11 @@ use crate::endian::{self, Endianness};
 use crate::pod::{Bytes, Pod};
 use crate::read::util::StringTable;
 use crate::read::{
-    self, ReadError, SectionIndex, Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope,
-    SymbolSection,
+    self, ObjectSymbol, ObjectSymbolTable, ReadError, SectionIndex, SymbolFlags, SymbolIndex,
+    SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
 };
 
-use super::{ElfFile, FileHeader, SectionHeader, SectionTable};
+use super::{FileHeader, SectionHeader, SectionTable};
 
 /// A table of symbol entries in an ELF file.
 ///
@@ -111,6 +112,12 @@ impl<'data, Elf: FileHeader> SymbolTable<'data, Elf> {
         self.symbols.is_empty()
     }
 
+    /// The number of symbols.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.symbols.len()
+    }
+
     /// Return the symbol at the given index.
     pub fn symbol(&self, index: usize) -> read::Result<&'data Elf::Sym> {
         self.symbols
@@ -122,6 +129,67 @@ impl<'data, Elf: FileHeader> SymbolTable<'data, Elf> {
     #[inline]
     pub fn shndx(&self, index: usize) -> Option<u32> {
         self.shndx.get(index).cloned()
+    }
+
+    /// Construct a map from addresses to a user-defined map entry.
+    pub fn map<Entry: SymbolMapEntry, F: Fn(&'data Elf::Sym) -> Option<Entry>>(
+        &self,
+        endian: Elf::Endian,
+        f: F,
+    ) -> SymbolMap<Entry> {
+        let mut symbols = Vec::with_capacity(self.symbols.len());
+        for symbol in self.symbols {
+            if !symbol.is_definition(endian) {
+                continue;
+            }
+            if let Some(entry) = f(symbol) {
+                symbols.push(entry);
+            }
+        }
+        SymbolMap::new(symbols)
+    }
+}
+
+/// A symbol table of an `ElfFile32`.
+pub type ElfSymbolTable32<'data, 'file, Endian = Endianness> =
+    ElfSymbolTable<'data, 'file, elf::FileHeader32<Endian>>;
+/// A symbol table of an `ElfFile32`.
+pub type ElfSymbolTable64<'data, 'file, Endian = Endianness> =
+    ElfSymbolTable<'data, 'file, elf::FileHeader64<Endian>>;
+
+/// A symbol table of an `ElfFile`.
+#[derive(Debug, Clone, Copy)]
+pub struct ElfSymbolTable<'data, 'file, Elf>
+where
+    'data: 'file,
+    Elf: FileHeader,
+{
+    pub(super) endian: Elf::Endian,
+    pub(super) symbols: &'file SymbolTable<'data, Elf>,
+}
+
+impl<'data, 'file, Elf: FileHeader> read::private::Sealed for ElfSymbolTable<'data, 'file, Elf> {}
+
+impl<'data, 'file, Elf: FileHeader> ObjectSymbolTable<'data> for ElfSymbolTable<'data, 'file, Elf> {
+    type Symbol = ElfSymbol<'data, 'file, Elf>;
+    type SymbolIterator = ElfSymbolIterator<'data, 'file, Elf>;
+
+    fn symbols(&self) -> Self::SymbolIterator {
+        ElfSymbolIterator {
+            endian: self.endian,
+            symbols: self.symbols,
+            index: 0,
+        }
+    }
+
+    fn symbol_by_index(&self, index: SymbolIndex) -> read::Result<Self::Symbol> {
+        let symbol = self.symbols.symbol(index.0)?;
+        Ok(ElfSymbol {
+            endian: self.endian,
+            symbols: self.symbols,
+            index,
+            symbol,
+        })
     }
 }
 
@@ -138,8 +206,8 @@ where
     'data: 'file,
     Elf: FileHeader,
 {
-    pub(super) file: &'file ElfFile<'data, Elf>,
-    pub(super) symbols: SymbolTable<'data, Elf>,
+    pub(super) endian: Elf::Endian,
+    pub(super) symbols: &'file SymbolTable<'data, Elf>,
     pub(super) index: usize,
 }
 
@@ -150,82 +218,154 @@ impl<'data, 'file, Elf: FileHeader> fmt::Debug for ElfSymbolIterator<'data, 'fil
 }
 
 impl<'data, 'file, Elf: FileHeader> Iterator for ElfSymbolIterator<'data, 'file, Elf> {
-    type Item = (SymbolIndex, Symbol<'data>);
+    type Item = ElfSymbol<'data, 'file, Elf>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.index;
-        let shndx = self.symbols.shndx(index);
-        self.symbols.symbols.get(index).map(|symbol| {
-            self.index += 1;
-            let name = symbol.name(self.file.endian, self.symbols.strings()).ok();
-            (
-                SymbolIndex(index),
-                parse_symbol::<Elf>(self.file.endian, index, symbol, name, shndx),
-            )
+        let symbol = self.symbols.symbols.get(index)?;
+        self.index += 1;
+        Some(ElfSymbol {
+            endian: self.endian,
+            symbols: self.symbols,
+            index: SymbolIndex(index),
+            symbol,
         })
     }
 }
 
-pub(super) fn parse_symbol<'data, Elf: FileHeader>(
-    endian: Elf::Endian,
-    index: usize,
-    symbol: &Elf::Sym,
-    name: Option<&'data [u8]>,
-    shndx: Option<u32>,
-) -> Symbol<'data> {
-    let name = name.and_then(|s| str::from_utf8(s).ok());
-    let kind = match symbol.st_type() {
-        elf::STT_NOTYPE if index == 0 => SymbolKind::Null,
-        elf::STT_OBJECT | elf::STT_COMMON => SymbolKind::Data,
-        elf::STT_FUNC => SymbolKind::Text,
-        elf::STT_SECTION => SymbolKind::Section,
-        elf::STT_FILE => SymbolKind::File,
-        elf::STT_TLS => SymbolKind::Tls,
-        _ => SymbolKind::Unknown,
-    };
-    let section = match symbol.st_shndx(endian) {
-        elf::SHN_UNDEF => SymbolSection::Undefined,
-        elf::SHN_ABS => {
-            if kind == SymbolKind::File {
-                SymbolSection::None
-            } else {
-                SymbolSection::Absolute
+/// A symbol of an `ElfFile32`.
+pub type ElfSymbol32<'data, 'file, Endian = Endianness> =
+    ElfSymbol<'data, 'file, elf::FileHeader32<Endian>>;
+/// A symbol of an `ElfFile64`.
+pub type ElfSymbol64<'data, 'file, Endian = Endianness> =
+    ElfSymbol<'data, 'file, elf::FileHeader64<Endian>>;
+
+/// A symbol of an `ElfFile`.
+#[derive(Debug, Clone, Copy)]
+pub struct ElfSymbol<'data, 'file, Elf>
+where
+    'data: 'file,
+    Elf: FileHeader,
+{
+    pub(super) endian: Elf::Endian,
+    pub(super) symbols: &'file SymbolTable<'data, Elf>,
+    pub(super) index: SymbolIndex,
+    pub(super) symbol: &'data Elf::Sym,
+}
+
+impl<'data, 'file, Elf: FileHeader> read::private::Sealed for ElfSymbol<'data, 'file, Elf> {}
+
+impl<'data, 'file, Elf: FileHeader> ObjectSymbol<'data> for ElfSymbol<'data, 'file, Elf> {
+    #[inline]
+    fn index(&self) -> SymbolIndex {
+        self.index
+    }
+
+    fn name(&self) -> read::Result<&'data str> {
+        let name = self.symbol.name(self.endian, self.symbols.strings())?;
+        str::from_utf8(name)
+            .ok()
+            .read_error("Non UTF-8 ELF symbol name")
+    }
+
+    #[inline]
+    fn address(&self) -> u64 {
+        self.symbol.st_value(self.endian).into()
+    }
+
+    #[inline]
+    fn size(&self) -> u64 {
+        self.symbol.st_size(self.endian).into()
+    }
+
+    fn kind(&self) -> SymbolKind {
+        match self.symbol.st_type() {
+            elf::STT_NOTYPE if self.index.0 == 0 => SymbolKind::Null,
+            elf::STT_OBJECT | elf::STT_COMMON => SymbolKind::Data,
+            elf::STT_FUNC => SymbolKind::Text,
+            elf::STT_SECTION => SymbolKind::Section,
+            elf::STT_FILE => SymbolKind::File,
+            elf::STT_TLS => SymbolKind::Tls,
+            _ => SymbolKind::Unknown,
+        }
+    }
+
+    fn section(&self) -> SymbolSection {
+        match self.symbol.st_shndx(self.endian) {
+            elf::SHN_UNDEF => SymbolSection::Undefined,
+            elf::SHN_ABS => {
+                if self.symbol.st_type() == elf::STT_FILE {
+                    SymbolSection::None
+                } else {
+                    SymbolSection::Absolute
+                }
+            }
+            elf::SHN_COMMON => SymbolSection::Common,
+            elf::SHN_XINDEX => match self.symbols.shndx(self.index.0) {
+                Some(index) => SymbolSection::Section(SectionIndex(index as usize)),
+                None => SymbolSection::Unknown,
+            },
+            index if index < elf::SHN_LORESERVE => {
+                SymbolSection::Section(SectionIndex(index as usize))
+            }
+            _ => SymbolSection::Unknown,
+        }
+    }
+
+    #[inline]
+    fn is_undefined(&self) -> bool {
+        self.symbol.st_shndx(self.endian) == elf::SHN_UNDEF
+    }
+
+    #[inline]
+    fn is_definition(&self) -> bool {
+        self.symbol.is_definition(self.endian)
+    }
+
+    #[inline]
+    fn is_common(&self) -> bool {
+        self.symbol.st_shndx(self.endian) == elf::SHN_COMMON
+    }
+
+    #[inline]
+    fn is_weak(&self) -> bool {
+        self.symbol.st_bind() == elf::STB_WEAK
+    }
+
+    fn scope(&self) -> SymbolScope {
+        if self.symbol.st_shndx(self.endian) == elf::SHN_UNDEF {
+            SymbolScope::Unknown
+        } else {
+            match self.symbol.st_bind() {
+                elf::STB_LOCAL => SymbolScope::Compilation,
+                elf::STB_GLOBAL | elf::STB_WEAK => {
+                    if self.symbol.st_visibility() == elf::STV_HIDDEN {
+                        SymbolScope::Linkage
+                    } else {
+                        SymbolScope::Dynamic
+                    }
+                }
+                _ => SymbolScope::Unknown,
             }
         }
-        elf::SHN_COMMON => SymbolSection::Common,
-        elf::SHN_XINDEX => match shndx {
-            Some(index) => SymbolSection::Section(SectionIndex(index as usize)),
-            None => SymbolSection::Unknown,
-        },
-        index if index < elf::SHN_LORESERVE => SymbolSection::Section(SectionIndex(index as usize)),
-        _ => SymbolSection::Unknown,
-    };
-    let weak = symbol.st_bind() == elf::STB_WEAK;
-    let scope = match symbol.st_bind() {
-        _ if section == SymbolSection::Undefined => SymbolScope::Unknown,
-        elf::STB_LOCAL => SymbolScope::Compilation,
-        elf::STB_GLOBAL | elf::STB_WEAK => {
-            if symbol.st_visibility() == elf::STV_HIDDEN {
-                SymbolScope::Linkage
-            } else {
-                SymbolScope::Dynamic
-            }
+    }
+
+    #[inline]
+    fn is_global(&self) -> bool {
+        self.symbol.st_bind() != elf::STB_LOCAL
+    }
+
+    #[inline]
+    fn is_local(&self) -> bool {
+        self.symbol.st_bind() == elf::STB_LOCAL
+    }
+
+    #[inline]
+    fn flags(&self) -> SymbolFlags<SectionIndex> {
+        SymbolFlags::Elf {
+            st_info: self.symbol.st_info(),
+            st_other: self.symbol.st_other(),
         }
-        _ => SymbolScope::Unknown,
-    };
-    let flags = SymbolFlags::Elf {
-        st_info: symbol.st_info(),
-        st_other: symbol.st_other(),
-    };
-    Symbol {
-        name,
-        address: symbol.st_value(endian).into(),
-        size: symbol.st_size(endian).into(),
-        kind,
-        section,
-        weak,
-        scope,
-        flags,
     }
 }
 
@@ -254,6 +394,13 @@ pub trait Sym: Debug + Pod {
         strings
             .get(self.st_name(endian))
             .read_error("Invalid ELF symbol name offset")
+    }
+
+    /// Return true if the symbol is a definition of a function or data object.
+    fn is_definition(&self, endian: Self::Endian) -> bool {
+        let st_type = self.st_type();
+        (st_type == elf::STT_NOTYPE || st_type == elf::STT_FUNC || st_type == elf::STT_OBJECT)
+            && self.st_shndx(endian) != elf::SHN_UNDEF
     }
 }
 

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -4,15 +4,14 @@ use core::{mem, str};
 
 use crate::read::{
     self, Architecture, ComdatKind, Error, FileFlags, Object, ObjectComdat, ObjectSection,
-    ReadError, Result, SectionIndex, Symbol, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap,
-    SymbolScope, SymbolSection,
+    ReadError, Result, SectionIndex, SymbolIndex,
 };
 use crate::{endian, macho, BigEndian, Bytes, Endian, Endianness, Pod};
 
 use super::{
-    parse_symbol, MachOLoadCommandIterator, MachOSection, MachOSectionInternal,
-    MachOSectionIterator, MachOSegment, MachOSegmentIterator, MachOSymbolIterator, Nlist, Section,
-    Segment, SymbolTable,
+    MachOLoadCommandIterator, MachOSection, MachOSectionInternal, MachOSectionIterator,
+    MachOSegment, MachOSegmentIterator, MachOSymbol, MachOSymbolIterator, MachOSymbolTable, Nlist,
+    Section, Segment, SymbolTable,
 };
 
 /// A 32-bit Mach-O object file.
@@ -91,7 +90,9 @@ where
     type SectionIterator = MachOSectionIterator<'data, 'file, Mach>;
     type Comdat = MachOComdat<'data, 'file, Mach>;
     type ComdatIterator = MachOComdatIterator<'data, 'file, Mach>;
+    type Symbol = MachOSymbol<'data, 'file, Mach>;
     type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach>;
+    type SymbolTable = MachOSymbolTable<'data, 'file, Mach>;
 
     fn architecture(&self) -> Architecture {
         match self.header.cputype(self.endian) {
@@ -169,67 +170,33 @@ where
         MachOComdatIterator { file: self }
     }
 
-    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Symbol<'data>> {
+    fn symbol_by_index(&'file self, index: SymbolIndex) -> Result<MachOSymbol<'data, 'file, Mach>> {
         let nlist = self.symbols.symbol(index.0)?;
-        parse_symbol(self, nlist, self.symbols.strings())
-            .read_error("Unsupported Mach-O symbol index")
+        MachOSymbol::new(self, index, nlist).read_error("Unsupported Mach-O symbol index")
     }
 
     fn symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach> {
         MachOSymbolIterator {
             file: self,
-            symbols: self.symbols,
             index: 0,
         }
     }
 
-    fn dynamic_symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach> {
-        // The LC_DYSYMTAB command contains indices into the same symbol
-        // table as the LC_SYMTAB command, so return all of them.
-        self.symbols()
+    #[inline]
+    fn symbol_table(&'file self) -> Option<MachOSymbolTable<'data, 'file, Mach>> {
+        Some(MachOSymbolTable { file: self })
     }
 
-    fn symbol_map(&self) -> SymbolMap<'data> {
-        let mut symbols: Vec<_> = self.symbols().map(|(_, s)| s).collect();
-
-        // Add symbols for the end of each section.
-        for section in self.sections() {
-            symbols.push(Symbol {
-                name: None,
-                address: section.address() + section.size(),
-                size: 0,
-                kind: SymbolKind::Section,
-                section: SymbolSection::Undefined,
-                weak: false,
-                scope: SymbolScope::Compilation,
-                flags: SymbolFlags::None,
-            });
+    fn dynamic_symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach> {
+        MachOSymbolIterator {
+            file: self,
+            index: self.symbols.len(),
         }
+    }
 
-        // Calculate symbol sizes by sorting and finding the next symbol.
-        symbols.sort_by(|a, b| {
-            a.address.cmp(&b.address).then_with(|| {
-                // Place the end of section symbols last.
-                (a.kind == SymbolKind::Section).cmp(&(b.kind == SymbolKind::Section))
-            })
-        });
-
-        for i in 0..symbols.len() {
-            let (before, after) = symbols.split_at_mut(i + 1);
-            let symbol = &mut before[i];
-            if symbol.kind != SymbolKind::Section {
-                if let Some(next) = after
-                    .iter()
-                    .skip_while(|x| x.kind != SymbolKind::Section && x.address == symbol.address)
-                    .next()
-                {
-                    symbol.size = next.address - symbol.address;
-                }
-            }
-        }
-
-        symbols.retain(SymbolMap::filter);
-        SymbolMap { symbols }
+    #[inline]
+    fn dynamic_symbol_table(&'file self) -> Option<MachOSymbolTable<'data, 'file, Mach>> {
+        None
     }
 
     fn has_debug_symbols(&self) -> bool {

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{fmt, slice, str};
 
@@ -6,8 +7,8 @@ use crate::macho;
 use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
-    ReadError, Result, SectionIndex, SectionKind, Symbol, SymbolFlags, SymbolIndex, SymbolKind,
-    SymbolScope, SymbolSection,
+    self, ObjectSymbol, ObjectSymbolTable, ReadError, Result, SectionIndex, SectionKind,
+    SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
 };
 
 use super::{MachHeader, MachOFile};
@@ -54,11 +55,71 @@ impl<'data, Mach: MachHeader> SymbolTable<'data, Mach> {
         self.symbols.is_empty()
     }
 
+    /// The number of symbols.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.symbols.len()
+    }
+
     /// Return the symbol at the given index.
     pub fn symbol(&self, index: usize) -> Result<&'data Mach::Nlist> {
         self.symbols
             .get(index)
             .read_error("Invalid Mach-O symbol index")
+    }
+
+    /// Construct a map from addresses to a user-defined map entry.
+    pub fn map<Entry: SymbolMapEntry, F: Fn(&'data Mach::Nlist) -> Option<Entry>>(
+        &self,
+        f: F,
+    ) -> SymbolMap<Entry> {
+        let mut symbols = Vec::with_capacity(self.symbols.len());
+        for nlist in self.symbols {
+            if !nlist.is_definition() {
+                continue;
+            }
+            if let Some(entry) = f(nlist) {
+                symbols.push(entry);
+            }
+        }
+        SymbolMap::new(symbols)
+    }
+}
+
+/// An iterator over the symbols of a `MachOFile32`.
+pub type MachOSymbolTable32<'data, 'file, Endian = Endianness> =
+    MachOSymbolTable<'data, 'file, macho::MachHeader32<Endian>>;
+/// An iterator over the symbols of a `MachOFile64`.
+pub type MachOSymbolTable64<'data, 'file, Endian = Endianness> =
+    MachOSymbolTable<'data, 'file, macho::MachHeader64<Endian>>;
+
+/// A symbol table of a `MachOFile`.
+#[derive(Debug, Clone, Copy)]
+pub struct MachOSymbolTable<'data, 'file, Mach: MachHeader> {
+    pub(super) file: &'file MachOFile<'data, Mach>,
+}
+
+impl<'data, 'file, Mach: MachHeader> read::private::Sealed
+    for MachOSymbolTable<'data, 'file, Mach>
+{
+}
+
+impl<'data, 'file, Mach: MachHeader> ObjectSymbolTable<'data>
+    for MachOSymbolTable<'data, 'file, Mach>
+{
+    type Symbol = MachOSymbol<'data, 'file, Mach>;
+    type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach>;
+
+    fn symbols(&self) -> Self::SymbolIterator {
+        MachOSymbolIterator {
+            file: self.file,
+            index: 0,
+        }
+    }
+
+    fn symbol_by_index(&self, index: SymbolIndex) -> Result<Self::Symbol> {
+        let nlist = self.file.symbols.symbol(index.0)?;
+        MachOSymbol::new(self.file, index, nlist).read_error("Unsupported Mach-O symbol index")
     }
 }
 
@@ -72,7 +133,6 @@ pub type MachOSymbolIterator64<'data, 'file, Endian = Endianness> =
 /// An iterator over the symbols of a `MachOFile`.
 pub struct MachOSymbolIterator<'data, 'file, Mach: MachHeader> {
     pub(super) file: &'file MachOFile<'data, Mach>,
-    pub(super) symbols: SymbolTable<'data, Mach>,
     pub(super) index: usize,
 }
 
@@ -83,86 +143,159 @@ impl<'data, 'file, Mach: MachHeader> fmt::Debug for MachOSymbolIterator<'data, '
 }
 
 impl<'data, 'file, Mach: MachHeader> Iterator for MachOSymbolIterator<'data, 'file, Mach> {
-    type Item = (SymbolIndex, Symbol<'data>);
+    type Item = MachOSymbol<'data, 'file, Mach>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let index = self.index;
-            let nlist = self.symbols.symbols.get(index)?;
+            let nlist = self.file.symbols.symbols.get(index)?;
             self.index += 1;
-            if let Some(symbol) = parse_symbol(self.file, nlist, self.symbols.strings) {
-                return Some((SymbolIndex(index), symbol));
+            if let Some(symbol) = MachOSymbol::new(self.file, SymbolIndex(index), nlist) {
+                return Some(symbol);
             }
         }
     }
 }
 
-pub(super) fn parse_symbol<'data, Mach: MachHeader>(
-    file: &MachOFile<'data, Mach>,
-    nlist: &Mach::Nlist,
-    strings: StringTable<'data>,
-) -> Option<Symbol<'data>> {
-    let endian = file.endian;
-    let name = nlist
-        .name(endian, strings)
-        .ok()
-        .and_then(|s| str::from_utf8(s).ok());
-    let n_type = nlist.n_type();
-    let n_desc = nlist.n_desc(endian);
-    if n_type & macho::N_STAB != 0 {
-        return None;
-    }
-    let section = match n_type & macho::N_TYPE {
-        macho::N_UNDF => SymbolSection::Undefined,
-        macho::N_ABS => SymbolSection::Absolute,
-        macho::N_SECT => {
-            let n_sect = nlist.n_sect();
-            if n_sect != 0 {
-                SymbolSection::Section(SectionIndex(n_sect as usize))
-            } else {
-                SymbolSection::Unknown
-            }
+/// A symbol of a `MachOFile32`.
+pub type MachOSymbol32<'data, 'file, Endian = Endianness> =
+    MachOSymbol<'data, 'file, macho::MachHeader32<Endian>>;
+/// A symbol of a `MachOFile64`.
+pub type MachOSymbol64<'data, 'file, Endian = Endianness> =
+    MachOSymbol<'data, 'file, macho::MachHeader64<Endian>>;
+
+/// A symbol of a `MachOFile`.
+#[derive(Debug, Clone, Copy)]
+pub struct MachOSymbol<'data, 'file, Mach: MachHeader> {
+    file: &'file MachOFile<'data, Mach>,
+    index: SymbolIndex,
+    nlist: &'data Mach::Nlist,
+}
+
+impl<'data, 'file, Mach: MachHeader> MachOSymbol<'data, 'file, Mach> {
+    pub(super) fn new(
+        file: &'file MachOFile<'data, Mach>,
+        index: SymbolIndex,
+        nlist: &'data Mach::Nlist,
+    ) -> Option<Self> {
+        if nlist.n_type() & macho::N_STAB != 0 {
+            return None;
         }
-        _ => SymbolSection::Unknown,
-    };
-    let kind = section
-        .index()
-        .and_then(|index| file.section_internal(index).ok())
-        .map(|section| match section.kind {
-            SectionKind::Text => SymbolKind::Text,
-            SectionKind::Data
-            | SectionKind::ReadOnlyData
-            | SectionKind::ReadOnlyString
-            | SectionKind::UninitializedData
-            | SectionKind::Common => SymbolKind::Data,
-            SectionKind::Tls | SectionKind::UninitializedTls | SectionKind::TlsVariables => {
-                SymbolKind::Tls
+        Some(MachOSymbol { file, index, nlist })
+    }
+}
+
+impl<'data, 'file, Mach: MachHeader> read::private::Sealed for MachOSymbol<'data, 'file, Mach> {}
+
+impl<'data, 'file, Mach: MachHeader> ObjectSymbol<'data> for MachOSymbol<'data, 'file, Mach> {
+    #[inline]
+    fn index(&self) -> SymbolIndex {
+        self.index
+    }
+
+    fn name(&self) -> Result<&'data str> {
+        let name = self
+            .nlist
+            .name(self.file.endian, self.file.symbols.strings)?;
+        str::from_utf8(name)
+            .ok()
+            .read_error("Non UTF-8 Mach-O symbol name")
+    }
+
+    #[inline]
+    fn address(&self) -> u64 {
+        self.nlist.n_value(self.file.endian).into()
+    }
+
+    #[inline]
+    fn size(&self) -> u64 {
+        0
+    }
+
+    fn kind(&self) -> SymbolKind {
+        self.section()
+            .index()
+            .and_then(|index| self.file.section_internal(index).ok())
+            .map(|section| match section.kind {
+                SectionKind::Text => SymbolKind::Text,
+                SectionKind::Data
+                | SectionKind::ReadOnlyData
+                | SectionKind::ReadOnlyString
+                | SectionKind::UninitializedData
+                | SectionKind::Common => SymbolKind::Data,
+                SectionKind::Tls | SectionKind::UninitializedTls | SectionKind::TlsVariables => {
+                    SymbolKind::Tls
+                }
+                _ => SymbolKind::Unknown,
+            })
+            .unwrap_or(SymbolKind::Unknown)
+    }
+
+    fn section(&self) -> SymbolSection {
+        match self.nlist.n_type() & macho::N_TYPE {
+            macho::N_UNDF => SymbolSection::Undefined,
+            macho::N_ABS => SymbolSection::Absolute,
+            macho::N_SECT => {
+                let n_sect = self.nlist.n_sect();
+                if n_sect != 0 {
+                    SymbolSection::Section(SectionIndex(n_sect as usize))
+                } else {
+                    SymbolSection::Unknown
+                }
             }
-            _ => SymbolKind::Unknown,
-        })
-        .unwrap_or(SymbolKind::Unknown);
-    let weak = n_desc & (macho::N_WEAK_REF | macho::N_WEAK_DEF) != 0;
-    let scope = if section == SymbolSection::Undefined {
-        SymbolScope::Unknown
-    } else if n_type & macho::N_EXT == 0 {
-        SymbolScope::Compilation
-    } else if n_type & macho::N_PEXT != 0 {
-        SymbolScope::Linkage
-    } else {
-        SymbolScope::Dynamic
-    };
-    let flags = SymbolFlags::MachO { n_desc };
-    Some(Symbol {
-        name,
-        address: nlist.n_value(endian).into(),
-        // Only calculated for symbol maps
-        size: 0,
-        kind,
-        section,
-        weak,
-        scope,
-        flags,
-    })
+            _ => SymbolSection::Unknown,
+        }
+    }
+
+    #[inline]
+    fn is_undefined(&self) -> bool {
+        self.nlist.n_type() & macho::N_TYPE == macho::N_UNDF
+    }
+
+    #[inline]
+    fn is_definition(&self) -> bool {
+        self.nlist.is_definition()
+    }
+
+    #[inline]
+    fn is_common(&self) -> bool {
+        // Mach-O common symbols are based on section, not symbol
+        false
+    }
+
+    #[inline]
+    fn is_weak(&self) -> bool {
+        self.nlist.n_desc(self.file.endian) & (macho::N_WEAK_REF | macho::N_WEAK_DEF) != 0
+    }
+
+    fn scope(&self) -> SymbolScope {
+        let n_type = self.nlist.n_type();
+        if n_type & macho::N_TYPE == macho::N_UNDF {
+            SymbolScope::Unknown
+        } else if n_type & macho::N_EXT == 0 {
+            SymbolScope::Compilation
+        } else if n_type & macho::N_PEXT != 0 {
+            SymbolScope::Linkage
+        } else {
+            SymbolScope::Dynamic
+        }
+    }
+
+    #[inline]
+    fn is_global(&self) -> bool {
+        self.scope() != SymbolScope::Compilation
+    }
+
+    #[inline]
+    fn is_local(&self) -> bool {
+        self.scope() == SymbolScope::Compilation
+    }
+
+    #[inline]
+    fn flags(&self) -> SymbolFlags<SectionIndex> {
+        let n_desc = self.nlist.n_desc(self.file.endian);
+        SymbolFlags::MachO { n_desc }
+    }
 }
 
 /// A trait for generic access to `Nlist32` and `Nlist64`.
@@ -187,8 +320,10 @@ pub trait Nlist: Debug + Pod {
             .read_error("Invalid Mach-O symbol name offset")
     }
 
-    fn is_undefined(&self) -> bool {
-        self.n_type() & macho::N_TYPE == macho::N_UNDF
+    /// Return true if the symbol is a definition of a function or data object.
+    fn is_definition(&self) -> bool {
+        let n_type = self.n_type();
+        n_type & macho::N_STAB == 0 && n_type & macho::N_TYPE != macho::N_UNDF
     }
 }
 

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -101,7 +101,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSegment<'data> for PeSegment<'data,
 
     #[inline]
     fn name(&self) -> Result<Option<&str>> {
-        let name = self.section.name(self.file.symbols.strings())?;
+        let name = self.section.name(self.file.common.symbols.strings())?;
         Ok(Some(
             str::from_utf8(name)
                 .ok()
@@ -218,7 +218,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
 
     #[inline]
     fn name(&self) -> Result<&str> {
-        let name = self.section.name(self.file.symbols.strings())?;
+        let name = self.section.name(self.file.common.symbols.strings())?;
         str::from_utf8(name)
             .ok()
             .read_error("Non UTF-8 PE section name")

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "read", feature = "write"))]
 
-use object::read::{Object, ObjectSection};
+use object::read::{Object, ObjectSection, ObjectSymbol};
 use object::{read, write};
 use object::{
     Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
@@ -63,9 +63,9 @@ fn coff_x86_64_bss() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.name(), Ok("v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -73,9 +73,9 @@ fn coff_x86_64_bss() {
     assert_eq!(symbol.is_undefined(), false);
     assert_eq!(symbol.address(), 0);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.name(), Ok("v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -145,13 +145,13 @@ fn elf_x86_64_bss() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some(""));
+    assert_eq!(symbol.name(), Ok(""));
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.name(), Ok("v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -160,9 +160,9 @@ fn elf_x86_64_bss() {
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 18);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.name(), Ok("v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -236,9 +236,9 @@ fn macho_x86_64_bss() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_v1"));
+    assert_eq!(symbol.name(), Ok("_v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -246,9 +246,9 @@ fn macho_x86_64_bss() {
     assert_eq!(symbol.is_undefined(), false);
     assert_eq!(symbol.address(), 0);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_v2"));
+    assert_eq!(symbol.name(), Ok("_v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);

--- a/tests/round_trip/comdat.rs
+++ b/tests/round_trip/comdat.rs
@@ -1,7 +1,7 @@
 #![cfg(all(feature = "read", feature = "write"))]
 
 use object::pe;
-use object::read::{Object, ObjectComdat, ObjectSection};
+use object::read::{Object, ObjectComdat, ObjectSection, ObjectSymbol};
 use object::{read, write};
 use object::{
     Architecture, BinaryFormat, ComdatKind, Endianness, SectionKind, SymbolFlags, SymbolKind,
@@ -65,9 +65,9 @@ fn coff_x86_64_comdat() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some(".text$s1"));
+    assert_eq!(symbol.name(), Ok(".text$s1"));
     assert_eq!(symbol.kind(), SymbolKind::Section);
     assert_eq!(
         symbol.section(),
@@ -81,9 +81,9 @@ fn coff_x86_64_comdat() {
         }
     );
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some(".data$s1"));
+    assert_eq!(symbol.name(), Ok(".data$s1"));
     assert_eq!(symbol.kind(), SymbolKind::Section);
     assert_eq!(
         symbol.section(),
@@ -97,9 +97,10 @@ fn coff_x86_64_comdat() {
         }
     );
 
-    let (symbol_index, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
+    let symbol_index = symbol.index();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("s1"));
+    assert_eq!(symbol.name(), Ok("s1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(
         symbol.section(),
@@ -189,13 +190,14 @@ fn elf_x86_64_common() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some(""));
+    assert_eq!(symbol.name(), Ok(""));
 
-    let (symbol_index, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
+    let symbol_index = symbol.index();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("s1"));
+    assert_eq!(symbol.name(), Ok("s1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(
         symbol.section(),

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "read", feature = "write"))]
 
-use object::read::{Object, ObjectSection};
+use object::read::{Object, ObjectSection, ObjectSymbol};
 use object::{read, write};
 use object::{
     Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
@@ -58,9 +58,9 @@ fn coff_x86_64_common() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.name(), Ok("v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section(), read::SymbolSection::Common);
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -69,9 +69,9 @@ fn coff_x86_64_common() {
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 4);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.name(), Ok("v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section(), read::SymbolSection::Common);
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -80,12 +80,12 @@ fn coff_x86_64_common() {
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 8);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v3"));
+    assert_eq!(symbol.name(), Ok("v3"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section(), read::SymbolSection::Undefined);
-    assert_eq!(symbol.scope(), SymbolScope::Unknown);
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), true);
     assert_eq!(symbol.address(), 0);
@@ -134,13 +134,13 @@ fn elf_x86_64_common() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some(""));
+    assert_eq!(symbol.name(), Ok(""));
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v1"));
+    assert_eq!(symbol.name(), Ok("v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section(), read::SymbolSection::Common);
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -149,9 +149,9 @@ fn elf_x86_64_common() {
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 4);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("v2"));
+    assert_eq!(symbol.name(), Ok("v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section(), read::SymbolSection::Common);
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -223,9 +223,9 @@ fn macho_x86_64_common() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_v1"));
+    assert_eq!(symbol.name(), Ok("_v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(common_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -233,9 +233,9 @@ fn macho_x86_64_common() {
     assert_eq!(symbol.is_undefined(), false);
     assert_eq!(symbol.address(), 0);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_v2"));
+    assert_eq!(symbol.name(), Ok("_v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(common_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -1,5 +1,5 @@
 use object::read::elf::{FileHeader, SectionHeader};
-use object::read::Object;
+use object::read::{Object, ObjectSymbol};
 use object::{
     elf, read, write, Architecture, BinaryFormat, Bytes, Endianness, LittleEndian, SectionIndex,
     SectionKind, SymbolFlags, SymbolKind, SymbolScope, SymbolSection, U32,
@@ -34,10 +34,10 @@ fn symtab_shndx() {
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
-    for (index, symbol) in object.symbols().skip(1) {
+    for symbol in object.symbols().skip(1) {
         assert_eq!(
             symbol.section(),
-            SymbolSection::Section(SectionIndex(index.0))
+            SymbolSection::Section(SectionIndex(symbol.index().0))
         );
     }
 }

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "read", feature = "write"))]
 
-use object::read::{Object, ObjectSection};
+use object::read::{Object, ObjectSection, ObjectSymbol};
 use object::{read, write};
 use object::{
     Architecture, BinaryFormat, Endianness, RelocationEncoding, RelocationKind, SectionKind,
@@ -45,9 +45,9 @@ fn coff_x86_64_tls() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("tls1"));
+    assert_eq!(symbol.name(), Ok("tls1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section_index(), Some(tls_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -118,13 +118,13 @@ fn elf_x86_64_tls() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some(""));
+    assert_eq!(symbol.name(), Ok(""));
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("tls1"));
+    assert_eq!(symbol.name(), Ok("tls1"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(tdata_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -132,9 +132,9 @@ fn elf_x86_64_tls() {
     assert_eq!(symbol.is_undefined(), false);
     assert_eq!(symbol.size(), 30);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("tls2"));
+    assert_eq!(symbol.name(), Ok("tls2"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(tbss_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
@@ -216,45 +216,48 @@ fn macho_x86_64_tls() {
 
     let mut symbols = object.symbols();
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_tls1"));
+    assert_eq!(symbol.name(), Ok("_tls1"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(thread_vars_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), false);
 
-    let (tls1_init_symbol, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_tls1$tlv$init"));
+    let tls1_init_symbol = symbol.index();
+    assert_eq!(symbol.name(), Ok("_tls1$tlv$init"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(thread_data_index));
     assert_eq!(symbol.scope(), SymbolScope::Compilation);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), false);
 
-    let (tlv_bootstrap_symbol, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("__tlv_bootstrap"));
+    let tlv_bootstrap_symbol = symbol.index();
+    assert_eq!(symbol.name(), Ok("__tlv_bootstrap"));
     assert_eq!(symbol.kind(), SymbolKind::Unknown);
     assert_eq!(symbol.section_index(), None);
     assert_eq!(symbol.scope(), SymbolScope::Unknown);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), true);
 
-    let (_, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_tls2"));
+    assert_eq!(symbol.name(), Ok("_tls2"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(thread_vars_index));
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), false);
 
-    let (tls2_init_symbol, symbol) = symbols.next().unwrap();
+    let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Some("_tls2$tlv$init"));
+    let tls2_init_symbol = symbol.index();
+    assert_eq!(symbol.name(), Ok("_tls2$tlv$init"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(thread_bss_index));
     assert_eq!(symbol.scope(), SymbolScope::Compilation);


### PR DESCRIPTION
This allows users to only store the parts of the symbol that they
are interested in. For example, the user may want to only store
the symbol index and retrieve specific details from the symbol table
only as needed.

`Object::symbol_map` now returns a map containing only symbol names and
addresses, which is the most common use case. `SymbolMap` can be
constructed with custom symbol entries if other information is required.
This method also uses the dynamic symbol table if there are no
debugging symbols.

Also fixes COFF/PE symbols to give the correct address. Previously
they weren't including the image base address and the section address.