### PR TITLE
read: implement imports and exports

### DIFF
--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -79,7 +79,7 @@ fn dump_object(data: &[u8]) {
         if file.is_64() { "64" } else { "32" }
     );
     println!("Architecture: {:?}", file.architecture());
-    println!("Flags: {:?}", file.flags());
+    println!("Flags: {:x?}", file.flags());
 
     match file.mach_uuid() {
         Ok(Some(uuid)) => println!("Mach UUID: {:x?}", uuid),
@@ -102,11 +102,11 @@ fn dump_object(data: &[u8]) {
     }
 
     for segment in file.segments() {
-        println!("{:?}", segment);
+        println!("{:x?}", segment);
     }
 
     for section in file.sections() {
-        println!("{}: {:?}", section.index().0, section);
+        println!("{}: {:x?}", section.index().0, section);
     }
 
     for comdat in file.comdats() {
@@ -120,7 +120,7 @@ fn dump_object(data: &[u8]) {
     println!();
     println!("Symbols");
     for symbol in file.symbols() {
-        println!("{}: {:?}", symbol.index().0, symbol);
+        println!("{}: {:x?}", symbol.index().0, symbol);
     }
 
     for section in file.sections() {
@@ -130,7 +130,7 @@ fn dump_object(data: &[u8]) {
                 section.name().unwrap_or("<invalid name>")
             );
             for relocation in section.relocations() {
-                println!("{:?}", relocation);
+                println!("{:x?}", relocation);
             }
         }
     }
@@ -138,14 +138,30 @@ fn dump_object(data: &[u8]) {
     println!();
     println!("Dynamic symbols");
     for symbol in file.dynamic_symbols() {
-        println!("{}: {:?}", symbol.index().0, symbol);
+        println!("{}: {:x?}", symbol.index().0, symbol);
     }
 
     if let Some(relocations) = file.dynamic_relocations() {
         println!();
         println!("Dynamic relocations");
         for relocation in relocations {
-            println!("{:?}", relocation);
+            println!("{:x?}", relocation);
+        }
+    }
+
+    let imports = file.imports().unwrap();
+    if !imports.is_empty() {
+        println!();
+        for import in imports {
+            println!("{:?}", import);
+        }
+    }
+
+    let exports = file.exports().unwrap();
+    if !exports.is_empty() {
+        println!();
+        for export in exports {
+            println!("{:x?}", export);
         }
     }
 }

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -602,13 +602,9 @@ pub const LC_SUB_LIBRARY: u32 = 0x15;
 pub const LC_TWOLEVEL_HINTS: u32 = 0x16;
 /// prebind checksum
 pub const LC_PREBIND_CKSUM: u32 = 0x17;
-
-/*
- * load a dynamically linked shared library that is allowed to be missing
- * (all symbols are weak imported).
- */
+/// load a dynamically linked shared library that is allowed to be missing
+/// (all symbols are weak imported).
 pub const LC_LOAD_WEAK_DYLIB: u32 = 0x18 | LC_REQ_DYLD;
-
 /// 64-bit segment of this file to be mapped
 pub const LC_SEGMENT_64: u32 = 0x19;
 /// 64-bit image routines

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1833,9 +1833,12 @@ pub struct ImageThunkData32 {
         pub address_of_data: U32<LE>,
     } u1;
 }
+*/
 
 pub const IMAGE_ORDINAL_FLAG64: u64 = 0x8000000000000000;
 pub const IMAGE_ORDINAL_FLAG32: u32 = 0x80000000;
+
+/*
 #define IMAGE_ORDINAL64(Ordinal) (Ordinal & 0xffff)
 #define IMAGE_ORDINAL32(Ordinal) (Ordinal & 0xffff)
 #define IMAGE_SNAP_BY_ORDINAL64(Ordinal) ((Ordinal & IMAGE_ORDINAL_FLAG64) != 0)
@@ -1877,16 +1880,14 @@ pub struct ImageTlsDirectory32 {
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct ImageImportDescriptor {
+    /// RVA to original unbound IAT (`ImageThunkData32`/`ImageThunkData64`)
     /// 0 for terminating null import descriptor
-    /// RVA to original unbound IAT (PIMAGE_THUNK_DATA)
-    pub characteristics_or_original_first_thunk: U32<LE>,
     pub original_first_thunk: U32<LE>,
     /// 0 if not bound,
     /// -1 if bound, and real date\time stamp
     ///     in IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT (new BIND)
     /// O.W. date/time stamp of DLL bound to (Old BIND)
     pub time_date_stamp: U32<LE>,
-
     /// -1 if no forwarders
     pub forwarder_chain: U32<LE>,
     pub name: U32<LE>,

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -5,6 +5,7 @@
 // This module provides functions for both read and write features.
 #![cfg_attr(not(all(feature = "read_core", feature = "write_core")), allow(dead_code))]
 
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::{fmt, mem, result, slice};
 
@@ -331,6 +332,20 @@ struct DebugLen(usize);
 impl fmt::Debug for DebugLen {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "...; {}", self.0)
+    }
+}
+
+/// A newtype for byte strings.
+///
+/// For byte slices that are strings of an unknown encoding.
+///
+/// Provides a `Debug` implementation that interprets the bytes as UTF-8.
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ByteString<'data>(pub &'data [u8]);
+
+impl<'data> fmt::Debug for ByteString<'data> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "\"{}\"", String::from_utf8_lossy(self.0))
     }
 }
 

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -1,4 +1,5 @@
 use alloc::fmt;
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 #[cfg(feature = "coff")]
@@ -12,8 +13,8 @@ use crate::read::pe;
 #[cfg(feature = "wasm")]
 use crate::read::wasm;
 use crate::read::{
-    self, Architecture, BinaryFormat, ComdatKind, CompressedData, Error, FileFlags, Object,
-    ObjectComdat, ObjectMap, ObjectSection, ObjectSegment, ObjectSymbol, ObjectSymbolTable,
+    self, Architecture, BinaryFormat, ComdatKind, CompressedData, Error, Export, FileFlags, Import,
+    Object, ObjectComdat, ObjectMap, ObjectSection, ObjectSegment, ObjectSymbol, ObjectSymbolTable,
     Relocation, Result, SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex,
     SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
 };
@@ -354,6 +355,14 @@ where
 
     fn object_map(&self) -> ObjectMap<'data> {
         with_inner!(self.inner, FileInternal, |x| x.object_map())
+    }
+
+    fn imports(&self) -> Result<Vec<Import<'data>>> {
+        with_inner!(self.inner, FileInternal, |x| x.imports())
+    }
+
+    fn exports(&self) -> Result<Vec<Export<'data>>> {
+        with_inner!(self.inner, FileInternal, |x| x.exports())
     }
 
     fn has_debug_symbols(&self) -> bool {

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -1,8 +1,9 @@
+use alloc::vec::Vec;
 use core::str;
 
 use crate::read::{
-    self, Architecture, FileFlags, NoDynamicRelocationIterator, Object, ObjectSection, ReadError,
-    Result, SectionIndex, SymbolIndex,
+    self, Architecture, Export, FileFlags, Import, NoDynamicRelocationIterator, Object,
+    ObjectSection, ReadError, Result, SectionIndex, SymbolIndex,
 };
 use crate::{pe, Bytes, LittleEndian as LE};
 
@@ -157,6 +158,18 @@ where
     #[inline]
     fn dynamic_relocations(&'file self) -> Option<NoDynamicRelocationIterator> {
         None
+    }
+
+    #[inline]
+    fn imports(&self) -> Result<Vec<Import<'data>>> {
+        // TODO: this could return undefined symbols, but not needed yet.
+        Ok(Vec::new())
+    }
+
+    #[inline]
+    fn exports(&self) -> Result<Vec<Export<'data>>> {
+        // TODO: this could return global symbols, but not needed yet.
+        Ok(Vec::new())
     }
 
     fn has_debug_symbols(&self) -> bool {

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -396,6 +396,12 @@ pub trait Sym: Debug + Pod {
             .read_error("Invalid ELF symbol name offset")
     }
 
+    /// Return true if the symbol is undefined.
+    #[inline]
+    fn is_undefined(&self, endian: Self::Endian) -> bool {
+        self.st_shndx(endian) == elf::SHN_UNDEF
+    }
+
     /// Return true if the symbol is a definition of a function or data object.
     fn is_definition(&self, endian: Self::Endian) -> bool {
         let st_type = self.st_type();

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -3,10 +3,10 @@ use core::fmt::Debug;
 use core::{mem, str};
 
 use crate::read::{
-    self, Architecture, ComdatKind, Error, FileFlags, NoDynamicRelocationIterator, Object,
-    ObjectComdat, ObjectMap, ObjectSection, ReadError, Result, SectionIndex, SymbolIndex,
+    self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
+    Object, ObjectComdat, ObjectMap, ObjectSection, ReadError, Result, SectionIndex, SymbolIndex,
 };
-use crate::{endian, macho, BigEndian, Bytes, Endian, Endianness, Pod};
+use crate::{endian, macho, BigEndian, ByteString, Bytes, Endian, Endianness, Pod};
 
 use super::{
     MachOLoadCommandIterator, MachOSection, MachOSectionInternal, MachOSectionIterator,
@@ -202,6 +202,76 @@ where
 
     fn object_map(&'file self) -> ObjectMap<'data> {
         self.symbols.object_map(self.endian)
+    }
+
+    fn imports(&self) -> Result<Vec<Import<'data>>> {
+        let mut dysymtab = None;
+        let mut libraries = Vec::new();
+        let twolevel = self.header.flags(self.endian) & macho::MH_TWOLEVEL != 0;
+        if twolevel {
+            libraries.push(&[][..]);
+        }
+        let mut commands = self.header.load_commands(self.endian, self.data)?;
+        while let Some(command) = commands.next()? {
+            if let Some(command) = command.dysymtab()? {
+                dysymtab = Some(command);
+            }
+            if twolevel {
+                if let Some(dylib) = command.dylib()? {
+                    libraries.push(command.string(self.endian, dylib.name)?);
+                }
+            }
+        }
+
+        let mut imports = Vec::new();
+        if let Some(dysymtab) = dysymtab {
+            let index = dysymtab.iundefsym.get(self.endian) as usize;
+            let number = dysymtab.nundefsym.get(self.endian) as usize;
+            for i in index..(index.wrapping_add(number)) {
+                let symbol = self.symbols.symbol(i)?;
+                let name = symbol.name(self.endian, self.symbols.strings())?;
+                let library = if twolevel {
+                    libraries
+                        .get(symbol.library_ordinal(self.endian) as usize)
+                        .copied()
+                        .read_error("Invalid Mach-O symbol library ordinal")?
+                } else {
+                    &[]
+                };
+                imports.push(Import {
+                    name: ByteString(name),
+                    library: ByteString(library),
+                });
+            }
+        }
+        Ok(imports)
+    }
+
+    fn exports(&self) -> Result<Vec<Export<'data>>> {
+        let mut dysymtab = None;
+        let mut commands = self.header.load_commands(self.endian, self.data)?;
+        while let Some(command) = commands.next()? {
+            if let Some(command) = command.dysymtab()? {
+                dysymtab = Some(command);
+                break;
+            }
+        }
+
+        let mut exports = Vec::new();
+        if let Some(dysymtab) = dysymtab {
+            let index = dysymtab.iextdefsym.get(self.endian) as usize;
+            let number = dysymtab.nextdefsym.get(self.endian) as usize;
+            for i in index..(index.wrapping_add(number)) {
+                let symbol = self.symbols.symbol(i)?;
+                let name = symbol.name(self.endian, self.symbols.strings())?;
+                let address = symbol.n_value(self.endian).into();
+                exports.push(Export {
+                    name: ByteString(name),
+                    address,
+                });
+            }
+        }
+        Ok(exports)
     }
 
     #[inline]

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -379,6 +379,15 @@ pub trait Nlist: Debug + Pod {
         let n_type = self.n_type();
         n_type & macho::N_STAB == 0 && n_type & macho::N_TYPE != macho::N_UNDF
     }
+
+    /// Return the library ordinal.
+    ///
+    /// This is either a 1-based index into the dylib load commands,
+    /// or a special ordinal.
+    #[inline]
+    fn library_ordinal(&self, endian: Self::Endian) -> u8 {
+        (self.n_desc(endian) >> 8) as u8
+    }
 }
 
 impl<Endian: endian::Endian> Nlist for macho::Nlist32<Endian> {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::{fmt, result};
 
 use crate::common::*;
-use crate::Bytes;
+use crate::{ByteString, Bytes};
 
 mod util;
 pub use util::StringTable;
@@ -297,6 +297,50 @@ impl<'data> ObjectMapEntry<'data> {
 impl<'data> SymbolMapEntry for ObjectMapEntry<'data> {
     #[inline]
     fn address(&self) -> u64 {
+        self.address
+    }
+}
+
+/// An imported symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Import<'data> {
+    // TODO: or ordinal
+    name: ByteString<'data>,
+    library: ByteString<'data>,
+}
+
+impl<'data> Import<'data> {
+    /// The symbol name.
+    #[inline]
+    pub fn name(&self) -> &'data [u8] {
+        self.name.0
+    }
+
+    /// The name of the library to import the symbol from.
+    #[inline]
+    pub fn library(&self) -> &'data [u8] {
+        self.library.0
+    }
+}
+
+/// An exported symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Export<'data> {
+    // TODO: and ordinal?
+    name: ByteString<'data>,
+    address: u64,
+}
+
+impl<'data> Export<'data> {
+    /// The symbol name.
+    #[inline]
+    pub fn name(&self) -> &'data [u8] {
+        self.name.0
+    }
+
+    /// The symbol address.
+    #[inline]
+    pub fn address(&self) -> u64 {
         self.address
     }
 }

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -1,12 +1,13 @@
+use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
 
 use crate::read::coff::{CoffCommon, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, SymbolTable};
 use crate::read::{
-    self, Architecture, ComdatKind, Error, FileFlags, NoDynamicRelocationIterator, Object,
-    ObjectComdat, ReadError, Result, SectionIndex, SymbolIndex,
+    self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
+    Object, ObjectComdat, ReadError, Result, SectionIndex, SymbolIndex,
 };
-use crate::{pe, Bytes, LittleEndian as LE, Pod};
+use crate::{pe, ByteString, Bytes, LittleEndian as LE, Pod, U16, U32, U64};
 
 use super::{PeSection, PeSectionIterator, PeSegment, PeSegmentIterator, SectionTable};
 
@@ -64,6 +65,20 @@ impl<'data, Pe: ImageNtHeaders> PeFile<'data, Pe> {
 
     pub(super) fn section_alignment(&self) -> u64 {
         u64::from(self.nt_headers.optional_header().section_alignment())
+    }
+
+    fn data_directory(&self, id: usize) -> Option<&'data pe::ImageDataDirectory> {
+        self.data_directories
+            .get(id)
+            .filter(|d| d.size.get(LE) != 0)
+    }
+
+    fn data_at(&self, va: u32) -> Option<Bytes<'data>> {
+        self.common
+            .sections
+            .iter()
+            .filter_map(|section| section.pe_data_at(self.data, va))
+            .next()
     }
 }
 
@@ -177,6 +192,141 @@ where
 
     fn dynamic_relocations(&'file self) -> Option<NoDynamicRelocationIterator> {
         None
+    }
+
+    fn imports(&self) -> Result<Vec<Import<'data>>> {
+        let data_dir = match self.data_directory(pe::IMAGE_DIRECTORY_ENTRY_IMPORT) {
+            Some(data_dir) => data_dir,
+            None => return Ok(Vec::new()),
+        };
+        let import_data = self
+            .data_at(data_dir.virtual_address.get(LE))
+            .read_error("Invalid PE import dir virtual address")?
+            .read_bytes(data_dir.size.get(LE) as usize)
+            .read_error("Invalid PE import dir size")?;
+
+        let mut imports = Vec::new();
+        let mut import_descriptors = import_data;
+        loop {
+            let import_desc = import_descriptors
+                .read::<pe::ImageImportDescriptor>()
+                .read_error("Missing PE null import descriptor")?;
+            if import_desc.original_first_thunk.get(LE) == 0 {
+                break;
+            }
+
+            let library = self
+                .data_at(import_desc.name.get(LE))
+                .read_error("Invalid PE import descriptor name")?
+                .read_string()
+                .read_error("Invalid PE import descriptor name")?;
+
+            let thunk_va = import_desc.original_first_thunk.get(LE);
+            let mut thunk_data = self
+                .data_at(thunk_va)
+                .read_error("Invalid PE import thunk address")?;
+            loop {
+                let hint_name = if self.is_64() {
+                    let thunk = thunk_data
+                        .read::<U64<_>>()
+                        .read_error("Missing PE null import thunk")?
+                        .get(LE);
+                    if thunk == 0 {
+                        break;
+                    }
+                    if thunk & pe::IMAGE_ORDINAL_FLAG64 != 0 {
+                        // TODO: handle import by ordinal
+                        continue;
+                    }
+                    thunk as u32
+                } else {
+                    let thunk = thunk_data
+                        .read::<U32<_>>()
+                        .read_error("Missing PE null import thunk")?
+                        .get(LE);
+                    if thunk == 0 {
+                        break;
+                    }
+                    if thunk & pe::IMAGE_ORDINAL_FLAG32 != 0 {
+                        // TODO: handle import by ordinal
+                        continue;
+                    }
+                    thunk
+                };
+                let name = self
+                    .data_at(hint_name)
+                    .read_error("Invalid PE import thunk name")?
+                    .read_string_at(2)
+                    .read_error("Invalid PE import thunk name")?;
+
+                imports.push(Import {
+                    name: ByteString(name),
+                    library: ByteString(library),
+                });
+            }
+        }
+        Ok(imports)
+    }
+
+    fn exports(&self) -> Result<Vec<Export<'data>>> {
+        let data_dir = match self.data_directory(pe::IMAGE_DIRECTORY_ENTRY_EXPORT) {
+            Some(data_dir) => data_dir,
+            None => return Ok(Vec::new()),
+        };
+        let export_va = data_dir.virtual_address.get(LE);
+        let export_size = data_dir.size.get(LE);
+        let export_data = self
+            .data_at(export_va)
+            .read_error("Invalid PE export dir virtual address")?
+            .read_bytes(export_size as usize)
+            .read_error("Invalid PE export dir size")?;
+        let export_dir = export_data
+            .read_at::<pe::ImageExportDirectory>(0)
+            .read_error("Invalid PE export dir size")?;
+        let addresses = export_data
+            .read_slice_at::<U32<_>>(
+                export_dir
+                    .address_of_functions
+                    .get(LE)
+                    .wrapping_sub(export_va) as usize,
+                export_dir.number_of_functions.get(LE) as usize,
+            )
+            .read_error("Invalid PE export address table")?;
+        let number = export_dir.number_of_names.get(LE) as usize;
+        let names = export_data
+            .read_slice_at::<U32<_>>(
+                export_dir.address_of_names.get(LE).wrapping_sub(export_va) as usize,
+                number,
+            )
+            .read_error("Invalid PE export name table")?;
+        let ordinals = export_data
+            .read_slice_at::<U16<_>>(
+                export_dir
+                    .address_of_name_ordinals
+                    .get(LE)
+                    .wrapping_sub(export_va) as usize,
+                number,
+            )
+            .read_error("Invalid PE export ordinal table")?;
+
+        let mut exports = Vec::new();
+        for (name, ordinal) in names.iter().zip(ordinals.iter()) {
+            let name = export_data
+                .read_string_at(name.get(LE).wrapping_sub(export_va) as usize)
+                .read_error("Invalid PE export name entry")?;
+            let address = addresses
+                .get(ordinal.get(LE) as usize)
+                .read_error("Invalid PE export ordinal entry")?
+                .get(LE);
+            // Check for export address (vs forwarder address).
+            if address < export_va || (address - export_va) >= export_size {
+                exports.push(Export {
+                    name: ByteString(name),
+                    address: self.common.image_base.wrapping_add(address.into()),
+                })
+            }
+        }
+        Ok(exports)
     }
 
     fn has_debug_symbols(&self) -> bool {

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -258,6 +258,15 @@ impl pe::ImageSectionHeader {
         let (offset, size) = self.pe_file_range();
         data.read_bytes_at(offset as usize, size as usize)
     }
+
+    /// Return the data at the given virtual address if this section contains it.
+    pub fn pe_data_at<'data>(&self, data: Bytes<'data>, va: u32) -> Option<Bytes<'data>> {
+        let section_va = self.virtual_address.get(LE);
+        let offset = va.checked_sub(section_va)?;
+        let mut section_data = self.pe_data(data).ok()?;
+        section_data.skip(offset as usize).ok()?;
+        Some(section_data)
+    }
 }
 
 /// An iterator over the relocations in an `PeSection`.

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -2,9 +2,9 @@ use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use crate::read::{
-    self, Architecture, ComdatKind, CompressedData, FileFlags, ObjectMap, Relocation, Result,
-    SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap,
-    SymbolMapName, SymbolScope, SymbolSection,
+    self, Architecture, ComdatKind, CompressedData, Export, FileFlags, Import, ObjectMap,
+    Relocation, Result, SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex,
+    SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
 };
 use crate::Endianness;
 
@@ -165,6 +165,12 @@ pub trait Object<'data: 'file, 'file>: read::private::Sealed {
     fn object_map(&'file self) -> ObjectMap<'data> {
         ObjectMap::default()
     }
+
+    /// Get the imported symbols.
+    fn imports(&self) -> Result<Vec<Import<'data>>>;
+
+    /// Get the exported symbols.
+    fn exports(&self) -> Result<Vec<Export<'data>>>;
 
     /// Return true if the file contains debug information sections, false if not.
     fn has_debug_symbols(&self) -> bool;

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -10,10 +10,10 @@ use core::{slice, str};
 use wasmparser as wp;
 
 use crate::read::{
-    self, Architecture, ComdatKind, CompressedData, Error, FileFlags, NoDynamicRelocationIterator,
-    Object, ObjectComdat, ObjectSection, ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadError,
-    Relocation, Result, SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex,
-    SymbolKind, SymbolScope, SymbolSection,
+    self, Architecture, ComdatKind, CompressedData, Error, Export, FileFlags, Import,
+    NoDynamicRelocationIterator, Object, ObjectComdat, ObjectSection, ObjectSegment, ObjectSymbol,
+    ObjectSymbolTable, ReadError, Relocation, Result, SectionFlags, SectionIndex, SectionKind,
+    SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;
@@ -385,6 +385,16 @@ where
     #[inline]
     fn dynamic_relocations(&self) -> Option<NoDynamicRelocationIterator> {
         None
+    }
+
+    fn imports(&self) -> Result<Vec<Import<'data>>> {
+        // TODO: return entries in the import section
+        Ok(Vec::new())
+    }
+
+    fn exports(&self) -> Result<Vec<Export<'data>>> {
+        // TODO: return entries in the export section
+        Ok(Vec::new())
     }
 
     fn has_debug_symbols(&self) -> bool {


### PR DESCRIPTION
Support is as follows:
- ELF: `.dynsym` entries. If required, we could extend this to parse GNU symbol versioning as well.
- Mach-O: `LC_DYSYMTAB` entries, with support for library names if `MH_TWOLEVEL` is used.
- PE: entries from the import data directory and export data directory
- COFF: not implemented. Probably not useful since this isn't an executable.
- Wasm: not implemented until someone requests it.

Fixes #182 