### PR TITLE
Add support for more relocations

### DIFF
--- a/examples/readobj.rs
+++ b/examples/readobj.rs
@@ -648,8 +648,12 @@ mod elf {
             for relocation in relocations {
                 p.group("Relocation", |p| {
                     p.field_hex("Offset", relocation.r_offset(endian).into());
-                    p.field_enum("Type", relocation.r_type(endian), proc);
-                    let sym = relocation.r_sym(endian);
+                    p.field_enum(
+                        "Type",
+                        relocation.r_type(endian, elf.is_mips64el(endian)),
+                        proc,
+                    );
+                    let sym = relocation.r_sym(endian, elf.is_mips64el(endian));
                     p.field_string("Symbol", sym, rel_symbol(endian, symbols, sym as usize));
                     let addend = relocation.r_addend(endian).into() as u64;
                     if addend != 0 {
@@ -912,7 +916,7 @@ mod elf {
         EM_CYPRESS_M8C,
         EM_R32C,
         EM_TRIMEDIA,
-        EM_QDSP6,
+        EM_HEXAGON,
         EM_8051,
         EM_STXP7X,
         EM_NDS32,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -448,8 +448,8 @@ pub const EM_CYPRESS_M8C: u16 = 161;
 pub const EM_R32C: u16 = 162;
 /// NXP Semi. TriMedia
 pub const EM_TRIMEDIA: u16 = 163;
-/// QUALCOMM DSP6
-pub const EM_QDSP6: u16 = 164;
+/// QUALCOMM Hexagon
+pub const EM_HEXAGON: u16 = 164;
 /// Intel 8051 and variants
 pub const EM_8051: u16 = 165;
 /// STMicroelectronics STxP7x
@@ -1124,16 +1124,28 @@ pub struct Rela64<E: Endian> {
 }
 
 impl<E: Endian> Rela64<E> {
+    pub(crate) fn get_r_info(&self, endian: E, is_mips64el: bool) -> u64 {
+        let mut t = self.r_info.get(endian);
+        if is_mips64el {
+            t = (t << 32)
+                | ((t >> 8) & 0xff000000)
+                | ((t >> 24) & 0x00ff0000)
+                | ((t >> 40) & 0x0000ff00)
+                | ((t >> 56) & 0x000000ff);
+        }
+        t
+    }
+
     /// Get the `r_sym` component of the `r_info` field.
     #[inline]
-    pub fn r_sym(&self, endian: E) -> u32 {
-        (self.r_info.get(endian) >> 32) as u32
+    pub fn r_sym(&self, endian: E, is_mips64el: bool) -> u32 {
+        (self.get_r_info(endian, is_mips64el) >> 32) as u32
     }
 
     /// Get the `r_type` component of the `r_info` field.
     #[inline]
-    pub fn r_type(&self, endian: E) -> u32 {
-        (self.r_info.get(endian) & 0xffff_ffff) as u32
+    pub fn r_type(&self, endian: E, is_mips64el: bool) -> u32 {
+        (self.get_r_info(endian, is_mips64el) & 0xffff_ffff) as u32
     }
 
     /// Calculate the `r_info` field given the `r_sym` and `r_type` components.
@@ -4005,6 +4017,25 @@ pub const R_AARCH64_TLS_TPREL: u32 = 1030;
 pub const R_AARCH64_TLSDESC: u32 = 1031;
 /// STT_GNU_IFUNC relocation.
 pub const R_AARCH64_IRELATIVE: u32 = 1032;
+
+// AVR values for `Rel*::r_type`.
+
+/// Direct 32 bit
+pub const R_AVR_32: u32 = 1;
+/// Direct 16 bit
+pub const R_AVR_16: u32 = 4;
+
+// MSP430 values for `Rel*::r_type`.
+
+/// Direct 32 bit
+pub const R_MSP430_32: u32 = 1;
+/// Direct 16 bit
+pub const R_MSP430_16_BYTE: u32 = 5;
+
+// Hexagon values for `Rel*::r_type`.
+
+/// Direct 32 bit
+pub const R_HEX_32: u32 = 6;
 
 // ARM values for `Rel*::r_type`.
 

--- a/src/read/coff/relocation.rs
+++ b/src/read/coff/relocation.rs
@@ -19,6 +19,17 @@ impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|relocation| {
             let (kind, size, addend) = match self.file.header.machine.get(LE) {
+                pe::IMAGE_FILE_MACHINE_ARMNT => match relocation.typ.get(LE) {
+                    pe::IMAGE_REL_ARM_ADDR32 => (RelocationKind::Absolute, 32, 0),
+                    pe::IMAGE_REL_ARM_SECREL => (RelocationKind::SectionOffset, 32, 0),
+                    typ => (RelocationKind::Coff(typ), 0, 0),
+                },
+                pe::IMAGE_FILE_MACHINE_ARM64 => match relocation.typ.get(LE) {
+                    pe::IMAGE_REL_ARM64_ADDR32 => (RelocationKind::Absolute, 32, 0),
+                    pe::IMAGE_REL_ARM64_SECREL => (RelocationKind::SectionOffset, 32, 0),
+                    pe::IMAGE_REL_ARM64_ADDR64 => (RelocationKind::Absolute, 64, 0),
+                    typ => (RelocationKind::Coff(typ), 0, 0),
+                },
                 pe::IMAGE_FILE_MACHINE_I386 => match relocation.typ.get(LE) {
                     pe::IMAGE_REL_I386_DIR16 => (RelocationKind::Absolute, 16, 0),
                     pe::IMAGE_REL_I386_REL16 => (RelocationKind::Relative, 16, 0),

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -581,6 +581,11 @@ pub trait FileHeader: Debug + Pod {
         let strings = self.section_strings(endian, data, sections)?;
         Ok(SectionTable::new(sections, strings))
     }
+
+    /// Returns whether this is a mips64el elf file.
+    fn is_mips64el(&self, endian: Self::Endian) -> bool {
+        self.is_class_64() && self.is_little_endian() && self.e_machine(endian) == elf::EM_MIPS
+    }
 }
 
 impl<Endian: endian::Endian> FileHeader for elf::FileHeader32<Endian> {

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -221,12 +221,13 @@ fn parse_relocation<Elf: FileHeader>(
     implicit_addend: bool,
 ) -> Relocation {
     let mut encoding = RelocationEncoding::Generic;
+    let is_mips64el = header.is_mips64el(endian);
     let (kind, size) = match header.e_machine(endian) {
-        elf::EM_ARM => match reloc.r_type(endian) {
+        elf::EM_ARM => match reloc.r_type(endian, false) {
             elf::R_ARM_ABS32 => (RelocationKind::Absolute, 32),
             r_type => (RelocationKind::Elf(r_type), 0),
         },
-        elf::EM_AARCH64 => match reloc.r_type(endian) {
+        elf::EM_AARCH64 => match reloc.r_type(endian, false) {
             elf::R_AARCH64_ABS64 => (RelocationKind::Absolute, 64),
             elf::R_AARCH64_ABS32 => (RelocationKind::Absolute, 32),
             elf::R_AARCH64_ABS16 => (RelocationKind::Absolute, 16),
@@ -235,7 +236,7 @@ fn parse_relocation<Elf: FileHeader>(
             elf::R_AARCH64_PREL16 => (RelocationKind::Relative, 16),
             r_type => (RelocationKind::Elf(r_type), 0),
         },
-        elf::EM_386 => match reloc.r_type(endian) {
+        elf::EM_386 => match reloc.r_type(endian, false) {
             elf::R_386_32 => (RelocationKind::Absolute, 32),
             elf::R_386_PC32 => (RelocationKind::Relative, 32),
             elf::R_386_GOT32 => (RelocationKind::Got, 32),
@@ -248,7 +249,7 @@ fn parse_relocation<Elf: FileHeader>(
             elf::R_386_PC8 => (RelocationKind::Relative, 8),
             r_type => (RelocationKind::Elf(r_type), 0),
         },
-        elf::EM_X86_64 => match reloc.r_type(endian) {
+        elf::EM_X86_64 => match reloc.r_type(endian, false) {
             elf::R_X86_64_64 => (RelocationKind::Absolute, 64),
             elf::R_X86_64_PC32 => (RelocationKind::Relative, 32),
             elf::R_X86_64_GOT32 => (RelocationKind::Got, 32),
@@ -265,7 +266,7 @@ fn parse_relocation<Elf: FileHeader>(
             elf::R_X86_64_PC8 => (RelocationKind::Relative, 8),
             r_type => (RelocationKind::Elf(r_type), 0),
         },
-        elf::EM_S390 => match reloc.r_type(endian) {
+        elf::EM_S390 => match reloc.r_type(endian, false) {
             elf::R_390_8 => (RelocationKind::Absolute, 8),
             elf::R_390_16 => (RelocationKind::Absolute, 16),
             elf::R_390_32 => (RelocationKind::Absolute, 32),
@@ -306,9 +307,50 @@ fn parse_relocation<Elf: FileHeader>(
             }
             r_type => (RelocationKind::Elf(r_type), 0),
         },
-        _ => (RelocationKind::Elf(reloc.r_type(endian)), 0),
+        elf::EM_AVR => match reloc.r_type(endian, false) {
+            elf::R_AVR_32 => (RelocationKind::Absolute, 32),
+            elf::R_AVR_16 => (RelocationKind::Absolute, 16),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        elf::EM_MSP430 => match reloc.r_type(endian, false) {
+            elf::R_MSP430_32 => (RelocationKind::Absolute, 32),
+            elf::R_MSP430_16_BYTE => (RelocationKind::Absolute, 16),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        elf::EM_PPC => match reloc.r_type(endian, false) {
+            elf::R_PPC_ADDR32 => (RelocationKind::Absolute, 32),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        elf::EM_PPC64 => match reloc.r_type(endian, false) {
+            elf::R_PPC64_ADDR32 => (RelocationKind::Absolute, 32),
+            elf::R_PPC64_ADDR64 => (RelocationKind::Absolute, 64),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        elf::EM_RISCV => match reloc.r_type(endian, false) {
+            elf::R_RISCV_32 => (RelocationKind::Absolute, 32),
+            elf::R_RISCV_64 => (RelocationKind::Absolute, 64),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        elf::EM_SPARC | elf::EM_SPARC32PLUS | elf::EM_SPARCV9 => {
+            match reloc.r_type(endian, false) {
+                elf::R_SPARC_32 | elf::R_SPARC_UA32 => (RelocationKind::Absolute, 32),
+                elf::R_SPARC_64 | elf::R_SPARC_UA64 => (RelocationKind::Absolute, 64),
+                r_type => (RelocationKind::Elf(r_type), 0),
+            }
+        }
+        elf::EM_MIPS => match reloc.r_type(endian, is_mips64el) {
+            elf::R_MIPS_16 => (RelocationKind::Absolute, 16),
+            elf::R_MIPS_32 => (RelocationKind::Absolute, 32),
+            elf::R_MIPS_64 => (RelocationKind::Absolute, 64),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        elf::EM_HEXAGON => match reloc.r_type(endian, false) {
+            elf::R_HEX_32 => (RelocationKind::Absolute, 32),
+            r_type => (RelocationKind::Elf(r_type), 0),
+        },
+        _ => (RelocationKind::Elf(reloc.r_type(endian, false)), 0),
     };
-    let sym = reloc.r_sym(endian) as usize;
+    let sym = reloc.r_sym(endian, is_mips64el) as usize;
     let target = if sym == 0 {
         RelocationTarget::Absolute
     } else {
@@ -397,10 +439,10 @@ pub trait Rela: Debug + Pod + Clone {
     type Endian: endian::Endian;
 
     fn r_offset(&self, endian: Self::Endian) -> Self::Word;
-    fn r_info(&self, endian: Self::Endian) -> Self::Word;
+    fn r_info(&self, endian: Self::Endian, is_mips64el: bool) -> Self::Word;
     fn r_addend(&self, endian: Self::Endian) -> Self::Sword;
-    fn r_sym(&self, endian: Self::Endian) -> u32;
-    fn r_type(&self, endian: Self::Endian) -> u32;
+    fn r_sym(&self, endian: Self::Endian, is_mips64el: bool) -> u32;
+    fn r_type(&self, endian: Self::Endian, is_mips64el: bool) -> u32;
 }
 
 impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
@@ -414,7 +456,7 @@ impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
     }
 
     #[inline]
-    fn r_info(&self, endian: Self::Endian) -> Self::Word {
+    fn r_info(&self, endian: Self::Endian, _is_mips64el: bool) -> Self::Word {
         self.r_info.get(endian)
     }
 
@@ -424,12 +466,12 @@ impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
     }
 
     #[inline]
-    fn r_sym(&self, endian: Self::Endian) -> u32 {
+    fn r_sym(&self, endian: Self::Endian, _is_mips64el: bool) -> u32 {
         self.r_sym(endian)
     }
 
     #[inline]
-    fn r_type(&self, endian: Self::Endian) -> u32 {
+    fn r_type(&self, endian: Self::Endian, _is_mips64el: bool) -> u32 {
         self.r_type(endian)
     }
 }
@@ -445,8 +487,8 @@ impl<Endian: endian::Endian> Rela for elf::Rela64<Endian> {
     }
 
     #[inline]
-    fn r_info(&self, endian: Self::Endian) -> Self::Word {
-        self.r_info.get(endian)
+    fn r_info(&self, endian: Self::Endian, is_mips64el: bool) -> Self::Word {
+        self.get_r_info(endian, is_mips64el)
     }
 
     #[inline]
@@ -455,12 +497,12 @@ impl<Endian: endian::Endian> Rela for elf::Rela64<Endian> {
     }
 
     #[inline]
-    fn r_sym(&self, endian: Self::Endian) -> u32 {
-        self.r_sym(endian)
+    fn r_sym(&self, endian: Self::Endian, is_mips64el: bool) -> u32 {
+        self.r_sym(endian, is_mips64el)
     }
 
     #[inline]
-    fn r_type(&self, endian: Self::Endian) -> u32 {
-        self.r_type(endian)
+    fn r_type(&self, endian: Self::Endian, is_mips64el: bool) -> u32 {
+        self.r_type(endian, is_mips64el)
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -188,8 +188,12 @@ impl FileKind {
             }
             // TODO: more COFF machines
             #[cfg(feature = "coff")]
+            // COFF arm
+            [0xc4, 0x01, ..]
+            // COFF arm64
+            | [0x64, 0xaa, ..]
             // COFF x86
-            [0x4c, 0x01, ..]
+            | [0x4c, 0x01, ..]
             // COFF x86-64
             | [0x64, 0x86, ..] => FileKind::Coff,
             _ => return Err(Error("Unknown file magic")),


### PR DESCRIPTION
I'm currently using a vendored version of object that adds support for more relocations. Since this crate does not expose any of the raw elf data structures and only exposes a fraction of the information, vendoring is usually necessary to use this crate for platforms not fully supported by it. In particular, the Relocation object throws away information present in the underlying data.

In my version I've made incompatible changes to the public interface to support mips64el relocations. Please feel free to add these changes to the crate (possibly in a backwards compatible way) so that I can stop vendoring it. Alternatively you could expose the internal data structures which would also make vendoring unnecessary.