### PR TITLE
Add ReadRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ required-features = ["read", "write"]
 
 [[example]]
 name = "objdump"
-required-features = ["read"]
+required-features = ["read_core"]
 
 [[example]]
 name = "objectmap"

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -49,7 +49,6 @@ fn main() {
                     }
                 }
             }
-        /*
         } else if let Ok(arches) = FatHeader::parse_arch32(file) {
             println!("Format: Mach-O Fat 32");
             for arch in arches {
@@ -68,7 +67,6 @@ fn main() {
                     dump_object(data);
                 }
             }
-            */
         } else {
             dump_object(file);
         }

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -44,9 +44,8 @@ fn main() {
                     println!("{}:", String::from_utf8_lossy(member.name()));
                     // TODO: this should parse the file at an offset, instead of reading the
                     // entire member.
-                    if let Ok(data) = member.data(file) {
-                        dump_object(data);
-                    }
+                    let (offset, size) = member.file_range();
+                    dump_object(file.range(offset, size));
                 }
             }
         } else if let Ok(arches) = FatHeader::parse_arch32(file) {
@@ -54,18 +53,16 @@ fn main() {
             for arch in arches {
                 println!();
                 println!("Fat Arch: {:?}", arch.architecture());
-                if let Ok(data) = arch.data(file) {
-                    dump_object(data);
-                }
+                let (offset, size) = arch.file_range();
+                dump_object(file.range(offset, size));
             }
         } else if let Ok(arches) = FatHeader::parse_arch64(file) {
             println!("Format: Mach-O Fat 64");
             for arch in arches {
                 println!();
                 println!("Fat Arch: {:?}", arch.architecture());
-                if let Ok(data) = arch.data(file) {
-                    dump_object(data);
-                }
+                let (offset, size) = arch.file_range();
+                dump_object(file.range(offset, size));
             }
         } else {
             dump_object(file);

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "archive")]
 use object::read::archive::ArchiveFile;
+#[cfg(feature = "macho")]
 use object::read::macho::{FatArch, FatHeader};
 use object::{Object, ObjectComdat, ObjectSection, ObjectSymbol};
 use std::{env, fs, process};
@@ -23,6 +25,7 @@ fn main() {
                 continue;
             }
         };
+        /*
         let file = match unsafe { memmap::Mmap::map(&file) } {
             Ok(mmap) => mmap,
             Err(err) => {
@@ -61,10 +64,13 @@ fn main() {
         } else {
             dump_object(&*file);
         }
+        */
+        let data = object::read::ReadCache::new(file);
+        dump_object(&data);
     }
 }
 
-fn dump_object(data: &[u8]) {
+fn dump_object(data: &object::read::ReadCache<fs::File>) {
     let file = match object::File::parse(data) {
         Ok(file) => file,
         Err(err) => {

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -33,44 +33,49 @@ fn main() {
                 continue;
             }
         };
+        */
 
-        if let Ok(archive) = ArchiveFile::parse(&*file) {
+        let file = &object::read::ReadCache::new(file);
+        if let Ok(archive) = ArchiveFile::parse(file) {
             println!("Format: Archive (kind: {:?})", archive.kind());
             for member in archive.members() {
                 if let Ok(member) = member {
                     println!();
                     println!("{}:", String::from_utf8_lossy(member.name()));
-                    dump_object(member.data());
+                    // TODO: this should parse the file at an offset, instead of reading the
+                    // entire member.
+                    if let Ok(data) = member.data(file) {
+                        dump_object(data);
+                    }
                 }
             }
-        } else if let Ok(arches) = FatHeader::parse_arch32(&*file) {
+        /*
+        } else if let Ok(arches) = FatHeader::parse_arch32(file) {
             println!("Format: Mach-O Fat 32");
             for arch in arches {
                 println!();
                 println!("Fat Arch: {:?}", arch.architecture());
-                if let Ok(data) = arch.data(&*file) {
+                if let Ok(data) = arch.data(file) {
                     dump_object(data);
                 }
             }
-        } else if let Ok(arches) = FatHeader::parse_arch64(&*file) {
+        } else if let Ok(arches) = FatHeader::parse_arch64(file) {
             println!("Format: Mach-O Fat 64");
             for arch in arches {
                 println!();
                 println!("Fat Arch: {:?}", arch.architecture());
-                if let Ok(data) = arch.data(&*file) {
+                if let Ok(data) = arch.data(file) {
                     dump_object(data);
                 }
             }
+            */
         } else {
-            dump_object(&*file);
+            dump_object(file);
         }
-        */
-        let data = object::read::ReadCache::new(file);
-        dump_object(&data);
     }
 }
 
-fn dump_object(data: &object::read::ReadCache<fs::File>) {
+fn dump_object<'data, R: object::read::ReadRef<'data>>(data: R) {
     let file = match object::File::parse(data) {
         Ok(file) => file,
         Err(err) => {

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -158,9 +158,9 @@ enum FileInternal<'data, R: ReadRef<'data>> {
     #[cfg(feature = "elf")]
     Elf64(elf::ElfFile64<'data>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOFile32<'data>),
+    MachO32(macho::MachOFile32<'data, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOFile64<'data>),
+    MachO64(macho::MachOFile64<'data, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeFile32<'data, R>),
     #[cfg(feature = "pe")]
@@ -224,9 +224,9 @@ where
     type SectionIterator = SectionIterator<'data, 'file, R>;
     type Comdat = Comdat<'data, 'file, R>;
     type ComdatIterator = ComdatIterator<'data, 'file, R>;
-    type Symbol = Symbol<'data, 'file>;
-    type SymbolIterator = SymbolIterator<'data, 'file>;
-    type SymbolTable = SymbolTable<'data, 'file>;
+    type Symbol = Symbol<'data, 'file, R>;
+    type SymbolIterator = SymbolIterator<'data, 'file, R>;
+    type SymbolTable = SymbolTable<'data, 'file, R>;
     type DynamicRelocationIterator = DynamicRelocationIterator<'data, 'file>;
 
     fn architecture(&self) -> Architecture {
@@ -274,33 +274,33 @@ where
         }
     }
 
-    fn symbol_by_index(&'file self, index: SymbolIndex) -> Result<Symbol<'data, 'file>> {
+    fn symbol_by_index(&'file self, index: SymbolIndex) -> Result<Symbol<'data, 'file, R>> {
         map_inner_option!(self.inner, FileInternal, SymbolInternal, |x| x
             .symbol_by_index(index))
         .map(|inner| Symbol { inner })
     }
 
-    fn symbols(&'file self) -> SymbolIterator<'data, 'file> {
+    fn symbols(&'file self) -> SymbolIterator<'data, 'file, R> {
         SymbolIterator {
             inner: map_inner!(self.inner, FileInternal, SymbolIteratorInternal, |x| x
                 .symbols()),
         }
     }
 
-    fn symbol_table(&'file self) -> Option<SymbolTable<'data, 'file>> {
+    fn symbol_table(&'file self) -> Option<SymbolTable<'data, 'file, R>> {
         map_inner_option!(self.inner, FileInternal, SymbolTableInternal, |x| x
             .symbol_table())
         .map(|inner| SymbolTable { inner })
     }
 
-    fn dynamic_symbols(&'file self) -> SymbolIterator<'data, 'file> {
+    fn dynamic_symbols(&'file self) -> SymbolIterator<'data, 'file, R> {
         SymbolIterator {
             inner: map_inner!(self.inner, FileInternal, SymbolIteratorInternal, |x| x
                 .dynamic_symbols()),
         }
     }
 
-    fn dynamic_symbol_table(&'file self) -> Option<SymbolTable<'data, 'file>> {
+    fn dynamic_symbol_table(&'file self) -> Option<SymbolTable<'data, 'file, R>> {
         map_inner_option!(self.inner, FileInternal, SymbolTableInternal, |x| x
             .dynamic_symbol_table())
         .map(|inner| SymbolTable { inner })
@@ -390,9 +390,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSegmentIterator64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSegmentIterator32<'data, 'file>),
+    MachO32(macho::MachOSegmentIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSegmentIterator64<'data, 'file>),
+    MachO64(macho::MachOSegmentIterator64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeSegmentIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -430,9 +430,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSegment64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSegment32<'data, 'file>),
+    MachO32(macho::MachOSegment32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSegment64<'data, 'file>),
+    MachO64(macho::MachOSegment64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeSegment32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -514,9 +514,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSectionIterator64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSectionIterator32<'data, 'file>),
+    MachO32(macho::MachOSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSectionIterator64<'data, 'file>),
+    MachO64(macho::MachOSectionIterator64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -553,9 +553,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSection64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSection32<'data, 'file>),
+    MachO32(macho::MachOSection32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSection64<'data, 'file>),
+    MachO64(macho::MachOSection64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeSection32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -673,9 +673,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfComdatIterator64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOComdatIterator32<'data, 'file>),
+    MachO32(macho::MachOComdatIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOComdatIterator64<'data, 'file>),
+    MachO64(macho::MachOComdatIterator64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeComdatIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -712,9 +712,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfComdat64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOComdat32<'data, 'file>),
+    MachO32(macho::MachOComdat32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOComdat64<'data, 'file>),
+    MachO64(macho::MachOComdat64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeComdat32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -783,9 +783,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfComdatSectionIterator64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOComdatSectionIterator32<'data, 'file>),
+    MachO32(macho::MachOComdatSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOComdatSectionIterator64<'data, 'file>),
+    MachO64(macho::MachOComdatSectionIterator64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeComdatSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
@@ -804,17 +804,19 @@ impl<'data, 'file, R: ReadRef<'data>> Iterator for ComdatSectionIterator<'data, 
 
 /// A symbol table.
 #[derive(Debug)]
-pub struct SymbolTable<'data, 'file>
+pub struct SymbolTable<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
-    inner: SymbolTableInternal<'data, 'file>,
+    inner: SymbolTableInternal<'data, 'file, R>,
 }
 
 #[derive(Debug)]
-enum SymbolTableInternal<'data, 'file>
+enum SymbolTableInternal<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
     #[cfg(feature = "coff")]
     Coff(coff::CoffSymbolTable<'data, 'file>),
@@ -823,9 +825,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSymbolTable64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSymbolTable32<'data, 'file>),
+    MachO32(macho::MachOSymbolTable32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSymbolTable64<'data, 'file>),
+    MachO64(macho::MachOSymbolTable64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(coff::CoffSymbolTable<'data, 'file>),
     #[cfg(feature = "pe")]
@@ -834,11 +836,11 @@ where
     Wasm(wasm::WasmSymbolTable<'data, 'file>),
 }
 
-impl<'data, 'file> read::private::Sealed for SymbolTable<'data, 'file> {}
+impl<'data, 'file, R: ReadRef<'data>> read::private::Sealed for SymbolTable<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectSymbolTable<'data> for SymbolTable<'data, 'file> {
-    type Symbol = Symbol<'data, 'file>;
-    type SymbolIterator = SymbolIterator<'data, 'file>;
+impl<'data, 'file, R: ReadRef<'data>> ObjectSymbolTable<'data> for SymbolTable<'data, 'file, R> {
+    type Symbol = Symbol<'data, 'file, R>;
+    type SymbolIterator = SymbolIterator<'data, 'file, R>;
 
     fn symbols(&self) -> Self::SymbolIterator {
         SymbolIterator {
@@ -860,17 +862,19 @@ impl<'data, 'file> ObjectSymbolTable<'data> for SymbolTable<'data, 'file> {
 
 /// An iterator over symbol table entries.
 #[derive(Debug)]
-pub struct SymbolIterator<'data, 'file>
+pub struct SymbolIterator<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
-    inner: SymbolIteratorInternal<'data, 'file>,
+    inner: SymbolIteratorInternal<'data, 'file, R>,
 }
 
 #[derive(Debug)]
-enum SymbolIteratorInternal<'data, 'file>
+enum SymbolIteratorInternal<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
     #[cfg(feature = "coff")]
     Coff(coff::CoffSymbolIterator<'data, 'file>),
@@ -879,9 +883,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSymbolIterator64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSymbolIterator32<'data, 'file>),
+    MachO32(macho::MachOSymbolIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSymbolIterator64<'data, 'file>),
+    MachO64(macho::MachOSymbolIterator64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(coff::CoffSymbolIterator<'data, 'file>),
     #[cfg(feature = "pe")]
@@ -890,8 +894,8 @@ where
     Wasm(wasm::WasmSymbolIterator<'data, 'file>),
 }
 
-impl<'data, 'file> Iterator for SymbolIterator<'data, 'file> {
-    type Item = Symbol<'data, 'file>;
+impl<'data, 'file, R: ReadRef<'data>> Iterator for SymbolIterator<'data, 'file, R> {
+    type Item = Symbol<'data, 'file, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         next_inner!(self.inner, SymbolIteratorInternal, SymbolInternal)
@@ -900,16 +904,18 @@ impl<'data, 'file> Iterator for SymbolIterator<'data, 'file> {
 }
 
 /// A symbol table entry.
-pub struct Symbol<'data, 'file>
+pub struct Symbol<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
-    inner: SymbolInternal<'data, 'file>,
+    inner: SymbolInternal<'data, 'file, R>,
 }
 
-enum SymbolInternal<'data, 'file>
+enum SymbolInternal<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
     #[cfg(feature = "coff")]
     Coff(coff::CoffSymbol<'data, 'file>),
@@ -918,9 +924,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSymbol64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachOSymbol32<'data, 'file>),
+    MachO32(macho::MachOSymbol32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachOSymbol64<'data, 'file>),
+    MachO64(macho::MachOSymbol64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(coff::CoffSymbol<'data, 'file>),
     #[cfg(feature = "pe")]
@@ -929,7 +935,7 @@ where
     Wasm(wasm::WasmSymbol<'data, 'file>),
 }
 
-impl<'data, 'file> fmt::Debug for Symbol<'data, 'file> {
+impl<'data, 'file, R: ReadRef<'data>> fmt::Debug for Symbol<'data, 'file, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Symbol")
             .field("name", &self.name().unwrap_or("<invalid>"))
@@ -944,9 +950,9 @@ impl<'data, 'file> fmt::Debug for Symbol<'data, 'file> {
     }
 }
 
-impl<'data, 'file> read::private::Sealed for Symbol<'data, 'file> {}
+impl<'data, 'file, R: ReadRef<'data>> read::private::Sealed for Symbol<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectSymbol<'data> for Symbol<'data, 'file> {
+impl<'data, 'file, R: ReadRef<'data>> ObjectSymbol<'data> for Symbol<'data, 'file, R> {
     fn index(&self) -> SymbolIndex {
         with_inner!(self.inner, SymbolInternal, |x| x.index())
     }
@@ -1062,9 +1068,9 @@ where
     #[cfg(feature = "elf")]
     Elf64(elf::ElfSectionRelocationIterator64<'data, 'file>),
     #[cfg(feature = "macho")]
-    MachO32(macho::MachORelocationIterator32<'data, 'file>),
+    MachO32(macho::MachORelocationIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
-    MachO64(macho::MachORelocationIterator64<'data, 'file>),
+    MachO64(macho::MachORelocationIterator64<'data, 'file, R>),
     #[cfg(feature = "pe")]
     Pe32(pe::PeRelocationIterator<'data, 'file>),
     #[cfg(feature = "pe")]

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -162,9 +162,9 @@ enum FileInternal<'data, R: ReadRef<'data>> {
     #[cfg(feature = "macho")]
     MachO64(macho::MachOFile64<'data>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeFile32<'data>),
+    Pe32(pe::PeFile32<'data, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeFile64<'data>),
+    Pe64(pe::PeFile64<'data, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmFile<'data>),
 }
@@ -173,7 +173,6 @@ impl<'data, R: ReadRef<'data>> File<'data, R> {
     /// Parse the raw file data.
     pub fn parse(data: R) -> Result<Self> {
         let inner = match FileKind::parse(data)? {
-            /*
             #[cfg(feature = "elf")]
             FileKind::Elf32 => FileInternal::Elf32(elf::ElfFile32::parse(data)?),
             #[cfg(feature = "elf")]
@@ -188,9 +187,9 @@ impl<'data, R: ReadRef<'data>> File<'data, R> {
             FileKind::Pe32 => FileInternal::Pe32(pe::PeFile32::parse(data)?),
             #[cfg(feature = "pe")]
             FileKind::Pe64 => FileInternal::Pe64(pe::PeFile64::parse(data)?),
-            */
             #[cfg(feature = "coff")]
             FileKind::Coff => FileInternal::Coff(coff::CoffFile::parse(data)?),
+            #[allow(unreachable_patterns)]
             _ => return Err(Error("Unsupported file format")),
         };
         Ok(File { inner })
@@ -395,9 +394,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOSegmentIterator64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeSegmentIterator32<'data, 'file>),
+    Pe32(pe::PeSegmentIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeSegmentIterator64<'data, 'file>),
+    Pe64(pe::PeSegmentIterator64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmSegmentIterator<'data, 'file>),
 }
@@ -435,9 +434,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOSegment64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeSegment32<'data, 'file>),
+    Pe32(pe::PeSegment32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeSegment64<'data, 'file>),
+    Pe64(pe::PeSegment64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmSegment<'data, 'file>),
 }
@@ -519,9 +518,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOSectionIterator64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeSectionIterator32<'data, 'file>),
+    Pe32(pe::PeSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeSectionIterator64<'data, 'file>),
+    Pe64(pe::PeSectionIterator64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmSectionIterator<'data, 'file>),
 }
@@ -558,9 +557,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOSection64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeSection32<'data, 'file>),
+    Pe32(pe::PeSection32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeSection64<'data, 'file>),
+    Pe64(pe::PeSection64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmSection<'data, 'file>),
 }
@@ -678,9 +677,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOComdatIterator64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeComdatIterator32<'data, 'file>),
+    Pe32(pe::PeComdatIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeComdatIterator64<'data, 'file>),
+    Pe64(pe::PeComdatIterator64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmComdatIterator<'data, 'file>),
 }
@@ -717,9 +716,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOComdat64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeComdat32<'data, 'file>),
+    Pe32(pe::PeComdat32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeComdat64<'data, 'file>),
+    Pe64(pe::PeComdat64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmComdat<'data, 'file>),
 }
@@ -788,9 +787,9 @@ where
     #[cfg(feature = "macho")]
     MachO64(macho::MachOComdatSectionIterator64<'data, 'file>),
     #[cfg(feature = "pe")]
-    Pe32(pe::PeComdatSectionIterator32<'data, 'file>),
+    Pe32(pe::PeComdatSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "pe")]
-    Pe64(pe::PeComdatSectionIterator64<'data, 'file>),
+    Pe64(pe::PeComdatSectionIterator64<'data, 'file, R>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmComdatSectionIterator<'data, 'file>),
 }

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -904,7 +904,7 @@ impl<'data, 'file, R: ReadRef<'data>> Iterator for SymbolIterator<'data, 'file, 
 }
 
 /// A symbol table entry.
-pub struct Symbol<'data, 'file, R>
+pub struct Symbol<'data, 'file, R = &'data [u8]>
 where
     'data: 'file,
     R: ReadRef<'data>,

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -154,9 +154,9 @@ enum FileInternal<'data, R: ReadRef<'data>> {
     #[cfg(feature = "coff")]
     Coff(coff::CoffFile<'data, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfFile32<'data>),
+    Elf32(elf::ElfFile32<'data, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfFile64<'data>),
+    Elf64(elf::ElfFile64<'data, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOFile32<'data, R>),
     #[cfg(feature = "macho")]
@@ -227,7 +227,7 @@ where
     type Symbol = Symbol<'data, 'file, R>;
     type SymbolIterator = SymbolIterator<'data, 'file, R>;
     type SymbolTable = SymbolTable<'data, 'file, R>;
-    type DynamicRelocationIterator = DynamicRelocationIterator<'data, 'file>;
+    type DynamicRelocationIterator = DynamicRelocationIterator<'data, 'file, R>;
 
     fn architecture(&self) -> Architecture {
         with_inner!(self.inner, FileInternal, |x| x.architecture())
@@ -307,7 +307,7 @@ where
     }
 
     #[cfg(feature = "elf")]
-    fn dynamic_relocations(&'file self) -> Option<DynamicRelocationIterator<'data, 'file>> {
+    fn dynamic_relocations(&'file self) -> Option<DynamicRelocationIterator<'data, 'file, R>> {
         let inner = match self.inner {
             FileInternal::Elf32(ref elf) => {
                 DynamicRelocationIteratorInternal::Elf32(elf.dynamic_relocations()?)
@@ -321,7 +321,7 @@ where
     }
 
     #[cfg(not(feature = "elf"))]
-    fn dynamic_relocations(&'file self) -> Option<DynamicRelocationIterator<'data, 'file>> {
+    fn dynamic_relocations(&'file self) -> Option<DynamicRelocationIterator<'data, 'file, R>> {
         None
     }
 
@@ -386,9 +386,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffSegmentIterator<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfSegmentIterator32<'data, 'file>),
+    Elf32(elf::ElfSegmentIterator32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfSegmentIterator64<'data, 'file>),
+    Elf64(elf::ElfSegmentIterator64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOSegmentIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -426,9 +426,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffSegment<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfSegment32<'data, 'file>),
+    Elf32(elf::ElfSegment32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfSegment64<'data, 'file>),
+    Elf64(elf::ElfSegment64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOSegment32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -510,9 +510,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffSectionIterator<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfSectionIterator32<'data, 'file>),
+    Elf32(elf::ElfSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfSectionIterator64<'data, 'file>),
+    Elf64(elf::ElfSectionIterator64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -549,9 +549,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffSection<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfSection32<'data, 'file>),
+    Elf32(elf::ElfSection32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfSection64<'data, 'file>),
+    Elf64(elf::ElfSection64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOSection32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -669,9 +669,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffComdatIterator<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfComdatIterator32<'data, 'file>),
+    Elf32(elf::ElfComdatIterator32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfComdatIterator64<'data, 'file>),
+    Elf64(elf::ElfComdatIterator64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOComdatIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -708,9 +708,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffComdat<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfComdat32<'data, 'file>),
+    Elf32(elf::ElfComdat32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfComdat64<'data, 'file>),
+    Elf64(elf::ElfComdat64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOComdat32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -779,9 +779,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffComdatSectionIterator<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfComdatSectionIterator32<'data, 'file>),
+    Elf32(elf::ElfComdatSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfComdatSectionIterator64<'data, 'file>),
+    Elf64(elf::ElfComdatSectionIterator64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachOComdatSectionIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]
@@ -1012,28 +1012,30 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSymbol<'data> for Symbol<'data, 'fil
 
 /// An iterator over dynamic relocation entries.
 #[derive(Debug)]
-pub struct DynamicRelocationIterator<'data, 'file>
+pub struct DynamicRelocationIterator<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
-    inner: DynamicRelocationIteratorInternal<'data, 'file>,
+    inner: DynamicRelocationIteratorInternal<'data, 'file, R>,
 }
 
 #[derive(Debug)]
-enum DynamicRelocationIteratorInternal<'data, 'file>
+enum DynamicRelocationIteratorInternal<'data, 'file, R>
 where
     'data: 'file,
+    R: ReadRef<'data>,
 {
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfDynamicRelocationIterator32<'data, 'file>),
+    Elf32(elf::ElfDynamicRelocationIterator32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfDynamicRelocationIterator64<'data, 'file>),
+    Elf64(elf::ElfDynamicRelocationIterator64<'data, 'file, R>),
     // We need to always use the lifetime parameters.
     #[allow(unused)]
-    None(PhantomData<(&'data (), &'file ())>),
+    None(PhantomData<(&'data (), &'file (), R)>),
 }
 
-impl<'data, 'file> Iterator for DynamicRelocationIterator<'data, 'file> {
+impl<'data, 'file, R: ReadRef<'data>> Iterator for DynamicRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1064,9 +1066,9 @@ where
     #[cfg(feature = "coff")]
     Coff(coff::CoffRelocationIterator<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf32(elf::ElfSectionRelocationIterator32<'data, 'file>),
+    Elf32(elf::ElfSectionRelocationIterator32<'data, 'file, R>),
     #[cfg(feature = "elf")]
-    Elf64(elf::ElfSectionRelocationIterator64<'data, 'file>),
+    Elf64(elf::ElfSectionRelocationIterator64<'data, 'file, R>),
     #[cfg(feature = "macho")]
     MachO32(macho::MachORelocationIterator32<'data, 'file, R>),
     #[cfg(feature = "macho")]

--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -259,7 +259,6 @@ impl<'data> ArchiveMember<'data> {
     /// Return the file data.
     #[inline]
     pub fn data<R: ReadRef<'data>>(&self, data: R) -> read::Result<&'data [u8]> {
-        println!("{} {}", self.offset, self.size);
         data.read_bytes_at(self.offset, self.size)
             .read_error("Archive member size is too large")
     }

--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -1,7 +1,7 @@
 //! Support for archive files.
 
-use crate::read::{self, Error, ReadError};
-use crate::{archive, Bytes};
+use crate::archive;
+use crate::read::{self, Error, ReadError, ReadRef};
 
 /// The kind of archive format.
 // TODO: Gnu64 and Darwin64 (and Darwin for writing)
@@ -19,31 +19,34 @@ pub enum ArchiveKind {
 
 /// A partially parsed archive file.
 #[derive(Debug)]
-pub struct ArchiveFile<'data> {
-    data: Bytes<'data>,
+pub struct ArchiveFile<'data, R: ReadRef<'data>> {
+    data: R,
+    len: usize,
+    offset: usize,
     kind: ArchiveKind,
-    symbols: Bytes<'data>,
-    names: Bytes<'data>,
+    symbols: &'data [u8],
+    names: &'data [u8],
 }
 
-impl<'data> ArchiveFile<'data> {
+impl<'data, R: ReadRef<'data>> ArchiveFile<'data, R> {
     /// Parse the archive header and special members.
-    pub fn parse(data: &'data [u8]) -> read::Result<Self> {
-        let data = Bytes(data);
-        let mut tail = data;
-
-        let magic = tail
-            .read_bytes(archive::MAGIC.len())
+    pub fn parse(data: R) -> read::Result<Self> {
+        let len = data.len().read_error("Unknown archive length")?;
+        let mut tail = 0;
+        let magic = data
+            .read_bytes(&mut tail, archive::MAGIC.len())
             .read_error("Invalid archive size")?;
-        if magic.0 != &archive::MAGIC[..] {
+        if magic != &archive::MAGIC[..] {
             return Err(Error("Unsupported archive identifier"));
         }
 
         let mut file = ArchiveFile {
-            data: tail,
+            data,
+            offset: tail,
+            len,
             kind: ArchiveKind::Unknown,
-            symbols: Bytes(&[]),
-            names: Bytes(&[]),
+            symbols: &[],
+            names: &[],
         };
 
         // The first few members may be special, so parse them.
@@ -56,46 +59,46 @@ impl<'data> ArchiveFile<'data> {
         // - "//": names table
         // BSD has:
         // - "__.SYMDEF" or "__.SYMDEF SORTED": symbol table (optional)
-        if !tail.is_empty() {
-            let member = ArchiveMember::parse(&mut tail, Bytes(&[]))?;
+        if tail < len {
+            let member = ArchiveMember::parse(data, &mut tail, &[])?;
             if member.name == b"/" {
                 // GNU symbol table (unless we later determine this is COFF).
                 file.kind = ArchiveKind::Gnu;
-                file.symbols = member.data;
-                file.data = tail;
+                file.symbols = member.data(data)?;
+                file.offset = tail;
 
-                if !tail.is_empty() {
-                    let member = ArchiveMember::parse(&mut tail, Bytes(&[]))?;
+                if tail < len {
+                    let member = ArchiveMember::parse(data, &mut tail, &[])?;
                     if member.name == b"/" {
                         // COFF linker member.
                         file.kind = ArchiveKind::Coff;
-                        file.symbols = member.data;
-                        file.data = tail;
+                        file.symbols = member.data(data)?;
+                        file.offset = tail;
 
-                        if !tail.is_empty() {
-                            let member = ArchiveMember::parse(&mut tail, Bytes(&[]))?;
+                        if tail < len {
+                            let member = ArchiveMember::parse(data, &mut tail, &[])?;
                             if member.name == b"//" {
                                 // COFF names table.
-                                file.names = member.data;
-                                file.data = tail;
+                                file.names = member.data(data)?;
+                                file.offset = tail;
                             }
                         }
                     } else if member.name == b"//" {
                         // GNU names table.
-                        file.names = member.data;
-                        file.data = tail;
+                        file.names = member.data(data)?;
+                        file.offset = tail;
                     }
                 }
             } else if member.name == b"//" {
                 // GNU names table.
                 file.kind = ArchiveKind::Gnu;
-                file.names = member.data;
-                file.data = tail;
+                file.names = member.data(data)?;
+                file.offset = tail;
             } else if member.name == b"__.SYMDEF" || member.name == b"__.SYMDEF SORTED" {
                 // BSD symbol table.
                 file.kind = ArchiveKind::Bsd;
-                file.symbols = member.data;
-                file.data = tail;
+                file.symbols = member.data(data)?;
+                file.offset = tail;
             } else {
                 // TODO: This could still be a BSD file. We leave this as unknown for now.
             }
@@ -113,9 +116,11 @@ impl<'data> ArchiveFile<'data> {
     ///
     /// This does not return special members.
     #[inline]
-    pub fn members(&self) -> ArchiveMemberIterator<'data> {
+    pub fn members(&self) -> ArchiveMemberIterator<'data, R> {
         ArchiveMemberIterator {
             data: self.data,
+            offset: self.offset,
+            len: self.len,
             names: self.names,
         }
     }
@@ -123,21 +128,23 @@ impl<'data> ArchiveFile<'data> {
 
 /// An iterator over the members of an archive.
 #[derive(Debug)]
-pub struct ArchiveMemberIterator<'data> {
-    data: Bytes<'data>,
-    names: Bytes<'data>,
+pub struct ArchiveMemberIterator<'data, R: ReadRef<'data>> {
+    data: R,
+    offset: usize,
+    len: usize,
+    names: &'data [u8],
 }
 
-impl<'data> Iterator for ArchiveMemberIterator<'data> {
+impl<'data, R: ReadRef<'data>> Iterator for ArchiveMemberIterator<'data, R> {
     type Item = read::Result<ArchiveMember<'data>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.data.is_empty() {
+        if self.offset >= self.len {
             return None;
         }
-        let member = ArchiveMember::parse(&mut self.data, self.names);
+        let member = ArchiveMember::parse(self.data, &mut self.offset, self.names);
         if member.is_err() {
-            self.data = Bytes(&[]);
+            self.offset = self.len;
         }
         Some(member)
     }
@@ -148,29 +155,35 @@ impl<'data> Iterator for ArchiveMemberIterator<'data> {
 pub struct ArchiveMember<'data> {
     header: &'data archive::Header,
     name: &'data [u8],
-    data: Bytes<'data>,
+    offset: usize,
+    size: usize,
 }
 
 impl<'data> ArchiveMember<'data> {
     /// Parse the archive member header, name, and file data.
     ///
     /// This reads the extended name (if any) and adjusts the file size.
-    fn parse(data: &mut Bytes<'data>, names: Bytes<'data>) -> read::Result<Self> {
+    fn parse<R: ReadRef<'data>>(
+        data: R,
+        offset: &mut usize,
+        names: &'data [u8],
+    ) -> read::Result<Self> {
         let header = data
-            .read::<archive::Header>()
+            .read::<archive::Header>(offset)
             .read_error("Invalid archive member header")?;
         if header.terminator != archive::TERMINATOR {
             return Err(Error("Invalid archive terminator"));
         }
 
-        let size =
+        let mut file_offset = *offset;
+        let file_size =
             parse_usize_digits(&header.size, 10).read_error("Invalid archive member size")?;
-        let mut file_data = data
-            .read_bytes(size)
+        *offset = offset
+            .checked_add(file_size)
             .read_error("Archive member size is too large")?;
         // Entries are padded to an even number of bytes.
-        if (size & 1) != 0 {
-            data.skip(1).ok();
+        if (file_size & 1) != 0 {
+            *offset = offset.saturating_add(1);
         }
 
         let name = if header.name[0] == b'/' && (header.name[1] as char).is_digit(10) {
@@ -179,7 +192,7 @@ impl<'data> ArchiveMember<'data> {
                 .read_error("Invalid archive extended name offset")?
         } else if &header.name[..3] == b"#1/" && (header.name[3] as char).is_digit(10) {
             // Read file name from the start of the file data.
-            parse_bsd_extended_name(&header.name[3..], &mut file_data)
+            parse_bsd_extended_name(&header.name[3..], data, &mut file_offset)
                 .read_error("Invalid archive extended name length")?
         } else if header.name[0] == b'/' {
             let name_len =
@@ -195,7 +208,8 @@ impl<'data> ArchiveMember<'data> {
         Ok(ArchiveMember {
             header,
             name,
-            data: file_data,
+            offset: file_offset,
+            size: file_size,
         })
     }
 
@@ -237,10 +251,16 @@ impl<'data> ArchiveMember<'data> {
         parse_usize_digits(&self.header.mode, 8)
     }
 
+    /// Return the offset and size of the file data.
+    pub fn file_range(&self) -> (usize, usize) {
+        (self.offset, self.size)
+    }
+
     /// Return the file data.
     #[inline]
-    pub fn data(&self) -> &'data [u8] {
-        self.data.0
+    pub fn data<R: ReadRef<'data>>(&self, data: R) -> read::Result<&'data [u8]> {
+        data.read_bytes_at(self.offset, self.size)
+            .read_error("Archive member size is too large")
     }
 }
 
@@ -264,31 +284,29 @@ fn parse_usize_digits(digits: &[u8], radix: u32) -> Option<usize> {
     Some(result)
 }
 
-fn parse_sysv_extended_name<'data>(
-    digits: &[u8],
-    mut names: Bytes<'data>,
-) -> Result<&'data [u8], ()> {
+fn parse_sysv_extended_name<'data>(digits: &[u8], names: &'data [u8]) -> Result<&'data [u8], ()> {
     let offset = parse_usize_digits(digits, 10).ok_or(())?;
-    names.skip(offset)?;
-    let name = match names.0.iter().position(|&x| x == b'/' || x == 0) {
-        Some(len) => names.read_bytes(len)?,
-        None => names,
+    let name_data = names.get(offset..).ok_or(())?;
+    let name = match name_data.iter().position(|&x| x == b'/' || x == 0) {
+        Some(len) => &name_data[..len],
+        None => name_data,
     };
-    Ok(name.0)
+    Ok(name)
 }
 
 /// Modifies `data` to start after the extended name.
-fn parse_bsd_extended_name<'data>(
+fn parse_bsd_extended_name<'data, R: ReadRef<'data>>(
     digits: &[u8],
-    data: &mut Bytes<'data>,
+    data: R,
+    offset: &mut usize,
 ) -> Result<&'data [u8], ()> {
     let len = parse_usize_digits(digits, 10).ok_or(())?;
-    let mut name_data = data.read_bytes(len)?;
-    let name = match name_data.0.iter().position(|&x| x == 0) {
-        Some(len) => name_data.read_bytes(len)?,
+    let name_data = data.read_bytes(offset, len)?;
+    let name = match name_data.iter().position(|&x| x == 0) {
+        Some(len) => &name_data[..len],
         None => name_data,
     };
-    Ok(name.0)
+    Ok(name)
 }
 
 #[cfg(test)]

--- a/src/read/coff/comdat.rs
+++ b/src/read/coff/comdat.rs
@@ -2,22 +2,24 @@ use core::str;
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
-use crate::read::{self, ComdatKind, ObjectComdat, ReadError, Result, SectionIndex, SymbolIndex};
+use crate::read::{
+    self, ComdatKind, ObjectComdat, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
+};
 
 use super::CoffFile;
 
 /// An iterator over the COMDAT section groups of a `CoffFile`.
 #[derive(Debug)]
-pub struct CoffComdatIterator<'data, 'file>
+pub struct CoffComdatIterator<'data, 'file, R: ReadRef + ?Sized>
 where
     'data: 'file,
 {
-    pub(super) file: &'file CoffFile<'data>,
+    pub(super) file: &'file CoffFile<'data, R>,
     pub(super) index: usize,
 }
 
-impl<'data, 'file> Iterator for CoffComdatIterator<'data, 'file> {
-    type Item = CoffComdat<'data, 'file>;
+impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffComdatIterator<'data, 'file, R> {
+    type Item = CoffComdat<'data, 'file, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -33,22 +35,22 @@ impl<'data, 'file> Iterator for CoffComdatIterator<'data, 'file> {
 
 /// A COMDAT section group of a `CoffFile`.
 #[derive(Debug)]
-pub struct CoffComdat<'data, 'file>
+pub struct CoffComdat<'data, 'file, R: ReadRef + ?Sized>
 where
     'data: 'file,
 {
-    file: &'file CoffFile<'data>,
+    file: &'file CoffFile<'data, R>,
     symbol_index: SymbolIndex,
     symbol: &'data pe::ImageSymbol,
     selection: u8,
 }
 
-impl<'data, 'file> CoffComdat<'data, 'file> {
+impl<'data, 'file, R: ReadRef + ?Sized> CoffComdat<'data, 'file, R> {
     fn parse(
-        file: &'file CoffFile<'data>,
+        file: &'file CoffFile<'data, R>,
         section_symbol: &'data pe::ImageSymbol,
         index: usize,
-    ) -> Option<CoffComdat<'data, 'file>> {
+    ) -> Option<CoffComdat<'data, 'file, R>> {
         // Must be a section symbol.
         if !section_symbol.has_aux_section() {
             return None;
@@ -82,10 +84,10 @@ impl<'data, 'file> CoffComdat<'data, 'file> {
     }
 }
 
-impl<'data, 'file> read::private::Sealed for CoffComdat<'data, 'file> {}
+impl<'data, 'file, R: ReadRef + ?Sized> read::private::Sealed for CoffComdat<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectComdat<'data> for CoffComdat<'data, 'file> {
-    type SectionIterator = CoffComdatSectionIterator<'data, 'file>;
+impl<'data, 'file, R: ReadRef + ?Sized> ObjectComdat<'data> for CoffComdat<'data, 'file, R> {
+    type SectionIterator = CoffComdatSectionIterator<'data, 'file, R>;
 
     #[inline]
     fn kind(&self) -> ComdatKind {
@@ -126,16 +128,16 @@ impl<'data, 'file> ObjectComdat<'data> for CoffComdat<'data, 'file> {
 
 /// An iterator over the sections in a COMDAT section group of a `CoffFile`.
 #[derive(Debug)]
-pub struct CoffComdatSectionIterator<'data, 'file>
+pub struct CoffComdatSectionIterator<'data, 'file, R: ReadRef + ?Sized>
 where
     'data: 'file,
 {
-    file: &'file CoffFile<'data>,
+    file: &'file CoffFile<'data, R>,
     section_number: u16,
     index: usize,
 }
 
-impl<'data, 'file> Iterator for CoffComdatSectionIterator<'data, 'file> {
+impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffComdatSectionIterator<'data, 'file, R> {
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/read/coff/comdat.rs
+++ b/src/read/coff/comdat.rs
@@ -10,7 +10,7 @@ use super::CoffFile;
 
 /// An iterator over the COMDAT section groups of a `CoffFile`.
 #[derive(Debug)]
-pub struct CoffComdatIterator<'data, 'file, R: ReadRef + ?Sized>
+pub struct CoffComdatIterator<'data, 'file, R: ReadRef<'data>>
 where
     'data: 'file,
 {
@@ -18,7 +18,7 @@ where
     pub(super) index: usize,
 }
 
-impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffComdatIterator<'data, 'file, R> {
+impl<'data, 'file, R: ReadRef<'data>> Iterator for CoffComdatIterator<'data, 'file, R> {
     type Item = CoffComdat<'data, 'file, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -35,7 +35,7 @@ impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffComdatIterator<'data, '
 
 /// A COMDAT section group of a `CoffFile`.
 #[derive(Debug)]
-pub struct CoffComdat<'data, 'file, R: ReadRef + ?Sized>
+pub struct CoffComdat<'data, 'file, R: ReadRef<'data>>
 where
     'data: 'file,
 {
@@ -45,7 +45,7 @@ where
     selection: u8,
 }
 
-impl<'data, 'file, R: ReadRef + ?Sized> CoffComdat<'data, 'file, R> {
+impl<'data, 'file, R: ReadRef<'data>> CoffComdat<'data, 'file, R> {
     fn parse(
         file: &'file CoffFile<'data, R>,
         section_symbol: &'data pe::ImageSymbol,
@@ -84,9 +84,9 @@ impl<'data, 'file, R: ReadRef + ?Sized> CoffComdat<'data, 'file, R> {
     }
 }
 
-impl<'data, 'file, R: ReadRef + ?Sized> read::private::Sealed for CoffComdat<'data, 'file, R> {}
+impl<'data, 'file, R: ReadRef<'data>> read::private::Sealed for CoffComdat<'data, 'file, R> {}
 
-impl<'data, 'file, R: ReadRef + ?Sized> ObjectComdat<'data> for CoffComdat<'data, 'file, R> {
+impl<'data, 'file, R: ReadRef<'data>> ObjectComdat<'data> for CoffComdat<'data, 'file, R> {
     type SectionIterator = CoffComdatSectionIterator<'data, 'file, R>;
 
     #[inline]
@@ -128,7 +128,7 @@ impl<'data, 'file, R: ReadRef + ?Sized> ObjectComdat<'data> for CoffComdat<'data
 
 /// An iterator over the sections in a COMDAT section group of a `CoffFile`.
 #[derive(Debug)]
-pub struct CoffComdatSectionIterator<'data, 'file, R: ReadRef + ?Sized>
+pub struct CoffComdatSectionIterator<'data, 'file, R: ReadRef<'data>>
 where
     'data: 'file,
 {
@@ -137,7 +137,7 @@ where
     index: usize,
 }
 
-impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffComdatSectionIterator<'data, 'file, R> {
+impl<'data, 'file, R: ReadRef<'data>> Iterator for CoffComdatSectionIterator<'data, 'file, R> {
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/read/coff/relocation.rs
+++ b/src/read/coff/relocation.rs
@@ -10,12 +10,12 @@ use crate::read::{
 use super::CoffFile;
 
 /// An iterator over the relocations in a `CoffSection`.
-pub struct CoffRelocationIterator<'data, 'file, R: ReadRef + ?Sized> {
+pub struct CoffRelocationIterator<'data, 'file, R: ReadRef<'data>> {
     pub(super) file: &'file CoffFile<'data, R>,
     pub(super) iter: slice::Iter<'data, pe::ImageRelocation>,
 }
 
-impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffRelocationIterator<'data, 'file, R> {
+impl<'data, 'file, R: ReadRef<'data>> Iterator for CoffRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -67,7 +67,7 @@ impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffRelocationIterator<'dat
     }
 }
 
-impl<'data, 'file, R: ReadRef + ?Sized> fmt::Debug for CoffRelocationIterator<'data, 'file, R> {
+impl<'data, 'file, R: ReadRef<'data>> fmt::Debug for CoffRelocationIterator<'data, 'file, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoffRelocationIterator").finish()
     }

--- a/src/read/coff/relocation.rs
+++ b/src/read/coff/relocation.rs
@@ -3,17 +3,19 @@ use core::slice;
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
-use crate::read::{Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex};
+use crate::read::{
+    ReadRef, Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex,
+};
 
 use super::CoffFile;
 
 /// An iterator over the relocations in a `CoffSection`.
-pub struct CoffRelocationIterator<'data, 'file> {
-    pub(super) file: &'file CoffFile<'data>,
+pub struct CoffRelocationIterator<'data, 'file, R: ReadRef + ?Sized> {
+    pub(super) file: &'file CoffFile<'data, R>,
     pub(super) iter: slice::Iter<'data, pe::ImageRelocation>,
 }
 
-impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
+impl<'data, 'file, R: ReadRef + ?Sized> Iterator for CoffRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -65,7 +67,7 @@ impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
     }
 }
 
-impl<'data, 'file> fmt::Debug for CoffRelocationIterator<'data, 'file> {
+impl<'data, 'file, R: ReadRef + ?Sized> fmt::Debug for CoffRelocationIterator<'data, 'file, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoffRelocationIterator").finish()
     }

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -21,13 +21,12 @@ impl<'data> SectionTable<'data> {
     /// Parse the section table.
     ///
     /// `data` must be the entire file data.
-    /// `offset` must be the file offset following the optional header.
+    /// `offset` must be after the optional file header.
     pub fn parse<R: ReadRef<'data>>(
         header: &pe::ImageFileHeader,
         data: R,
         offset: usize,
     ) -> Result<Self> {
-        // TODO: maybe offset should be the `ImageFileHeader` offset.
         let sections = data
             .read_slice_at(offset, header.number_of_sections.get(LE) as usize)
             .read_error("Invalid COFF/PE section headers")?;
@@ -382,7 +381,8 @@ impl pe::ImageSectionHeader {
     /// Returns `Err` for invalid values.
     pub fn coff_data<'data, R: ReadRef<'data>>(&self, data: R) -> result::Result<Bytes<'data>, ()> {
         if let Some((offset, size)) = self.coff_file_range() {
-            data.read_bytes(offset as usize, size as usize).map(Bytes)
+            data.read_bytes_at(offset as usize, size as usize)
+                .map(Bytes)
         } else {
             Ok(Bytes(&[]))
         }

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -38,7 +38,7 @@ impl<'data> SymbolTable<'data> {
                 .read_error("Missing COFF string table")?
                 .get(LE);
             let strings = data
-                .read_bytes(offset, length as usize)
+                .read_bytes_at(offset, length as usize)
                 .read_error("Invalid COFF string table length")?;
 
             (symbols, strings)

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -24,10 +24,7 @@ pub struct SymbolTable<'data> {
 
 impl<'data> SymbolTable<'data> {
     /// Read the symbol table.
-    pub fn parse<R: ReadRef + ?Sized>(
-        header: &pe::ImageFileHeader,
-        data: &'data R,
-    ) -> Result<Self> {
+    pub fn parse<R: ReadRef<'data>>(header: &pe::ImageFileHeader, data: R) -> Result<Self> {
         // The symbol table may not be present.
         let mut offset = header.pointer_to_symbol_table.get(LE) as usize;
         let (symbols, strings) = if offset != 0 {

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -3,10 +3,10 @@ use core::fmt::Debug;
 use core::{mem, str};
 
 use crate::read::{
-    self, util, Architecture, Error, Export, FileFlags, Import, Object, ReadError, SectionIndex,
-    StringTable, SymbolIndex,
+    self, util, Architecture, Error, Export, FileFlags, Import, Object, ReadError, ReadRef,
+    SectionIndex, StringTable, SymbolIndex,
 };
-use crate::{elf, endian, ByteString, Bytes, Endian, Endianness, Pod, U32};
+use crate::{elf, endian, ByteString, Endian, Endianness, Pod, U32};
 
 use super::{
     CompressionHeader, Dyn, ElfComdat, ElfComdatIterator, ElfDynamicRelocationIterator, ElfSection,
@@ -16,17 +16,17 @@ use super::{
 };
 
 /// A 32-bit ELF object file.
-pub type ElfFile32<'data, Endian = Endianness> = ElfFile<'data, elf::FileHeader32<Endian>>;
+pub type ElfFile32<'data, R, Endian = Endianness> = ElfFile<'data, elf::FileHeader32<Endian>, R>;
 /// A 64-bit ELF object file.
-pub type ElfFile64<'data, Endian = Endianness> = ElfFile<'data, elf::FileHeader64<Endian>>;
+pub type ElfFile64<'data, R, Endian = Endianness> = ElfFile<'data, elf::FileHeader64<Endian>, R>;
 
 /// A partially parsed ELF file.
 ///
 /// Most of the functionality of this type is provided by the `Object` trait implementation.
 #[derive(Debug)]
-pub struct ElfFile<'data, Elf: FileHeader> {
+pub struct ElfFile<'data, Elf: FileHeader, R: ReadRef<'data>> {
     pub(super) endian: Elf::Endian,
-    pub(super) data: Bytes<'data>,
+    pub(super) data: R,
     pub(super) header: &'data Elf,
     pub(super) segments: &'data [Elf::ProgramHeader],
     pub(super) sections: SectionTable<'data, Elf>,
@@ -35,10 +35,9 @@ pub struct ElfFile<'data, Elf: FileHeader> {
     pub(super) dynamic_symbols: SymbolTable<'data, Elf>,
 }
 
-impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
+impl<'data, Elf: FileHeader, R: ReadRef<'data>> ElfFile<'data, Elf, R> {
     /// Parse the raw ELF file data.
-    pub fn parse(data: &'data [u8]) -> read::Result<Self> {
-        let data = Bytes(data);
+    pub fn parse(data: R) -> read::Result<Self> {
         let header = Elf::parse(data)?;
         let endian = header.endian()?;
         let segments = header.program_headers(endian, data)?;
@@ -84,7 +83,7 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
     fn raw_section_by_name<'file>(
         &'file self,
         section_name: &str,
-    ) -> Option<ElfSection<'data, 'file, Elf>> {
+    ) -> Option<ElfSection<'data, 'file, Elf, R>> {
         self.sections
             .section_by_name(self.endian, section_name.as_bytes())
             .map(|(index, section)| ElfSection {
@@ -98,7 +97,7 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
     fn zdebug_section_by_name<'file>(
         &'file self,
         section_name: &str,
-    ) -> Option<ElfSection<'data, 'file, Elf>> {
+    ) -> Option<ElfSection<'data, 'file, Elf, R>> {
         if !section_name.starts_with(".debug_") {
             return None;
         }
@@ -109,28 +108,28 @@ impl<'data, Elf: FileHeader> ElfFile<'data, Elf> {
     fn zdebug_section_by_name<'file>(
         &'file self,
         _section_name: &str,
-    ) -> Option<ElfSection<'data, 'file, Elf>> {
+    ) -> Option<ElfSection<'data, 'file, Elf, R>> {
         None
     }
 }
 
-impl<'data, Elf: FileHeader> read::private::Sealed for ElfFile<'data, Elf> {}
+impl<'data, Elf: FileHeader, R: ReadRef<'data>> read::private::Sealed for ElfFile<'data, Elf, R> {}
 
-impl<'data, 'file, Elf> Object<'data, 'file> for ElfFile<'data, Elf>
+impl<'data, 'file, Elf, R: ReadRef<'data>> Object<'data, 'file> for ElfFile<'data, Elf, R>
 where
     'data: 'file,
     Elf: FileHeader,
 {
-    type Segment = ElfSegment<'data, 'file, Elf>;
-    type SegmentIterator = ElfSegmentIterator<'data, 'file, Elf>;
-    type Section = ElfSection<'data, 'file, Elf>;
-    type SectionIterator = ElfSectionIterator<'data, 'file, Elf>;
-    type Comdat = ElfComdat<'data, 'file, Elf>;
-    type ComdatIterator = ElfComdatIterator<'data, 'file, Elf>;
+    type Segment = ElfSegment<'data, 'file, Elf, R>;
+    type SegmentIterator = ElfSegmentIterator<'data, 'file, Elf, R>;
+    type Section = ElfSection<'data, 'file, Elf, R>;
+    type SectionIterator = ElfSectionIterator<'data, 'file, Elf, R>;
+    type Comdat = ElfComdat<'data, 'file, Elf, R>;
+    type ComdatIterator = ElfComdatIterator<'data, 'file, Elf, R>;
     type Symbol = ElfSymbol<'data, 'file, Elf>;
     type SymbolIterator = ElfSymbolIterator<'data, 'file, Elf>;
     type SymbolTable = ElfSymbolTable<'data, 'file, Elf>;
-    type DynamicRelocationIterator = ElfDynamicRelocationIterator<'data, 'file, Elf>;
+    type DynamicRelocationIterator = ElfDynamicRelocationIterator<'data, 'file, Elf, R>;
 
     fn architecture(&self) -> Architecture {
         match self.header.e_machine(self.endian) {
@@ -162,14 +161,17 @@ where
         self.header.is_class_64()
     }
 
-    fn segments(&'file self) -> ElfSegmentIterator<'data, 'file, Elf> {
+    fn segments(&'file self) -> ElfSegmentIterator<'data, 'file, Elf, R> {
         ElfSegmentIterator {
             file: self,
             iter: self.segments.iter(),
         }
     }
 
-    fn section_by_name(&'file self, section_name: &str) -> Option<ElfSection<'data, 'file, Elf>> {
+    fn section_by_name(
+        &'file self,
+        section_name: &str,
+    ) -> Option<ElfSection<'data, 'file, Elf, R>> {
         self.raw_section_by_name(section_name)
             .or_else(|| self.zdebug_section_by_name(section_name))
     }
@@ -177,7 +179,7 @@ where
     fn section_by_index(
         &'file self,
         index: SectionIndex,
-    ) -> read::Result<ElfSection<'data, 'file, Elf>> {
+    ) -> read::Result<ElfSection<'data, 'file, Elf, R>> {
         let section = self.sections.section(index.0)?;
         Ok(ElfSection {
             file: self,
@@ -186,14 +188,14 @@ where
         })
     }
 
-    fn sections(&'file self) -> ElfSectionIterator<'data, 'file, Elf> {
+    fn sections(&'file self) -> ElfSectionIterator<'data, 'file, Elf, R> {
         ElfSectionIterator {
             file: self,
             iter: self.sections.iter().enumerate(),
         }
     }
 
-    fn comdats(&'file self) -> ElfComdatIterator<'data, 'file, Elf> {
+    fn comdats(&'file self) -> ElfComdatIterator<'data, 'file, Elf, R> {
         ElfComdatIterator {
             file: self,
             iter: self.sections.iter().enumerate(),
@@ -243,7 +245,9 @@ where
         })
     }
 
-    fn dynamic_relocations(&'file self) -> Option<ElfDynamicRelocationIterator<'data, 'file, Elf>> {
+    fn dynamic_relocations(
+        &'file self,
+    ) -> Option<ElfDynamicRelocationIterator<'data, 'file, Elf, R>> {
         Some(ElfDynamicRelocationIterator {
             section_index: 1,
             file: self,
@@ -399,7 +403,7 @@ pub trait FileHeader: Debug + Pod {
     /// Read the file header.
     ///
     /// Also checks that the ident field in the file header is a supported format.
-    fn parse<'data>(data: Bytes<'data>) -> read::Result<&'data Self> {
+    fn parse<'data, R: ReadRef<'data>>(data: R) -> read::Result<&'data Self> {
         let header = data
             .read_at::<Self>(0)
             .read_error("Invalid ELF header size or alignment")?;
@@ -447,10 +451,10 @@ pub trait FileHeader: Debug + Pod {
     ///
     /// Section 0 is a special case because getting the section headers normally
     /// requires `shnum`, but `shnum` may be in the first section header.
-    fn section_0<'data>(
+    fn section_0<'data, R: ReadRef<'data>>(
         &self,
         endian: Self::Endian,
-        data: Bytes<'data>,
+        data: R,
     ) -> read::Result<Option<&'data Self::SectionHeader>> {
         let shoff: u64 = self.e_shoff(endian).into();
         if shoff == 0 {
@@ -470,7 +474,11 @@ pub trait FileHeader: Debug + Pod {
     /// Return the `e_phnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn phnum<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> read::Result<usize> {
+    fn phnum<'data, R: ReadRef<'data>>(
+        &self,
+        endian: Self::Endian,
+        data: R,
+    ) -> read::Result<usize> {
         let e_phnum = self.e_phnum(endian);
         if e_phnum < elf::PN_XNUM {
             Ok(e_phnum as usize)
@@ -485,7 +493,11 @@ pub trait FileHeader: Debug + Pod {
     /// Return the `e_shnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn shnum<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> read::Result<usize> {
+    fn shnum<'data, R: ReadRef<'data>>(
+        &self,
+        endian: Self::Endian,
+        data: R,
+    ) -> read::Result<usize> {
         let e_shnum = self.e_shnum(endian);
         if e_shnum > 0 {
             Ok(e_shnum as usize)
@@ -501,7 +513,11 @@ pub trait FileHeader: Debug + Pod {
     /// Return the `e_shstrndx` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values (including if the index is 0).
-    fn shstrndx<'data>(&self, endian: Self::Endian, data: Bytes<'data>) -> read::Result<u32> {
+    fn shstrndx<'data, R: ReadRef<'data>>(
+        &self,
+        endian: Self::Endian,
+        data: R,
+    ) -> read::Result<u32> {
         let e_shstrndx = self.e_shstrndx(endian);
         let index = if e_shstrndx != elf::SHN_XINDEX {
             e_shstrndx.into()
@@ -521,10 +537,10 @@ pub trait FileHeader: Debug + Pod {
     ///
     /// Returns `Ok(&[])` if there are no program headers.
     /// Returns `Err` for invalid values.
-    fn program_headers<'data>(
+    fn program_headers<'data, R: ReadRef<'data>>(
         &self,
         endian: Self::Endian,
-        data: Bytes<'data>,
+        data: R,
     ) -> read::Result<&'data [Self::ProgramHeader]> {
         let phoff: u64 = self.e_phoff(endian).into();
         if phoff == 0 {
@@ -549,10 +565,10 @@ pub trait FileHeader: Debug + Pod {
     ///
     /// Returns `Ok(&[])` if there are no section headers.
     /// Returns `Err` for invalid values.
-    fn section_headers<'data>(
+    fn section_headers<'data, R: ReadRef<'data>>(
         &self,
         endian: Self::Endian,
-        data: Bytes<'data>,
+        data: R,
     ) -> read::Result<&'data [Self::SectionHeader]> {
         let shoff: u64 = self.e_shoff(endian).into();
         if shoff == 0 {
@@ -574,10 +590,10 @@ pub trait FileHeader: Debug + Pod {
     }
 
     /// Return the string table for the section headers.
-    fn section_strings<'data>(
+    fn section_strings<'data, R: ReadRef<'data>>(
         &self,
         endian: Self::Endian,
-        data: Bytes<'data>,
+        data: R,
         sections: &[Self::SectionHeader],
     ) -> read::Result<StringTable<'data>> {
         if sections.is_empty() {
@@ -592,10 +608,10 @@ pub trait FileHeader: Debug + Pod {
     }
 
     /// Return the section table.
-    fn sections<'data>(
+    fn sections<'data, R: ReadRef<'data>>(
         &self,
         endian: Self::Endian,
-        data: Bytes<'data>,
+        data: R,
     ) -> read::Result<SectionTable<'data, Self>> {
         let sections = self.section_headers(endian, data)?;
         let strings = self.section_strings(endian, data, sections)?;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -66,7 +66,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> ElfFile<'data, Elf, R> {
     }
 
     /// Returns the raw data.
-    pub fn data(&self) -> Bytes<'data> {
+    pub fn data(&self) -> R {
         self.data
     }
 

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -7,7 +7,8 @@ use crate::elf;
 use crate::endian::{self, Endianness};
 use crate::pod::Pod;
 use crate::read::{
-    self, Error, Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex,
+    self, Error, ReadRef, Relocation, RelocationEncoding, RelocationKind, RelocationTarget,
+    SymbolIndex,
 };
 
 use super::{ElfFile, FileHeader, SectionHeader, SectionTable};
@@ -91,25 +92,28 @@ impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf> {
 }
 
 /// An iterator over the dynamic relocations for an `ElfFile32`.
-pub type ElfDynamicRelocationIterator32<'data, 'file, Endian = Endianness> =
-    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfDynamicRelocationIterator32<'data, 'file, R, Endian = Endianness> =
+    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// An iterator over the dynamic relocations for an `ElfFile64`.
-pub type ElfDynamicRelocationIterator64<'data, 'file, Endian = Endianness> =
-    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfDynamicRelocationIterator64<'data, 'file, R, Endian = Endianness> =
+    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// An iterator over the dynamic relocations for an `ElfFile`.
-pub struct ElfDynamicRelocationIterator<'data, 'file, Elf>
+pub struct ElfDynamicRelocationIterator<'data, 'file, Elf, R>
 where
     'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
     /// The current relocation section index.
     pub(super) section_index: usize,
-    pub(super) file: &'file ElfFile<'data, Elf>,
+    pub(super) file: &'file ElfFile<'data, Elf, R>,
     pub(super) relocations: Option<ElfRelaIterator<'data, Elf>>,
 }
 
-impl<'data, 'file, Elf: FileHeader> Iterator for ElfDynamicRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> Iterator
+    for ElfDynamicRelocationIterator<'data, 'file, Elf, R>
+{
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -149,32 +153,37 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfDynamicRelocationIterator<'d
     }
 }
 
-impl<'data, 'file, Elf: FileHeader> fmt::Debug for ElfDynamicRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> fmt::Debug
+    for ElfDynamicRelocationIterator<'data, 'file, Elf, R>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ElfDynamicRelocationIterator").finish()
     }
 }
 
 /// An iterator over the relocations for an `ElfSection32`.
-pub type ElfSectionRelocationIterator32<'data, 'file, Endian = Endianness> =
-    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfSectionRelocationIterator32<'data, 'file, R, Endian = Endianness> =
+    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// An iterator over the relocations for an `ElfSection64`.
-pub type ElfSectionRelocationIterator64<'data, 'file, Endian = Endianness> =
-    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfSectionRelocationIterator64<'data, 'file, R, Endian = Endianness> =
+    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// An iterator over the relocations for an `ElfSection`.
-pub struct ElfSectionRelocationIterator<'data, 'file, Elf>
+pub struct ElfSectionRelocationIterator<'data, 'file, Elf, R>
 where
     'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
     /// The current pointer in the chain of relocation sections.
     pub(super) section_index: usize,
-    pub(super) file: &'file ElfFile<'data, Elf>,
+    pub(super) file: &'file ElfFile<'data, Elf, R>,
     pub(super) relocations: Option<ElfRelaIterator<'data, Elf>>,
 }
 
-impl<'data, 'file, Elf: FileHeader> Iterator for ElfSectionRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> Iterator
+    for ElfSectionRelocationIterator<'data, 'file, Elf, R>
+{
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -208,7 +217,9 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfSectionRelocationIterator<'d
     }
 }
 
-impl<'data, 'file, Elf: FileHeader> fmt::Debug for ElfSectionRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> fmt::Debug
+    for ElfSectionRelocationIterator<'data, 'file, Elf, R>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ElfSectionRelocationIterator").finish()
     }

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -6,11 +6,11 @@ use core::str;
 
 use crate::elf;
 use crate::endian::{self, Endianness};
-use crate::pod::{Bytes, Pod};
+use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
-    self, ObjectSymbol, ObjectSymbolTable, ReadError, SectionIndex, SymbolFlags, SymbolIndex,
-    SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
+    self, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, SectionIndex, SymbolFlags,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
 };
 
 use super::{FileHeader, SectionHeader, SectionTable};
@@ -39,9 +39,9 @@ impl<'data, Elf: FileHeader> Default for SymbolTable<'data, Elf> {
 
 impl<'data, Elf: FileHeader> SymbolTable<'data, Elf> {
     /// Parse the given symbol table section.
-    pub fn parse(
+    pub fn parse<R: ReadRef<'data>>(
         endian: Elf::Endian,
-        data: Bytes<'data>,
+        data: R,
         sections: &SectionTable<Elf>,
         section_index: usize,
         section: &Elf::SectionHeader,

--- a/src/read/macho/fat.rs
+++ b/src/read/macho/fat.rs
@@ -1,5 +1,5 @@
-use crate::read::{Architecture, Error, ReadError, Result};
-use crate::{macho, BigEndian, Bytes, Pod};
+use crate::read::{Architecture, Error, ReadError, ReadRef, Result};
+use crate::{macho, BigEndian, Pod};
 
 pub use macho::{FatArch32, FatArch64, FatHeader};
 
@@ -7,35 +7,34 @@ impl FatHeader {
     /// Attempt to parse a fat header.
     ///
     /// Does not validate the magic value.
-    pub fn parse<'data>(file: &'data [u8]) -> Result<&'data FatHeader> {
-        let mut file = Bytes(file);
-        file.read::<FatHeader>()
+    pub fn parse<'data, R: ReadRef<'data>>(file: R) -> Result<&'data FatHeader> {
+        file.read_at::<FatHeader>(0)
             .read_error("Invalid fat header size or alignment")
     }
 
     /// Attempt to parse a fat header and 32-bit fat arches.
-    pub fn parse_arch32<'data>(file: &'data [u8]) -> Result<&'data [FatArch32]> {
-        let mut file = Bytes(file);
+    pub fn parse_arch32<'data, R: ReadRef<'data>>(file: R) -> Result<&'data [FatArch32]> {
+        let mut offset = 0;
         let header = file
-            .read::<FatHeader>()
+            .read::<FatHeader>(&mut offset)
             .read_error("Invalid fat header size or alignment")?;
         if header.magic.get(BigEndian) != macho::FAT_MAGIC {
             return Err(Error("Invalid 32-bit fat magic"));
         }
-        file.read_slice::<FatArch32>(header.nfat_arch.get(BigEndian) as usize)
+        file.read_slice::<FatArch32>(&mut offset, header.nfat_arch.get(BigEndian) as usize)
             .read_error("Invalid nfat_arch")
     }
 
     /// Attempt to parse a fat header and 64-bit fat arches.
-    pub fn parse_arch64<'data>(file: &'data [u8]) -> Result<&'data [FatArch64]> {
-        let mut file = Bytes(file);
+    pub fn parse_arch64<'data, R: ReadRef<'data>>(file: R) -> Result<&'data [FatArch64]> {
+        let mut offset = 0;
         let header = file
-            .read::<FatHeader>()
+            .read::<FatHeader>(&mut offset)
             .read_error("Invalid fat header size or alignment")?;
         if header.magic.get(BigEndian) != macho::FAT_MAGIC_64 {
             return Err(Error("Invalid 64-bit fat magic"));
         }
-        file.read_slice::<FatArch64>(header.nfat_arch.get(BigEndian) as usize)
+        file.read_slice::<FatArch64>(&mut offset, header.nfat_arch.get(BigEndian) as usize)
             .read_error("Invalid nfat_arch")
     }
 }
@@ -62,13 +61,11 @@ pub trait FatArch: Pod {
         }
     }
 
-    fn data<'data>(&self, file: &'data [u8]) -> Result<&'data [u8]> {
+    fn data<'data, R: ReadRef<'data>>(&self, file: R) -> Result<&'data [u8]> {
         let offset = self.offset().into();
         let size = self.size().into();
-        let data = Bytes(file)
-            .read_bytes_at(offset as usize, size as usize)
-            .read_error("Invalid fat arch offset or size")?;
-        Ok(data.0)
+        file.read_bytes_at(offset as usize, size as usize)
+            .read_error("Invalid fat arch offset or size")
     }
 }
 

--- a/src/read/macho/fat.rs
+++ b/src/read/macho/fat.rs
@@ -61,10 +61,13 @@ pub trait FatArch: Pod {
         }
     }
 
+    fn file_range(&self) -> (usize, usize) {
+        (self.offset().into() as usize, self.size().into() as usize)
+    }
+
     fn data<'data, R: ReadRef<'data>>(&self, file: R) -> Result<&'data [u8]> {
-        let offset = self.offset().into();
-        let size = self.size().into();
-        file.read_bytes_at(offset as usize, size as usize)
+        let (offset, size) = self.file_range();
+        file.read_bytes_at(offset, size)
             .read_error("Invalid fat arch offset or size")
     }
 }

--- a/src/read/macho/relocation.rs
+++ b/src/read/macho/relocation.rs
@@ -3,29 +3,33 @@ use core::{fmt, slice};
 use crate::endian::Endianness;
 use crate::macho;
 use crate::read::{
-    Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SectionIndex, SymbolIndex,
+    ReadRef, Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SectionIndex,
+    SymbolIndex,
 };
 
 use super::{MachHeader, MachOFile};
 
 /// An iterator over the relocations in a `MachOSection32`.
-pub type MachORelocationIterator32<'data, 'file, Endian = Endianness> =
-    MachORelocationIterator<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachORelocationIterator32<'data, 'file, R, Endian = Endianness> =
+    MachORelocationIterator<'data, 'file, macho::MachHeader32<Endian>, R>;
 /// An iterator over the relocations in a `MachOSection64`.
-pub type MachORelocationIterator64<'data, 'file, Endian = Endianness> =
-    MachORelocationIterator<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachORelocationIterator64<'data, 'file, R, Endian = Endianness> =
+    MachORelocationIterator<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// An iterator over the relocations in a `MachOSection`.
-pub struct MachORelocationIterator<'data, 'file, Mach>
+pub struct MachORelocationIterator<'data, 'file, Mach, R>
 where
     'data: 'file,
     Mach: MachHeader,
+    R: ReadRef<'data>,
 {
-    pub(super) file: &'file MachOFile<'data, Mach>,
+    pub(super) file: &'file MachOFile<'data, Mach, R>,
     pub(super) relocations: slice::Iter<'data, macho::Relocation<Mach::Endian>>,
 }
 
-impl<'data, 'file, Mach: MachHeader> Iterator for MachORelocationIterator<'data, 'file, Mach> {
+impl<'data, 'file, Mach: MachHeader, R: ReadRef<'data>> Iterator
+    for MachORelocationIterator<'data, 'file, Mach, R>
+{
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -109,7 +113,9 @@ impl<'data, 'file, Mach: MachHeader> Iterator for MachORelocationIterator<'data,
     }
 }
 
-impl<'data, 'file, Mach: MachHeader> fmt::Debug for MachORelocationIterator<'data, 'file, Mach> {
+impl<'data, 'file, Mach: MachHeader, R: ReadRef<'data>> fmt::Debug
+    for MachORelocationIterator<'data, 'file, Mach, R>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MachORelocationIterator").finish()
     }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -81,7 +81,7 @@ impl<T> ReadError<T> for Option<T> {
     target_pointer_width = "32",
     feature = "elf"
 ))]
-pub type NativeFile<'data> = elf::ElfFile32<'data>;
+pub type NativeFile<'data, R> = elf::ElfFile32<'data, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(
@@ -90,27 +90,27 @@ pub type NativeFile<'data> = elf::ElfFile32<'data>;
     target_pointer_width = "64",
     feature = "elf"
 ))]
-pub type NativeFile<'data> = elf::ElfFile64<'data>;
+pub type NativeFile<'data, R> = elf::ElfFile64<'data, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "macos", target_pointer_width = "32", feature = "macho"))]
-pub type NativeFile<'data> = macho::MachOFile32<'data>;
+pub type NativeFile<'data, R> = macho::MachOFile32<'data, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "macos", target_pointer_width = "64", feature = "macho"))]
-pub type NativeFile<'data> = macho::MachOFile64<'data>;
+pub type NativeFile<'data, R> = macho::MachOFile64<'data, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "windows", target_pointer_width = "32", feature = "pe"))]
-pub type NativeFile<'data> = pe::PeFile32<'data>;
+pub type NativeFile<'data, R> = pe::PeFile32<'data, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "windows", target_pointer_width = "64", feature = "pe"))]
-pub type NativeFile<'data> = pe::PeFile64<'data>;
+pub type NativeFile<'data, R> = pe::PeFile64<'data, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(feature = "wasm", target_arch = "wasm32", feature = "wasm"))]
-pub type NativeFile<'data> = wasm::WasmFile<'data>;
+pub type NativeFile<'data, R> = wasm::WasmFile<'data, R>;
 
 /// An object file kind.
 #[derive(Debug)]

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -154,7 +154,9 @@ pub enum FileKind {
 impl FileKind {
     /// Determine a file kind by parsing the start of the file.
     pub fn parse<'data, R: ReadRef<'data>>(data: R) -> Result<FileKind> {
-        let magic = data.read_bytes(0, 16).read_error("Could not read magic")?;
+        let magic = data
+            .read_bytes_at(0, 16)
+            .read_error("Could not read magic")?;
         if magic.len() < 16 {
             return Err(Error("File too short"));
         }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -153,7 +153,7 @@ pub enum FileKind {
 
 impl FileKind {
     /// Determine a file kind by parsing the start of the file.
-    pub fn parse<R: ReadRef + ?Sized>(data: &R) -> Result<FileKind> {
+    pub fn parse<'data, R: ReadRef<'data>>(data: R) -> Result<FileKind> {
         let magic = data.read_bytes(0, 16).read_error("Could not read magic")?;
         if magic.len() < 16 {
             return Err(Error("File too short"));

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -12,26 +12,27 @@ use crate::{pe, ByteString, Bytes, LittleEndian as LE, Pod, U16Bytes, U32Bytes, 
 use super::{PeSection, PeSectionIterator, PeSegment, PeSegmentIterator, SectionTable};
 
 /// A PE32 (32-bit) image file.
-pub type PeFile32<'data> = PeFile<'data, pe::ImageNtHeaders32>;
+pub type PeFile32<'data, R> = PeFile<'data, pe::ImageNtHeaders32, R>;
 /// A PE32+ (64-bit) image file.
-pub type PeFile64<'data> = PeFile<'data, pe::ImageNtHeaders64>;
+pub type PeFile64<'data, R> = PeFile<'data, pe::ImageNtHeaders64, R>;
 
 /// A PE object file.
 #[derive(Debug)]
-pub struct PeFile<'data, Pe: ImageNtHeaders, R: ReadRef + ?Sized = [u8]> {
+pub struct PeFile<'data, Pe: ImageNtHeaders, R: ReadRef<'data>> {
     pub(super) dos_header: &'data pe::ImageDosHeader,
     pub(super) nt_headers: &'data Pe,
     pub(super) data_directories: &'data [pe::ImageDataDirectory],
     pub(super) common: CoffCommon<'data>,
-    pub(super) data: &'data R,
+    pub(super) data: R,
 }
 
-impl<'data, Pe: ImageNtHeaders, R: ReadRef + ?Sized> PeFile<'data, Pe, R> {
+impl<'data, Pe: ImageNtHeaders, R: ReadRef<'data>> PeFile<'data, Pe, R> {
     /// Parse the raw PE file data.
-    pub fn parse(data: &'data R) -> Result<Self> {
+    pub fn parse(data: R) -> Result<Self> {
         let dos_header = pe::ImageDosHeader::parse(data)?;
-        let (nt_headers, data_directories, nt_tail) = dos_header.nt_headers::<Pe>(data)?;
-        let sections = nt_headers.sections(nt_tail)?;
+        let mut offset = dos_header.nt_headers_offset();
+        let (nt_headers, data_directories) = Pe::parse(data, &mut offset)?;
+        let sections = nt_headers.sections(data, offset)?;
         let symbols = nt_headers.symbols(data)?;
         let image_base = u64::from(nt_headers.optional_header().image_base());
 
@@ -63,19 +64,19 @@ impl<'data, Pe: ImageNtHeaders, R: ReadRef + ?Sized> PeFile<'data, Pe, R> {
     }
 }
 
-impl<'data, Pe: ImageNtHeaders> read::private::Sealed for PeFile<'data, Pe> {}
+impl<'data, Pe: ImageNtHeaders, R: ReadRef<'data>> read::private::Sealed for PeFile<'data, Pe, R> {}
 
-impl<'data, 'file, Pe> Object<'data, 'file> for PeFile<'data, Pe>
+impl<'data, 'file, Pe, R: ReadRef<'data>> Object<'data, 'file> for PeFile<'data, Pe, R>
 where
     'data: 'file,
     Pe: ImageNtHeaders,
 {
-    type Segment = PeSegment<'data, 'file, Pe>;
-    type SegmentIterator = PeSegmentIterator<'data, 'file, Pe>;
-    type Section = PeSection<'data, 'file, Pe>;
-    type SectionIterator = PeSectionIterator<'data, 'file, Pe>;
-    type Comdat = PeComdat<'data, 'file, Pe>;
-    type ComdatIterator = PeComdatIterator<'data, 'file, Pe>;
+    type Segment = PeSegment<'data, 'file, Pe, R>;
+    type SegmentIterator = PeSegmentIterator<'data, 'file, Pe, R>;
+    type Section = PeSection<'data, 'file, Pe, R>;
+    type SectionIterator = PeSectionIterator<'data, 'file, Pe, R>;
+    type Comdat = PeComdat<'data, 'file, Pe, R>;
+    type ComdatIterator = PeComdatIterator<'data, 'file, Pe, R>;
     type Symbol = CoffSymbol<'data, 'file>;
     type SymbolIterator = CoffSymbolIterator<'data, 'file>;
     type SymbolTable = CoffSymbolTable<'data, 'file>;
@@ -101,14 +102,14 @@ where
         self.nt_headers.is_type_64()
     }
 
-    fn segments(&'file self) -> PeSegmentIterator<'data, 'file, Pe> {
+    fn segments(&'file self) -> PeSegmentIterator<'data, 'file, Pe, R> {
         PeSegmentIterator {
             file: self,
             iter: self.common.sections.iter(),
         }
     }
 
-    fn section_by_name(&'file self, section_name: &str) -> Option<PeSection<'data, 'file, Pe>> {
+    fn section_by_name(&'file self, section_name: &str) -> Option<PeSection<'data, 'file, Pe, R>> {
         self.common
             .sections
             .section_by_name(self.common.symbols.strings(), section_name.as_bytes())
@@ -119,7 +120,10 @@ where
             })
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Result<PeSection<'data, 'file, Pe>> {
+    fn section_by_index(
+        &'file self,
+        index: SectionIndex,
+    ) -> Result<PeSection<'data, 'file, Pe, R>> {
         let section = self.common.sections.section(index.0)?;
         Ok(PeSection {
             file: self,
@@ -128,14 +132,14 @@ where
         })
     }
 
-    fn sections(&'file self) -> PeSectionIterator<'data, 'file, Pe> {
+    fn sections(&'file self) -> PeSectionIterator<'data, 'file, Pe, R> {
         PeSectionIterator {
             file: self,
             iter: self.common.sections.iter().enumerate(),
         }
     }
 
-    fn comdats(&'file self) -> PeComdatIterator<'data, 'file, Pe> {
+    fn comdats(&'file self) -> PeComdatIterator<'data, 'file, Pe, R> {
         PeComdatIterator { file: self }
     }
 
@@ -316,18 +320,22 @@ where
 }
 
 /// An iterator over the COMDAT section groups of a `PeFile32`.
-pub type PeComdatIterator32<'data, 'file> = PeComdatIterator<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeComdatIterator32<'data, 'file, R> =
+    PeComdatIterator<'data, 'file, pe::ImageNtHeaders32, R>;
 /// An iterator over the COMDAT section groups of a `PeFile64`.
-pub type PeComdatIterator64<'data, 'file> = PeComdatIterator<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeComdatIterator64<'data, 'file, R> =
+    PeComdatIterator<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// An iterator over the COMDAT section groups of a `PeFile`.
 #[derive(Debug)]
-pub struct PeComdatIterator<'data, 'file, Pe: ImageNtHeaders> {
-    file: &'file PeFile<'data, Pe>,
+pub struct PeComdatIterator<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> {
+    file: &'file PeFile<'data, Pe, R>,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeComdatIterator<'data, 'file, Pe> {
-    type Item = PeComdat<'data, 'file, Pe>;
+impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> Iterator
+    for PeComdatIterator<'data, 'file, Pe, R>
+{
+    type Item = PeComdat<'data, 'file, Pe, R>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -336,20 +344,25 @@ impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeComdatIterator<'data, 'fil
 }
 
 /// A COMDAT section group of a `PeFile32`.
-pub type PeComdat32<'data, 'file> = PeComdat<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeComdat32<'data, 'file, R> = PeComdat<'data, 'file, pe::ImageNtHeaders32, R>;
 /// A COMDAT section group of a `PeFile64`.
-pub type PeComdat64<'data, 'file> = PeComdat<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeComdat64<'data, 'file, R> = PeComdat<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// A COMDAT section group of a `PeFile`.
 #[derive(Debug)]
-pub struct PeComdat<'data, 'file, Pe: ImageNtHeaders> {
-    file: &'file PeFile<'data, Pe>,
+pub struct PeComdat<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> {
+    file: &'file PeFile<'data, Pe, R>,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> read::private::Sealed for PeComdat<'data, 'file, Pe> {}
+impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> read::private::Sealed
+    for PeComdat<'data, 'file, Pe, R>
+{
+}
 
-impl<'data, 'file, Pe: ImageNtHeaders> ObjectComdat<'data> for PeComdat<'data, 'file, Pe> {
-    type SectionIterator = PeComdatSectionIterator<'data, 'file, Pe>;
+impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> ObjectComdat<'data>
+    for PeComdat<'data, 'file, Pe, R>
+{
+    type SectionIterator = PeComdatSectionIterator<'data, 'file, Pe, R>;
 
     #[inline]
     fn kind(&self) -> ComdatKind {
@@ -373,22 +386,24 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectComdat<'data> for PeComdat<'data, '
 }
 
 /// An iterator over the sections in a COMDAT section group of a `PeFile32`.
-pub type PeComdatSectionIterator32<'data, 'file> =
-    PeComdatSectionIterator<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeComdatSectionIterator32<'data, 'file, R> =
+    PeComdatSectionIterator<'data, 'file, pe::ImageNtHeaders32, R>;
 /// An iterator over the sections in a COMDAT section group of a `PeFile64`.
-pub type PeComdatSectionIterator64<'data, 'file> =
-    PeComdatSectionIterator<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeComdatSectionIterator64<'data, 'file, R> =
+    PeComdatSectionIterator<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// An iterator over the sections in a COMDAT section group of a `PeFile`.
 #[derive(Debug)]
-pub struct PeComdatSectionIterator<'data, 'file, Pe: ImageNtHeaders>
+pub struct PeComdatSectionIterator<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>>
 where
     'data: 'file,
 {
-    file: &'file PeFile<'data, Pe>,
+    file: &'file PeFile<'data, Pe, R>,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeComdatSectionIterator<'data, 'file, Pe> {
+impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> Iterator
+    for PeComdatSectionIterator<'data, 'file, Pe, R>
+{
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -400,7 +415,7 @@ impl pe::ImageDosHeader {
     /// Read the DOS header.
     ///
     /// Also checks that the `e_magic` field in the header is valid.
-    pub fn parse<'data, R: ReadRef + ?Sized>(data: &'data R) -> read::Result<&'data Self> {
+    pub fn parse<'data, R: ReadRef<'data>>(data: R) -> read::Result<&'data Self> {
         // DOS header comes first.
         let dos_header = data
             .read_at::<pe::ImageDosHeader>(0)
@@ -411,18 +426,10 @@ impl pe::ImageDosHeader {
         Ok(dos_header)
     }
 
-    /// Read the NT headers, including the data directories.
-    ///
-    /// The given data must be for the entire file.  Returns the data following the NT headers,
-    /// which will contain the section headers.
-    ///
-    /// Also checks that the `signature` and `magic` fields in the headers are valid.
+    /// Return the file offset of the NT headers.
     #[inline]
-    pub fn nt_headers<'data, Pe: ImageNtHeaders>(
-        &self,
-        data: Bytes<'data>,
-    ) -> read::Result<(&'data Pe, &'data [pe::ImageDataDirectory], Bytes<'data>)> {
-        Pe::parse(self, data)
+    pub fn nt_headers_offset(&self) -> usize {
+        self.e_lfanew.get(LE) as usize
     }
 }
 
@@ -430,14 +437,14 @@ impl pe::ImageDosHeader {
 ///
 /// It can be useful to know this magic value before trying to
 /// fully parse the NT headers.
-pub fn optional_header_magic(data: &[u8]) -> Result<u16> {
-    let data = Bytes(data);
+pub fn optional_header_magic<'data, R: ReadRef<'data>>(data: R) -> Result<u16> {
     let dos_header = pe::ImageDosHeader::parse(data)?;
     // NT headers are at an offset specified in the DOS header.
+    let offset = dos_header.nt_headers_offset();
     // It doesn't matter which NT header type is used for the purpose
     // of reading the optional header magic.
     let nt_headers = data
-        .read_at::<pe::ImageNtHeaders32>(dos_header.e_lfanew.get(LE) as usize)
+        .read_at::<pe::ImageNtHeaders32>(offset)
         .read_error("Invalid NT headers offset, size, or alignment")?;
     if nt_headers.signature() != pe::IMAGE_NT_SIGNATURE {
         return Err(Error("Invalid PE magic"));
@@ -471,22 +478,20 @@ pub trait ImageNtHeaders: Debug + Pod {
 
     /// Read the NT headers, including the data directories.
     ///
-    /// The DOS header is required to determine the NT headers offset.
+    /// The given data must be for the entire file.
     ///
-    /// The given data must be for the entire file.  Returns the data following the NT headers,
-    /// which will contain the section headers.
+    /// `offset` must be the file header offset. It is updated to point after the optional header,
+    /// which is where the section headers are located.
     ///
     /// Also checks that the `signature` and `magic` fields in the headers are valid.
-    fn parse<'data>(
-        dos_header: &pe::ImageDosHeader,
-        mut data: Bytes<'data>,
-    ) -> read::Result<(&'data Self, &'data [pe::ImageDataDirectory], Bytes<'data>)> {
-        data.skip(dos_header.e_lfanew.get(LE) as usize)
-            .read_error("Invalid PE headers offset")?;
+    fn parse<'data, R: ReadRef<'data>>(
+        data: R,
+        offset: &mut usize,
+    ) -> read::Result<(&'data Self, &'data [pe::ImageDataDirectory])> {
         // Note that this does not include the data directories in the optional header.
         let nt_headers = data
-            .read::<Self>()
-            .read_error("Invalid PE headers size or alignment")?;
+            .read::<Self>(offset)
+            .read_error("Invalid PE headers offset or size")?;
         if nt_headers.signature() != pe::IMAGE_NT_SIGNATURE {
             return Err(Error("Invalid PE magic"));
         }
@@ -499,29 +504,37 @@ pub trait ImageNtHeaders: Debug + Pod {
             as usize)
             .checked_sub(mem::size_of::<Self::ImageOptionalHeader>())
             .read_error("PE optional header size is too small")?;
-        let mut optional_data = data
-            .read_bytes(optional_data_size)
+        let optional_data = data
+            .read_bytes(offset, optional_data_size)
             .read_error("Invalid PE optional header size")?;
         let data_directories = optional_data
-            .read_slice(nt_headers.optional_header().number_of_rva_and_sizes() as usize)
+            .read_slice_at(
+                0,
+                nt_headers.optional_header().number_of_rva_and_sizes() as usize,
+            )
             .read_error("Invalid PE number of RVA and sizes")?;
 
-        Ok((nt_headers, data_directories, data))
+        Ok((nt_headers, data_directories))
     }
 
     /// Read the section table.
     ///
-    /// `nt_tail` must be the data following the NT headers.
+    /// `data` must be the entire file data.
+    /// `offset` must be after the optional file header.
     #[inline]
-    fn sections<'data>(&self, nt_tail: Bytes<'data>) -> read::Result<SectionTable<'data>> {
-        SectionTable::parse(self.file_header(), nt_tail)
+    fn sections<'data, R: ReadRef<'data>>(
+        &self,
+        data: R,
+        offset: usize,
+    ) -> read::Result<SectionTable<'data>> {
+        SectionTable::parse(self.file_header(), data, offset)
     }
 
     /// Read the symbol table and string table.
     ///
     /// `data` must be the entire file data.
     #[inline]
-    fn symbols<'data>(&self, data: Bytes<'data>) -> read::Result<SymbolTable<'data>> {
+    fn symbols<'data, R: ReadRef<'data>>(&self, data: R) -> read::Result<SymbolTable<'data>> {
         SymbolTable::parse(self.file_header(), data)
     }
 }
@@ -917,9 +930,9 @@ impl ImageOptionalHeader for pe::ImageOptionalHeader64 {
 
 impl pe::ImageDataDirectory {
     /// Get the data referenced by this directory entry.
-    pub fn data<'data>(
+    pub fn data<'data, R: ReadRef<'data>>(
         &self,
-        data: Bytes<'data>,
+        data: R,
         sections: &SectionTable<'data>,
     ) -> Result<Bytes<'data>> {
         sections

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -188,7 +188,7 @@ impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> read::private::Sealed
 impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> ObjectSection<'data>
     for PeSection<'data, 'file, Pe, R>
 {
-    type RelocationIterator = PeRelocationIterator<'data, 'file>;
+    type RelocationIterator = PeRelocationIterator<'data, 'file, R>;
 
     #[inline]
     fn index(&self) -> SectionIndex {
@@ -256,8 +256,8 @@ impl<'data, 'file, Pe: ImageNtHeaders, R: ReadRef<'data>> ObjectSection<'data>
         self.section.kind()
     }
 
-    fn relocations(&self) -> PeRelocationIterator<'data, 'file> {
-        PeRelocationIterator::default()
+    fn relocations(&self) -> PeRelocationIterator<'data, 'file, R> {
+        PeRelocationIterator(PhantomData)
     }
 
     fn flags(&self) -> SectionFlags {
@@ -305,10 +305,10 @@ impl pe::ImageSectionHeader {
 }
 
 /// An iterator over the relocations in an `PeSection`.
-#[derive(Debug, Default)]
-pub struct PeRelocationIterator<'data, 'file>(PhantomData<(&'data (), &'file ())>);
+#[derive(Debug)]
+pub struct PeRelocationIterator<'data, 'file, R>(PhantomData<(&'data (), &'file (), R)>);
 
-impl<'data, 'file> Iterator for PeRelocationIterator<'data, 'file> {
+impl<'data, 'file, R> Iterator for PeRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -1,0 +1,98 @@
+use crate::pod::{from_bytes, slice_from_bytes, Pod};
+use std::boxed::Box;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::mem;
+
+/// TODO
+pub trait ReadRef {
+    /// TODO
+    fn read_bytes(&self, offset: usize, size: usize) -> Result<&[u8], ()>;
+
+    /// TODO
+    fn read<T: Pod>(&self, offset: &mut usize) -> Result<&T, ()> {
+        let size = mem::size_of::<T>();
+        let bytes = self.read_bytes(*offset, size)?;
+        let (t, _) = from_bytes(bytes)?;
+        *offset = offset.wrapping_add(size);
+        Ok(t)
+    }
+
+    /// TODO
+    fn read_at<T: Pod>(&self, mut offset: usize) -> Result<&T, ()> {
+        self.read(&mut offset)
+    }
+
+    /// TODO
+    fn read_slice<T: Pod>(&self, offset: &mut usize, count: usize) -> Result<&[T], ()> {
+        let size = count.checked_mul(mem::size_of::<T>()).ok_or(())?;
+        let bytes = self.read_bytes(*offset, size)?;
+        let (t, _) = slice_from_bytes(bytes, count)?;
+        *offset = offset.wrapping_add(size);
+        Ok(t)
+    }
+
+    /// TODO
+    fn read_slice_at<T: Pod>(&self, mut offset: usize, count: usize) -> Result<&[T], ()> {
+        self.read_slice(&mut offset, count)
+    }
+}
+
+/// TODO
+impl ReadRef for [u8] {
+    fn read_bytes(&self, offset: usize, size: usize) -> Result<&[u8], ()> {
+        self.get(offset..).ok_or(())?.get(..size).ok_or(())
+    }
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct ReadCache<R: Read + Seek> {
+    cache: RefCell<ReadCacheInternal<R>>,
+}
+
+#[derive(Debug)]
+struct ReadCacheInternal<R: Read + Seek> {
+    read: R,
+    bufs: HashMap<(usize, usize), Box<[u8]>>,
+}
+
+/// TODO
+impl<R: Read + Seek> ReadCache<R> {
+    /// TODO
+    pub fn new(read: R) -> Self {
+        ReadCache {
+            cache: RefCell::new(ReadCacheInternal {
+                read,
+                bufs: HashMap::new(),
+            }),
+        }
+    }
+}
+
+impl<R: Read + Seek> ReadRef for ReadCache<R> {
+    fn read_bytes(&self, offset: usize, size: usize) -> Result<&[u8], ()> {
+        let cache = &mut *self.cache.borrow_mut();
+        let buf = match cache.bufs.entry((offset, size)) {
+            Entry::Occupied(entry) => {
+                println!("Cache hit at {:x}[{:x}]", offset, size);
+                entry.into_mut()
+            }
+            Entry::Vacant(entry) => {
+                println!("Reading at {:x}[{:x}]", offset, size);
+                cache
+                    .read
+                    .seek(SeekFrom::Start(offset as u64))
+                    .map_err(|_| ())?;
+                let mut bytes = vec![0; size].into_boxed_slice();
+                cache.read.read_exact(&mut bytes).map_err(|_| ())?;
+                entry.insert(bytes)
+            }
+        };
+        // Extend the lifetime to that of self.
+        // This is OK because we never mutate or remove entries.
+        Ok(unsafe { mem::transmute::<&[u8], &[u8]>(buf) })
+    }
+}

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -1,4 +1,5 @@
 use crate::pod::{from_bytes, slice_from_bytes, Pod};
+use alloc::vec::Vec;
 use std::boxed::Box;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
@@ -51,6 +52,17 @@ pub trait ReadRef<'data>: 'data + Clone + Copy {
 
 /// TODO
 impl<'data> ReadRef<'data> for &'data [u8] {
+    fn len(self) -> Result<usize, ()> {
+        Ok(self.len())
+    }
+
+    fn read_bytes_at(self, offset: usize, size: usize) -> Result<&'data [u8], ()> {
+        self.get(offset..).ok_or(())?.get(..size).ok_or(())
+    }
+}
+
+/// TODO
+impl<'data> ReadRef<'data> for &'data Vec<u8> {
     fn len(self) -> Result<usize, ()> {
         Ok(self.len())
     }

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -33,8 +33,8 @@ const SECTION_DATA_COUNT: usize = 12;
 const MAX_SECTION_ID: usize = SECTION_DATA_COUNT;
 
 /// A WebAssembly object file.
-#[derive(Debug, Default)]
-pub struct WasmFile<'data> {
+#[derive(Debug)]
+pub struct WasmFile<'data, R> {
     // All sections, including custom sections.
     sections: Vec<wp::Section<'data>>,
     // Indices into `sections` of sections with a non-zero id.
@@ -45,6 +45,7 @@ pub struct WasmFile<'data> {
     symbols: Vec<WasmSymbolInternal<'data>>,
     // Address of the function body for the entry point.
     entry: u64,
+    marker: PhantomData<R>,
 }
 
 #[derive(Clone)]
@@ -60,14 +61,21 @@ impl<T> ReadError<T> for wasmparser::Result<T> {
     }
 }
 
-impl<'data> WasmFile<'data> {
+impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
     /// Parse the raw wasm data.
-    pub fn parse<R: ReadRef<'data>>(data: R) -> Result<Self> {
+    pub fn parse(data: R) -> Result<Self> {
         let len = data.len().read_error("Unknown Wasm file size")?;
         let data = data.read_bytes_at(0, len).read_error("Wasm read failed")?;
         let module = wp::ModuleReader::new(data).read_error("Invalid Wasm header")?;
 
-        let mut file = WasmFile::default();
+        let mut file = WasmFile {
+            sections: Vec::new(),
+            id_sections: Default::default(),
+            has_debug_symbols: false,
+            symbols: Vec::new(),
+            entry: 0,
+            marker: PhantomData,
+        };
 
         let mut main_file_symbol = Some(WasmSymbolInternal {
             name: "",
@@ -285,18 +293,19 @@ impl<'data> WasmFile<'data> {
     }
 }
 
-impl<'data> read::private::Sealed for WasmFile<'data> {}
+impl<'data, R> read::private::Sealed for WasmFile<'data, R> {}
 
-impl<'data, 'file> Object<'data, 'file> for WasmFile<'data>
+impl<'data, 'file, R> Object<'data, 'file> for WasmFile<'data, R>
 where
     'data: 'file,
+    R: 'file,
 {
-    type Segment = WasmSegment<'data, 'file>;
-    type SegmentIterator = WasmSegmentIterator<'data, 'file>;
-    type Section = WasmSection<'data, 'file>;
-    type SectionIterator = WasmSectionIterator<'data, 'file>;
-    type Comdat = WasmComdat<'data, 'file>;
-    type ComdatIterator = WasmComdatIterator<'data, 'file>;
+    type Segment = WasmSegment<'data, 'file, R>;
+    type SegmentIterator = WasmSegmentIterator<'data, 'file, R>;
+    type Section = WasmSection<'data, 'file, R>;
+    type SectionIterator = WasmSectionIterator<'data, 'file, R>;
+    type Comdat = WasmComdat<'data, 'file, R>;
+    type ComdatIterator = WasmComdatIterator<'data, 'file, R>;
     type Symbol = WasmSymbol<'data, 'file>;
     type SymbolIterator = WasmSymbolIterator<'data, 'file>;
     type SymbolTable = WasmSymbolTable<'data, 'file>;
@@ -326,12 +335,12 @@ where
         self.entry
     }
 
-    fn section_by_name(&'file self, section_name: &str) -> Option<WasmSection<'data, 'file>> {
+    fn section_by_name(&'file self, section_name: &str) -> Option<WasmSection<'data, 'file, R>> {
         self.sections()
             .find(|section| section.name() == Ok(section_name))
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Result<WasmSection<'data, 'file>> {
+    fn section_by_index(&'file self, index: SectionIndex) -> Result<WasmSection<'data, 'file, R>> {
         // TODO: Missing sections should return an empty section.
         let id_section = self
             .id_sections
@@ -339,12 +348,16 @@ where
             .and_then(|x| *x)
             .read_error("Invalid Wasm section index")?;
         let section = self.sections.get(id_section).unwrap();
-        Ok(WasmSection { section })
+        Ok(WasmSection {
+            section,
+            marker: PhantomData,
+        })
     }
 
     fn sections(&'file self) -> Self::SectionIterator {
         WasmSectionIterator {
             sections: self.sections.iter(),
+            marker: PhantomData,
         }
     }
 
@@ -411,12 +424,12 @@ where
 
 /// An iterator over the segments of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSegmentIterator<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmSegmentIterator<'data, 'file, R> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> Iterator for WasmSegmentIterator<'data, 'file> {
-    type Item = WasmSegment<'data, 'file>;
+impl<'data, 'file, R> Iterator for WasmSegmentIterator<'data, 'file, R> {
+    type Item = WasmSegment<'data, 'file, R>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -426,13 +439,13 @@ impl<'data, 'file> Iterator for WasmSegmentIterator<'data, 'file> {
 
 /// A segment of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSegment<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmSegment<'data, 'file, R> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> read::private::Sealed for WasmSegment<'data, 'file> {}
+impl<'data, 'file, R> read::private::Sealed for WasmSegment<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectSegment<'data> for WasmSegment<'data, 'file> {
+impl<'data, 'file, R> ObjectSegment<'data> for WasmSegment<'data, 'file, R> {
     #[inline]
     fn address(&self) -> u64 {
         unreachable!()
@@ -469,29 +482,34 @@ impl<'data, 'file> ObjectSegment<'data> for WasmSegment<'data, 'file> {
 
 /// An iterator over the sections of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSectionIterator<'data, 'file> {
+pub struct WasmSectionIterator<'data, 'file, R> {
     sections: slice::Iter<'file, wp::Section<'data>>,
+    marker: PhantomData<R>,
 }
 
-impl<'data, 'file> Iterator for WasmSectionIterator<'data, 'file> {
-    type Item = WasmSection<'data, 'file>;
+impl<'data, 'file, R> Iterator for WasmSectionIterator<'data, 'file, R> {
+    type Item = WasmSection<'data, 'file, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let section = self.sections.next()?;
-        Some(WasmSection { section })
+        Some(WasmSection {
+            section,
+            marker: PhantomData,
+        })
     }
 }
 
 /// A section of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSection<'data, 'file> {
+pub struct WasmSection<'data, 'file, R> {
     section: &'file wp::Section<'data>,
+    marker: PhantomData<R>,
 }
 
-impl<'data, 'file> read::private::Sealed for WasmSection<'data, 'file> {}
+impl<'data, 'file, R> read::private::Sealed for WasmSection<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
-    type RelocationIterator = WasmRelocationIterator<'data, 'file>;
+impl<'data, 'file, R> ObjectSection<'data> for WasmSection<'data, 'file, R> {
+    type RelocationIterator = WasmRelocationIterator<'data, 'file, R>;
 
     #[inline]
     fn index(&self) -> SectionIndex {
@@ -588,8 +606,8 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
     }
 
     #[inline]
-    fn relocations(&self) -> WasmRelocationIterator<'data, 'file> {
-        WasmRelocationIterator::default()
+    fn relocations(&self) -> WasmRelocationIterator<'data, 'file, R> {
+        WasmRelocationIterator(PhantomData)
     }
 
     #[inline]
@@ -600,12 +618,12 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
 
 /// An iterator over the COMDAT section groups of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmComdatIterator<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmComdatIterator<'data, 'file, R> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> Iterator for WasmComdatIterator<'data, 'file> {
-    type Item = WasmComdat<'data, 'file>;
+impl<'data, 'file, R> Iterator for WasmComdatIterator<'data, 'file, R> {
+    type Item = WasmComdat<'data, 'file, R>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -615,14 +633,14 @@ impl<'data, 'file> Iterator for WasmComdatIterator<'data, 'file> {
 
 /// A COMDAT section group of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmComdat<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmComdat<'data, 'file, R> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> read::private::Sealed for WasmComdat<'data, 'file> {}
+impl<'data, 'file, R> read::private::Sealed for WasmComdat<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectComdat<'data> for WasmComdat<'data, 'file> {
-    type SectionIterator = WasmComdatSectionIterator<'data, 'file>;
+impl<'data, 'file, R> ObjectComdat<'data> for WasmComdat<'data, 'file, R> {
+    type SectionIterator = WasmComdatSectionIterator<'data, 'file, R>;
 
     #[inline]
     fn kind(&self) -> ComdatKind {
@@ -647,14 +665,14 @@ impl<'data, 'file> ObjectComdat<'data> for WasmComdat<'data, 'file> {
 
 /// An iterator over the sections in a COMDAT section group of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmComdatSectionIterator<'data, 'file>
+pub struct WasmComdatSectionIterator<'data, 'file, R>
 where
     'data: 'file,
 {
-    file: &'file WasmFile<'data>,
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> Iterator for WasmComdatSectionIterator<'data, 'file> {
+impl<'data, 'file, R> Iterator for WasmComdatSectionIterator<'data, 'file, R> {
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -799,10 +817,10 @@ impl<'data, 'file> ObjectSymbol<'data> for WasmSymbol<'data, 'file> {
 }
 
 /// An iterator over the relocations in a `WasmSection`.
-#[derive(Debug, Default)]
-pub struct WasmRelocationIterator<'data, 'file>(PhantomData<(&'data (), &'file ())>);
+#[derive(Debug)]
+pub struct WasmRelocationIterator<'data, 'file, R>(PhantomData<(&'data (), &'file (), R)>);
 
-impl<'data, 'file> Iterator for WasmRelocationIterator<'data, 'file> {
+impl<'data, 'file, R> Iterator for WasmRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     #[inline]

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -1,7 +1,7 @@
 use object::read::elf::{FileHeader, SectionHeader};
 use object::read::{Object, ObjectSymbol};
 use object::{
-    elf, read, write, Architecture, BinaryFormat, Bytes, Endianness, LittleEndian, SectionIndex,
+    elf, read, write, Architecture, BinaryFormat, Endianness, LittleEndian, SectionIndex,
     SectionKind, SymbolFlags, SymbolKind, SymbolScope, SymbolSection, U32,
 };
 use std::io::Write;
@@ -180,11 +180,10 @@ fn note() {
     let section = object.add_section(Vec::new(), b".note8".to_vec(), SectionKind::Note);
     object.section_mut(section).set_data(buffer, 8);
 
-    let bytes = object.write().unwrap();
+    let bytes = &object.write().unwrap();
 
     //std::fs::write(&"note.o", &bytes).unwrap();
 
-    let bytes = Bytes(&bytes);
     let header = elf::FileHeader64::parse(bytes).unwrap();
     let endian: LittleEndian = header.endian().unwrap();
     let sections = header.sections(endian, bytes).unwrap();


### PR DESCRIPTION
Allows reading from `Read + Seek` instead of `&[u8]`.

Todo:

- [ ] maybe completely remove `Bytes`, since `ReadRef` now implements most of what it did
- [x] archive and Mach-O fat members are still completely read into memory. `ReadRef` probably needs to become more like a cursor to support this.
- [ ] change `usize` to `u64` for file offsets