### PR TITLE
Added getters for PeFile

### DIFF
--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -53,6 +53,16 @@ impl<'data, Pe: ImageNtHeaders> PeFile<'data, Pe> {
         u64::from(self.nt_headers.optional_header().section_alignment())
     }
 
+    /// Return the DOS header of this file
+    pub fn dos_header(&self) -> &'data pe::ImageDosHeader {
+        self.dos_header
+    }
+
+    /// Return the NT Headers of this file
+    pub fn nt_headers(&self) -> &'data Pe {
+        self.nt_headers
+    }
+
     fn data_directory(&self, id: usize) -> Option<&'data pe::ImageDataDirectory> {
         self.data_directories
             .get(id)


### PR DESCRIPTION
The fields `dos_header` and `nt_headers` of a `PeFile` are private (or rather, they are defined `pub(crate)`).
They may be of interest for a user who has already parsed a file into a `PeFile`, so I have added getters for them.

I am not sure whether this would have made sense as well to add a getter for the `CoffCommon` part and to turn `PeFile::data_directory` and `PeFile::data_at` public, so I did not change them.
Changing the fields form `pub(crate)` to `pub` (instead of implementing getters) would have made the trick as well, but I'm not experienced enough with `object` to tell whether that would be a good idea.