### PR TITLE
Add `ReadRef`

### DIFF
--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -37,7 +37,9 @@ fn main() {
                 if let Ok(member) = member {
                     println!();
                     println!("{}:", String::from_utf8_lossy(member.name()));
-                    dump_object(member.data());
+                    if let Ok(data) = member.data(&*file) {
+                        dump_object(data);
+                    }
                 }
             }
         } else if let Ok(arches) = FatHeader::parse_arch32(&*file) {

--- a/examples/readobj.rs
+++ b/examples/readobj.rs
@@ -212,7 +212,9 @@ fn print_archive(p: &mut Printer<impl Write>, data: &[u8]) {
             if let Ok(member) = member {
                 p.blank();
                 p.field("Member", String::from_utf8_lossy(member.name()));
-                print_object(p, member.data());
+                if let Ok(data) = member.data(data) {
+                    print_object(p, data);
+                }
             }
         }
     }

--- a/examples/readobj.rs
+++ b/examples/readobj.rs
@@ -2,7 +2,7 @@
 
 use object::read::archive::ArchiveFile;
 use object::read::macho::{FatArch, FatHeader};
-use object::{Bytes, Endianness};
+use object::Endianness;
 use std::convert::TryInto;
 use std::io::Write;
 use std::{env, fmt, fs, io, process, str};
@@ -65,7 +65,7 @@ impl<W: Write> Printer<W> {
         if let Ok(s) = str::from_utf8(s) {
             write!(self.w, "\"{}\"", s).unwrap();
         } else {
-            write!(self.w, "{:?}", Bytes(s)).unwrap();
+            write!(self.w, "{:X?}", s).unwrap();
         }
     }
 
@@ -191,15 +191,15 @@ fn print_object(p: &mut Printer<impl Write>, data: &[u8]) {
     };
     match kind {
         object::FileKind::Archive => print_archive(p, data),
-        object::FileKind::Coff => pe::print_coff(p, Bytes(data)),
-        object::FileKind::Elf32 => elf::print_elf32(p, Bytes(data)),
-        object::FileKind::Elf64 => elf::print_elf64(p, Bytes(data)),
-        object::FileKind::MachO32 => macho::print_macho32(p, Bytes(data)),
-        object::FileKind::MachO64 => macho::print_macho64(p, Bytes(data)),
+        object::FileKind::Coff => pe::print_coff(p, data),
+        object::FileKind::Elf32 => elf::print_elf32(p, data),
+        object::FileKind::Elf64 => elf::print_elf64(p, data),
+        object::FileKind::MachO32 => macho::print_macho32(p, data),
+        object::FileKind::MachO64 => macho::print_macho64(p, data),
         object::FileKind::MachOFat32 => macho::print_macho_fat32(p, data),
         object::FileKind::MachOFat64 => macho::print_macho_fat64(p, data),
-        object::FileKind::Pe32 => pe::print_pe32(p, Bytes(data)),
-        object::FileKind::Pe64 => pe::print_pe64(p, Bytes(data)),
+        object::FileKind::Pe32 => pe::print_pe32(p, data),
+        object::FileKind::Pe64 => pe::print_pe64(p, data),
         // TODO
         _ => {}
     }
@@ -223,14 +223,14 @@ mod elf {
     use object::elf::*;
     use object::read::elf::*;
 
-    pub(super) fn print_elf32(p: &mut Printer<impl Write>, data: Bytes) {
+    pub(super) fn print_elf32(p: &mut Printer<impl Write>, data: &[u8]) {
         if let Ok(elf) = FileHeader32::<Endianness>::parse(data) {
             println!("Format: ELF 32-bit");
             print_elf(p, elf, data);
         }
     }
 
-    pub(super) fn print_elf64(p: &mut Printer<impl Write>, data: Bytes) {
+    pub(super) fn print_elf64(p: &mut Printer<impl Write>, data: &[u8]) {
         if let Ok(elf) = FileHeader64::<Endianness>::parse(data) {
             println!("Format: ELF 64-bit");
             print_elf(p, elf, data);
@@ -240,7 +240,7 @@ mod elf {
     fn print_elf<Elf: FileHeader<Endian = Endianness>>(
         p: &mut Printer<impl Write>,
         elf: &Elf,
-        data: Bytes,
+        data: &[u8],
     ) {
         if let Ok(endian) = elf.endian() {
             print_file_header(p, endian, elf);
@@ -324,7 +324,7 @@ mod elf {
     fn print_program_headers<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         elf: &Elf,
         segments: &[Elf::ProgramHeader],
     ) {
@@ -386,7 +386,7 @@ mod elf {
     fn print_segment_notes<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         _elf: &Elf,
         segment: &Elf::ProgramHeader,
     ) {
@@ -398,7 +398,7 @@ mod elf {
     fn print_segment_dynamic<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         elf: &Elf,
         segments: &[Elf::ProgramHeader],
         segment: &Elf::ProgramHeader,
@@ -468,7 +468,7 @@ mod elf {
     fn print_section_headers<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         elf: &Elf,
         sections: &SectionTable<Elf>,
     ) {
@@ -537,7 +537,7 @@ mod elf {
     fn print_section_symbols<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         elf: &Elf,
         sections: &SectionTable<Elf>,
         section_index: usize,
@@ -615,7 +615,7 @@ mod elf {
     fn print_section_rel<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         elf: &Elf,
         sections: &SectionTable<Elf>,
         section: &Elf::SectionHeader,
@@ -637,7 +637,7 @@ mod elf {
     fn print_section_rela<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         elf: &Elf,
         sections: &SectionTable<Elf>,
         section: &Elf::SectionHeader,
@@ -709,7 +709,7 @@ mod elf {
     fn print_section_notes<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         _elf: &Elf,
         section: &Elf::SectionHeader,
     ) {
@@ -721,7 +721,7 @@ mod elf {
     fn print_section_group<Elf: FileHeader>(
         p: &mut Printer<impl Write>,
         endian: Elf::Endian,
-        data: Bytes,
+        data: &[u8],
         _elf: &Elf,
         sections: &SectionTable<Elf>,
         section: &Elf::SectionHeader,
@@ -3219,14 +3219,14 @@ mod macho {
         });
     }
 
-    pub(super) fn print_macho32(p: &mut Printer<impl Write>, data: Bytes) {
+    pub(super) fn print_macho32(p: &mut Printer<impl Write>, data: &[u8]) {
         if let Ok(header) = MachHeader32::parse(data) {
             println!("Format: Mach-O 32-bit");
             print_macho(p, header, data);
         }
     }
 
-    pub(super) fn print_macho64(p: &mut Printer<impl Write>, data: Bytes) {
+    pub(super) fn print_macho64(p: &mut Printer<impl Write>, data: &[u8]) {
         if let Ok(header) = MachHeader64::parse(data) {
             println!("Format: Mach-O 64-bit");
             print_macho(p, header, data);
@@ -3241,7 +3241,7 @@ mod macho {
     fn print_macho<Mach: MachHeader<Endian = Endianness>>(
         p: &mut Printer<impl Write>,
         header: &Mach,
-        data: Bytes,
+        data: &[u8],
     ) {
         if let Ok(endian) = header.endian() {
             let mut state = MachState::default();
@@ -3272,7 +3272,7 @@ mod macho {
     fn print_load_command<Mach: MachHeader>(
         p: &mut Printer<impl Write>,
         endian: Mach::Endian,
-        data: Bytes,
+        data: &[u8],
         header: &Mach,
         command: LoadCommandData<Mach::Endian>,
         state: &mut MachState,
@@ -3616,10 +3616,10 @@ mod macho {
     fn print_segment<S: Segment>(
         p: &mut Printer<impl Write>,
         endian: S::Endian,
-        data: Bytes,
+        data: &[u8],
         cputype: u32,
         segment: &S,
-        section_data: Bytes,
+        section_data: &[u8],
         state: &mut MachState,
     ) {
         p.group("SegmentCommand", |p| {
@@ -3648,7 +3648,7 @@ mod macho {
     fn print_section<S: Section>(
         p: &mut Printer<impl Write>,
         endian: S::Endian,
-        data: Bytes,
+        data: &[u8],
         cputype: u32,
         section: &S,
         state: &mut MachState,
@@ -3715,7 +3715,7 @@ mod macho {
     fn print_symtab<Mach: MachHeader, W: Write>(
         p: &mut Printer<W>,
         endian: Mach::Endian,
-        data: Bytes,
+        data: &[u8],
         symtab: &SymtabCommand<Mach::Endian>,
     ) {
         p.group("SymtabCommand", |p| {
@@ -3725,7 +3725,7 @@ mod macho {
             p.field_hex("NumberOfSymbols", symtab.nsyms.get(endian));
             p.field_hex("StringOffset", symtab.stroff.get(endian));
             p.field_hex("StringSize", symtab.strsize.get(endian));
-            if let Ok(symbols) = symtab.symbols::<Mach>(endian, data) {
+            if let Ok(symbols) = symtab.symbols::<Mach, _>(endian, data) {
                 for (index, nlist) in symbols.iter().enumerate() {
                     p.group("Nlist", |p| {
                         p.field("Index", index);
@@ -4157,11 +4157,12 @@ mod pe {
     use object::read::pe::*;
     use object::LittleEndian as LE;
 
-    pub(super) fn print_coff(p: &mut Printer<impl Write>, data: Bytes) {
-        if let Ok((header, tail)) = ImageFileHeader::parse(data) {
+    pub(super) fn print_coff(p: &mut Printer<impl Write>, data: &[u8]) {
+        let mut offset = 0;
+        if let Ok(header) = ImageFileHeader::parse(data, &mut offset) {
             println!("Format: COFF");
             print_file(p, header);
-            let sections = header.sections(tail).ok();
+            let sections = header.sections(data, offset).ok();
             let symbols = header.symbols(data).ok();
             if let Some(ref sections) = sections {
                 print_sections(p, data, header.machine.get(LE), symbols.as_ref(), &sections);
@@ -4172,17 +4173,17 @@ mod pe {
         }
     }
 
-    pub(super) fn print_pe32(p: &mut Printer<impl Write>, data: Bytes) {
+    pub(super) fn print_pe32(p: &mut Printer<impl Write>, data: &[u8]) {
         println!("Format: PE 32-bit");
         print_pe::<ImageNtHeaders32, _>(p, data);
     }
 
-    pub(super) fn print_pe64(p: &mut Printer<impl Write>, data: Bytes) {
+    pub(super) fn print_pe64(p: &mut Printer<impl Write>, data: &[u8]) {
         println!("Format: PE 64-bit");
         print_pe::<ImageNtHeaders64, _>(p, data);
     }
 
-    fn print_pe<Pe: ImageNtHeaders, W: Write>(p: &mut Printer<W>, data: Bytes) {
+    fn print_pe<Pe: ImageNtHeaders, W: Write>(p: &mut Printer<W>, data: &[u8]) {
         if let Ok(dos_header) = ImageDosHeader::parse(data) {
             p.group("ImageDosHeader", |p| {
                 p.field_hex("Magic", dos_header.e_magic.get(LE));
@@ -4203,12 +4204,13 @@ mod pe {
                 p.field_hex("OemInfo", dos_header.e_oeminfo.get(LE));
                 p.field_hex("AddressOfNewHeader", dos_header.e_lfanew.get(LE));
             });
-            if let Ok((nt_headers, data_directories, nt_tail)) = dos_header.nt_headers::<Pe>(data) {
+            let mut offset = dos_header.nt_headers_offset().into();
+            if let Ok((nt_headers, data_directories)) = Pe::parse(data, &mut offset) {
                 p.group("ImageNtHeaders", |p| {
                     p.field_hex("Signature", nt_headers.signature());
                 });
                 let header = nt_headers.file_header();
-                let sections = header.sections(nt_tail).ok();
+                let sections = header.sections(data, offset).ok();
                 let symbols = header.symbols(data).ok();
                 print_file(p, header);
                 print_optional(p, nt_headers.optional_header());
@@ -4305,8 +4307,8 @@ mod pe {
         });
     }
 
-    fn print_export_dir(p: &mut Printer<impl Write>, _dir: &ImageDataDirectory, dir_data: Bytes) {
-        if let Ok(export_dir) = dir_data.read_at::<pe::ImageExportDirectory>(0) {
+    fn print_export_dir(p: &mut Printer<impl Write>, _dir: &ImageDataDirectory, dir_data: &[u8]) {
+        if let Ok((export_dir, _)) = object::from_bytes::<pe::ImageExportDirectory>(dir_data) {
             p.group("ImageExportDirectory", |p| {
                 p.field_hex("Characteristics", export_dir.characteristics.get(LE));
                 p.field_hex("TimeDateStamp", export_dir.time_date_stamp.get(LE));
@@ -4332,7 +4334,7 @@ mod pe {
 
     fn print_sections(
         p: &mut Printer<impl Write>,
-        data: Bytes,
+        data: &[u8],
         machine: u16,
         symbols: Option<&SymbolTable>,
         sections: &SectionTable,

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -189,6 +189,7 @@ impl<'data> File<'data> {
             FileKind::Pe64 => FileInternal::Pe64(pe::PeFile64::parse(data)?),
             #[cfg(feature = "coff")]
             FileKind::Coff => FileInternal::Coff(coff::CoffFile::parse(data)?),
+            #[allow(unreachable_patterns)]
             _ => return Err(Error("Unsupported file format")),
         };
         Ok(File { inner })
@@ -314,6 +315,7 @@ where
             FileInternal::Elf64(ref elf) => {
                 DynamicRelocationIteratorInternal::Elf64(elf.dynamic_relocations()?)
             }
+            #[allow(unreachable_patterns)]
             _ => return None,
         };
         Some(DynamicRelocationIterator { inner })

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -13,10 +13,11 @@ use crate::read::pe;
 #[cfg(feature = "wasm")]
 use crate::read::wasm;
 use crate::read::{
-    self, Architecture, BinaryFormat, ComdatKind, CompressedData, Error, Export, FileFlags,
-    FileKind, Import, Object, ObjectComdat, ObjectMap, ObjectSection, ObjectSegment, ObjectSymbol,
-    ObjectSymbolTable, ReadRef, Relocation, Result, SectionFlags, SectionIndex, SectionKind,
-    SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
+    self, Architecture, BinaryFormat, ComdatKind, CompressedData, CompressedFileRange, Error,
+    Export, FileFlags, FileKind, Import, Object, ObjectComdat, ObjectMap, ObjectSection,
+    ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadRef, Relocation, Result, SectionFlags,
+    SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName,
+    SymbolScope, SymbolSection,
 };
 use crate::Endianness;
 
@@ -655,6 +656,10 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSection<'data> for Section<'data, 'f
 
     fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>> {
         with_inner!(self.inner, SectionInternal, |x| x.data_range(address, size))
+    }
+
+    fn compressed_file_range(&self) -> Result<CompressedFileRange> {
+        with_inner!(self.inner, SectionInternal, |x| x.compressed_file_range())
     }
 
     fn compressed_data(&self) -> Result<CompressedData<'data>> {

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -348,6 +348,7 @@ where
             FileInternal::Elf64(ref elf) => {
                 DynamicRelocationIteratorInternal::Elf64(elf.dynamic_relocations()?)
             }
+            #[allow(unreachable_patterns)]
             _ => return None,
         };
         Some(DynamicRelocationIterator { inner })

--- a/src/read/coff/relocation.rs
+++ b/src/read/coff/relocation.rs
@@ -3,17 +3,19 @@ use core::slice;
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
-use crate::read::{Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex};
+use crate::read::{
+    ReadRef, Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex,
+};
 
 use super::CoffFile;
 
 /// An iterator over the relocations in a `CoffSection`.
-pub struct CoffRelocationIterator<'data, 'file> {
-    pub(super) file: &'file CoffFile<'data>,
+pub struct CoffRelocationIterator<'data, 'file, R: ReadRef<'data> = &'data [u8]> {
+    pub(super) file: &'file CoffFile<'data, R>,
     pub(super) iter: slice::Iter<'data, pe::ImageRelocation>,
 }
 
-impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
+impl<'data, 'file, R: ReadRef<'data>> Iterator for CoffRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -76,7 +78,7 @@ impl<'data, 'file> Iterator for CoffRelocationIterator<'data, 'file> {
     }
 }
 
-impl<'data, 'file> fmt::Debug for CoffRelocationIterator<'data, 'file> {
+impl<'data, 'file, R: ReadRef<'data>> fmt::Debug for CoffRelocationIterator<'data, 'file, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoffRelocationIterator").finish()
     }

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -2,11 +2,10 @@ use core::{iter, result, slice, str};
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
-use crate::pod::Bytes;
 use crate::read::util::StringTable;
 use crate::read::{
-    self, CompressedData, Error, ObjectSection, ObjectSegment, ReadError, Result, SectionFlags,
-    SectionIndex, SectionKind,
+    self, CompressedData, Error, ObjectSection, ObjectSegment, ReadError, ReadRef, Result,
+    SectionFlags, SectionIndex, SectionKind,
 };
 
 use super::{CoffFile, CoffRelocationIterator};
@@ -20,10 +19,15 @@ pub struct SectionTable<'data> {
 impl<'data> SectionTable<'data> {
     /// Parse the section table.
     ///
-    /// `data` must be the data following the optional header.
-    pub fn parse(header: &pe::ImageFileHeader, mut data: Bytes<'data>) -> Result<Self> {
+    /// `data` must be the entire file data.
+    /// `offset` must be after the optional file header.
+    pub fn parse<R: ReadRef<'data>>(
+        header: &pe::ImageFileHeader,
+        data: R,
+        offset: u64,
+    ) -> Result<Self> {
         let sections = data
-            .read_slice(header.number_of_sections.get(LE) as usize)
+            .read_slice_at(offset, header.number_of_sections.get(LE).into())
             .read_error("Invalid COFF/PE section headers")?;
         Ok(SectionTable { sections })
     }
@@ -107,7 +111,7 @@ where
 }
 
 impl<'data, 'file> CoffSegment<'data, 'file> {
-    fn bytes(&self) -> Result<Bytes<'data>> {
+    fn bytes(&self) -> Result<&'data [u8]> {
         self.section
             .coff_data(self.file.data)
             .read_error("Invalid COFF section offset or size")
@@ -139,11 +143,11 @@ impl<'data, 'file> ObjectSegment<'data> for CoffSegment<'data, 'file> {
     }
 
     fn data(&self) -> Result<&'data [u8]> {
-        Ok(self.bytes()?.0)
+        Ok(self.bytes()?)
     }
 
     fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>> {
-        Ok(read::data_range(
+        Ok(read::util::data_range(
             self.bytes()?,
             self.address(),
             address,
@@ -196,7 +200,7 @@ where
 }
 
 impl<'data, 'file> CoffSection<'data, 'file> {
-    fn bytes(&self) -> Result<Bytes<'data>> {
+    fn bytes(&self) -> Result<&'data [u8]> {
         self.section
             .coff_data(self.file.data)
             .read_error("Invalid COFF section offset or size")
@@ -236,11 +240,11 @@ impl<'data, 'file> ObjectSection<'data> for CoffSection<'data, 'file> {
     }
 
     fn data(&self) -> Result<&'data [u8]> {
-        Ok(self.bytes()?.0)
+        Ok(self.bytes()?)
     }
 
     fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>> {
-        Ok(read::data_range(
+        Ok(read::util::data_range(
             self.bytes()?,
             self.address(),
             address,
@@ -374,11 +378,11 @@ impl pe::ImageSectionHeader {
     ///
     /// Returns `Ok(&[])` if the section has no data.
     /// Returns `Err` for invalid values.
-    pub fn coff_data<'data>(&self, data: Bytes<'data>) -> result::Result<Bytes<'data>, ()> {
+    pub fn coff_data<'data, R: ReadRef<'data>>(&self, data: R) -> result::Result<&'data [u8], ()> {
         if let Some((offset, size)) = self.coff_file_range() {
-            data.read_bytes_at(offset as usize, size as usize)
+            data.read_bytes_at(offset.into(), size.into())
         } else {
-            Ok(Bytes(&[]))
+            Ok(&[])
         }
     }
 
@@ -408,12 +412,12 @@ impl pe::ImageSectionHeader {
     /// Read the relocations in a COFF file.
     ///
     /// `data` must be the entire file data.
-    pub fn coff_relocations<'data>(
+    pub fn coff_relocations<'data, R: ReadRef<'data>>(
         &self,
-        data: Bytes<'data>,
+        data: R,
     ) -> read::Result<&'data [pe::ImageRelocation]> {
-        let pointer = self.pointer_to_relocations.get(LE) as usize;
-        let number = self.number_of_relocations.get(LE) as usize;
+        let pointer = self.pointer_to_relocations.get(LE).into();
+        let number = self.number_of_relocations.get(LE).into();
         data.read_slice_at(pointer, number)
             .read_error("Invalid COFF relocation offset or number")
     }

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -4,8 +4,8 @@ use crate::endian::LittleEndian as LE;
 use crate::pe;
 use crate::read::util::StringTable;
 use crate::read::{
-    self, CompressedData, Error, ObjectSection, ObjectSegment, ReadError, ReadRef, Result,
-    SectionFlags, SectionIndex, SectionKind,
+    self, CompressedData, CompressedFileRange, Error, ObjectSection, ObjectSegment, ReadError,
+    ReadRef, Result, SectionFlags, SectionIndex, SectionKind,
 };
 
 use super::{CoffFile, CoffRelocationIterator};
@@ -238,6 +238,11 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSection<'data> for CoffSection<'data
             address,
             size,
         ))
+    }
+
+    #[inline]
+    fn compressed_file_range(&self) -> Result<CompressedFileRange> {
+        Ok(CompressedFileRange::none(self.file_range()))
     }
 
     #[inline]

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -240,10 +240,7 @@ impl pe::ImageSymbol {
 
 /// A symbol table of a `CoffFile`.
 #[derive(Debug, Clone, Copy)]
-pub struct CoffSymbolTable<'data, 'file>
-where
-    'data: 'file,
-{
+pub struct CoffSymbolTable<'data, 'file> {
     pub(crate) file: &'file CoffCommon<'data>,
 }
 
@@ -271,10 +268,7 @@ impl<'data, 'file> ObjectSymbolTable<'data> for CoffSymbolTable<'data, 'file> {
 }
 
 /// An iterator over the symbols of a `CoffFile`.
-pub struct CoffSymbolIterator<'data, 'file>
-where
-    'data: 'file,
-{
+pub struct CoffSymbolIterator<'data, 'file> {
     pub(crate) file: &'file CoffCommon<'data>,
     pub(crate) index: usize,
 }
@@ -302,10 +296,7 @@ impl<'data, 'file> Iterator for CoffSymbolIterator<'data, 'file> {
 
 /// A symbol of a `CoffFile`.
 #[derive(Debug, Clone, Copy)]
-pub struct CoffSymbol<'data, 'file>
-where
-    'data: 'file,
-{
+pub struct CoffSymbol<'data, 'file> {
     pub(crate) file: &'file CoffCommon<'data>,
     pub(crate) index: SymbolIndex,
     pub(crate) symbol: &'data pe::ImageSymbol,

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -9,7 +9,7 @@ use crate::pe;
 use crate::pod::{bytes_of_slice, Bytes, Pod};
 use crate::read::util::StringTable;
 use crate::read::{
-    self, ObjectSymbol, ObjectSymbolTable, ReadError, Result, SectionIndex, SymbolFlags,
+    self, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Result, SectionIndex, SymbolFlags,
     SymbolIndex, SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
 };
 
@@ -24,28 +24,26 @@ pub struct SymbolTable<'data> {
 
 impl<'data> SymbolTable<'data> {
     /// Read the symbol table.
-    pub fn parse(header: &pe::ImageFileHeader, mut data: Bytes<'data>) -> Result<Self> {
+    pub fn parse<R: ReadRef<'data>>(header: &pe::ImageFileHeader, data: R) -> Result<Self> {
         // The symbol table may not be present.
-        let symbol_offset = header.pointer_to_symbol_table.get(LE) as usize;
-        let (symbols, strings) = if symbol_offset != 0 {
-            data.skip(symbol_offset)
-                .read_error("Invalid COFF symbol table offset")?;
+        let mut offset = header.pointer_to_symbol_table.get(LE).into();
+        let (symbols, strings) = if offset != 0 {
             let symbols = data
-                .read_slice(header.number_of_symbols.get(LE) as usize)
-                .read_error("Invalid COFF symbol table size")?;
+                .read_slice(&mut offset, header.number_of_symbols.get(LE) as usize)
+                .read_error("Invalid COFF symbol table offset or size")?;
 
             // Note: don't update data when reading length; the length includes itself.
             let length = data
-                .read_at::<U32Bytes<_>>(0)
+                .read_at::<U32Bytes<_>>(offset)
                 .read_error("Missing COFF string table")?
                 .get(LE);
             let strings = data
-                .read_bytes(length as usize)
+                .read_bytes(&mut offset, length.into())
                 .read_error("Invalid COFF string table length")?;
 
             (symbols, strings)
         } else {
-            (&[][..], Bytes(&[]))
+            (&[][..], &[][..])
         };
 
         Ok(SymbolTable {
@@ -429,7 +427,7 @@ impl<'data, 'file> ObjectSymbol<'data> for CoffSymbol<'data, 'file> {
                     SymbolSection::Unknown
                 }
             }
-            index if index > 0 => SymbolSection::Section(SectionIndex(index as usize)),
+            index if index > 0 => SymbolSection::Section(SectionIndex(index.into())),
             _ => SymbolSection::Unknown,
         }
     }

--- a/src/read/elf/comdat.rs
+++ b/src/read/elf/comdat.rs
@@ -3,30 +3,35 @@ use core::{iter, slice, str};
 
 use crate::elf;
 use crate::endian::{Endianness, U32Bytes};
-use crate::read::{self, ComdatKind, ObjectComdat, ReadError, SectionIndex, SymbolIndex};
+use crate::read::{self, ComdatKind, ObjectComdat, ReadError, ReadRef, SectionIndex, SymbolIndex};
 
 use super::{ElfFile, FileHeader, SectionHeader, Sym};
 
 /// An iterator over the COMDAT section groups of an `ElfFile32`.
-pub type ElfComdatIterator32<'data, 'file, Endian = Endianness> =
-    ElfComdatIterator<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfComdatIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfComdatIterator<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// An iterator over the COMDAT section groups of an `ElfFile64`.
-pub type ElfComdatIterator64<'data, 'file, Endian = Endianness> =
-    ElfComdatIterator<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfComdatIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfComdatIterator<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// An iterator over the COMDAT section groups of an `ElfFile`.
 #[derive(Debug)]
-pub struct ElfComdatIterator<'data, 'file, Elf>
+pub struct ElfComdatIterator<'data, 'file, Elf, R = &'data [u8]>
 where
     'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
-    pub(super) file: &'file ElfFile<'data, Elf>,
+    pub(super) file: &'file ElfFile<'data, Elf, R>,
     pub(super) iter: iter::Enumerate<slice::Iter<'data, Elf::SectionHeader>>,
 }
 
-impl<'data, 'file, Elf: FileHeader> Iterator for ElfComdatIterator<'data, 'file, Elf> {
-    type Item = ElfComdat<'data, 'file, Elf>;
+impl<'data, 'file, Elf, R> Iterator for ElfComdatIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
+    type Item = ElfComdat<'data, 'file, Elf, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some((index, section)) = self.iter.next() {
@@ -39,31 +44,35 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfComdatIterator<'data, 'file,
 }
 
 /// A COMDAT section group of an `ElfFile32`.
-pub type ElfComdat32<'data, 'file, Endian = Endianness> =
-    ElfComdat<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfComdat32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfComdat<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// A COMDAT section group of an `ElfFile64`.
-pub type ElfComdat64<'data, 'file, Endian = Endianness> =
-    ElfComdat<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfComdat64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfComdat<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// A COMDAT section group of an `ElfFile`.
 #[derive(Debug)]
-pub struct ElfComdat<'data, 'file, Elf>
+pub struct ElfComdat<'data, 'file, Elf, R = &'data [u8]>
 where
-    'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
-    file: &'file ElfFile<'data, Elf>,
+    file: &'file ElfFile<'data, Elf, R>,
     index: SectionIndex,
     section: &'data Elf::SectionHeader,
     sections: &'data [U32Bytes<Elf::Endian>],
 }
 
-impl<'data, 'file, Elf: FileHeader> ElfComdat<'data, 'file, Elf> {
+impl<'data, 'file, Elf, R> ElfComdat<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
     fn parse(
-        file: &'file ElfFile<'data, Elf>,
+        file: &'file ElfFile<'data, Elf, R>,
         index: usize,
         section: &'data Elf::SectionHeader,
-    ) -> Option<ElfComdat<'data, 'file, Elf>> {
+    ) -> Option<ElfComdat<'data, 'file, Elf, R>> {
         let (flag, sections) = section.group(file.endian, file.data).ok()??;
         if flag != elf::GRP_COMDAT {
             return None;
@@ -77,10 +86,19 @@ impl<'data, 'file, Elf: FileHeader> ElfComdat<'data, 'file, Elf> {
     }
 }
 
-impl<'data, 'file, Elf: FileHeader> read::private::Sealed for ElfComdat<'data, 'file, Elf> {}
+impl<'data, 'file, Elf, R> read::private::Sealed for ElfComdat<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
+}
 
-impl<'data, 'file, Elf: FileHeader> ObjectComdat<'data> for ElfComdat<'data, 'file, Elf> {
-    type SectionIterator = ElfComdatSectionIterator<'data, 'file, Elf>;
+impl<'data, 'file, Elf, R> ObjectComdat<'data> for ElfComdat<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
+    type SectionIterator = ElfComdatSectionIterator<'data, 'file, Elf, R>;
 
     #[inline]
     fn kind(&self) -> ComdatKind {
@@ -111,24 +129,29 @@ impl<'data, 'file, Elf: FileHeader> ObjectComdat<'data> for ElfComdat<'data, 'fi
 }
 
 /// An iterator over the sections in a COMDAT section group of an `ElfFile32`.
-pub type ElfComdatSectionIterator32<'data, 'file, Endian = Endianness> =
-    ElfComdatSectionIterator<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfComdatSectionIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfComdatSectionIterator<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// An iterator over the sections in a COMDAT section group of an `ElfFile64`.
-pub type ElfComdatSectionIterator64<'data, 'file, Endian = Endianness> =
-    ElfComdatSectionIterator<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfComdatSectionIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfComdatSectionIterator<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// An iterator over the sections in a COMDAT section group of an `ElfFile`.
 #[derive(Debug)]
-pub struct ElfComdatSectionIterator<'data, 'file, Elf>
+pub struct ElfComdatSectionIterator<'data, 'file, Elf, R = &'data [u8]>
 where
     'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
-    file: &'file ElfFile<'data, Elf>,
+    file: &'file ElfFile<'data, Elf, R>,
     sections: slice::Iter<'data, U32Bytes<Elf::Endian>>,
 }
 
-impl<'data, 'file, Elf: FileHeader> Iterator for ElfComdatSectionIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf, R> Iterator for ElfComdatSectionIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/read/elf/note.rs
+++ b/src/read/elf/note.rs
@@ -28,7 +28,7 @@ where
     pub(super) fn new(
         endian: Elf::Endian,
         align: Elf::Word,
-        data: Bytes<'data>,
+        data: &'data [u8],
     ) -> read::Result<Self> {
         let align = match align.into() {
             0u64..=4 => 4,
@@ -39,7 +39,7 @@ where
         Ok(NoteIterator {
             endian,
             align,
-            data,
+            data: Bytes(data),
         })
     }
 

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -7,7 +7,8 @@ use crate::elf;
 use crate::endian::{self, Endianness};
 use crate::pod::Pod;
 use crate::read::{
-    self, Error, Relocation, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex,
+    self, Error, ReadRef, Relocation, RelocationEncoding, RelocationKind, RelocationTarget,
+    SymbolIndex,
 };
 
 use super::{ElfFile, FileHeader, SectionHeader, SectionTable};
@@ -91,25 +92,29 @@ impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf> {
 }
 
 /// An iterator over the dynamic relocations for an `ElfFile32`.
-pub type ElfDynamicRelocationIterator32<'data, 'file, Endian = Endianness> =
-    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfDynamicRelocationIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// An iterator over the dynamic relocations for an `ElfFile64`.
-pub type ElfDynamicRelocationIterator64<'data, 'file, Endian = Endianness> =
-    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfDynamicRelocationIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfDynamicRelocationIterator<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// An iterator over the dynamic relocations for an `ElfFile`.
-pub struct ElfDynamicRelocationIterator<'data, 'file, Elf>
+pub struct ElfDynamicRelocationIterator<'data, 'file, Elf, R = &'data [u8]>
 where
-    'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
     /// The current relocation section index.
     pub(super) section_index: usize,
-    pub(super) file: &'file ElfFile<'data, Elf>,
+    pub(super) file: &'file ElfFile<'data, Elf, R>,
     pub(super) relocations: Option<ElfRelaIterator<'data, Elf>>,
 }
 
-impl<'data, 'file, Elf: FileHeader> Iterator for ElfDynamicRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf, R> Iterator for ElfDynamicRelocationIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -149,32 +154,40 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfDynamicRelocationIterator<'d
     }
 }
 
-impl<'data, 'file, Elf: FileHeader> fmt::Debug for ElfDynamicRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf, R> fmt::Debug for ElfDynamicRelocationIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ElfDynamicRelocationIterator").finish()
     }
 }
 
 /// An iterator over the relocations for an `ElfSection32`.
-pub type ElfSectionRelocationIterator32<'data, 'file, Endian = Endianness> =
-    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader32<Endian>>;
+pub type ElfSectionRelocationIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader32<Endian>, R>;
 /// An iterator over the relocations for an `ElfSection64`.
-pub type ElfSectionRelocationIterator64<'data, 'file, Endian = Endianness> =
-    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader64<Endian>>;
+pub type ElfSectionRelocationIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    ElfSectionRelocationIterator<'data, 'file, elf::FileHeader64<Endian>, R>;
 
 /// An iterator over the relocations for an `ElfSection`.
-pub struct ElfSectionRelocationIterator<'data, 'file, Elf>
+pub struct ElfSectionRelocationIterator<'data, 'file, Elf, R = &'data [u8]>
 where
-    'data: 'file,
     Elf: FileHeader,
+    R: ReadRef<'data>,
 {
     /// The current pointer in the chain of relocation sections.
     pub(super) section_index: usize,
-    pub(super) file: &'file ElfFile<'data, Elf>,
+    pub(super) file: &'file ElfFile<'data, Elf, R>,
     pub(super) relocations: Option<ElfRelaIterator<'data, Elf>>,
 }
 
-impl<'data, 'file, Elf: FileHeader> Iterator for ElfSectionRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf, R> Iterator for ElfSectionRelocationIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -208,7 +221,11 @@ impl<'data, 'file, Elf: FileHeader> Iterator for ElfSectionRelocationIterator<'d
     }
 }
 
-impl<'data, 'file, Elf: FileHeader> fmt::Debug for ElfSectionRelocationIterator<'data, 'file, Elf> {
+impl<'data, 'file, Elf, R> fmt::Debug for ElfSectionRelocationIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ElfSectionRelocationIterator").finish()
     }

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -6,11 +6,11 @@ use core::str;
 
 use crate::elf;
 use crate::endian::{self, Endianness};
-use crate::pod::{Bytes, Pod};
+use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
-    self, ObjectSymbol, ObjectSymbolTable, ReadError, SectionIndex, SymbolFlags, SymbolIndex,
-    SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
+    self, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, SectionIndex, SymbolFlags,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
 };
 
 use super::{FileHeader, SectionHeader, SectionTable};
@@ -39,9 +39,9 @@ impl<'data, Elf: FileHeader> Default for SymbolTable<'data, Elf> {
 
 impl<'data, Elf: FileHeader> SymbolTable<'data, Elf> {
     /// Parse the given symbol table section.
-    pub fn parse(
+    pub fn parse<R: ReadRef<'data>>(
         endian: Elf::Endian,
-        data: Bytes<'data>,
+        data: R,
         sections: &SectionTable<Elf>,
         section_index: usize,
         section: &Elf::SectionHeader,

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -16,25 +16,35 @@ use super::{
 };
 
 /// A 32-bit Mach-O object file.
-pub type MachOFile32<'data, Endian = Endianness> = MachOFile<'data, macho::MachHeader32<Endian>>;
+pub type MachOFile32<'data, Endian = Endianness, R = &'data [u8]> =
+    MachOFile<'data, macho::MachHeader32<Endian>, R>;
 /// A 64-bit Mach-O object file.
-pub type MachOFile64<'data, Endian = Endianness> = MachOFile<'data, macho::MachHeader64<Endian>>;
+pub type MachOFile64<'data, Endian = Endianness, R = &'data [u8]> =
+    MachOFile<'data, macho::MachHeader64<Endian>, R>;
 
 /// A partially parsed Mach-O file.
 ///
 /// Most of the functionality of this type is provided by the `Object` trait implementation.
 #[derive(Debug)]
-pub struct MachOFile<'data, Mach: MachHeader> {
+pub struct MachOFile<'data, Mach, R = &'data [u8]>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
     pub(super) endian: Mach::Endian,
-    pub(super) data: &'data [u8],
+    pub(super) data: R,
     pub(super) header: &'data Mach,
     pub(super) sections: Vec<MachOSectionInternal<'data, Mach>>,
     pub(super) symbols: SymbolTable<'data, Mach>,
 }
 
-impl<'data, Mach: MachHeader> MachOFile<'data, Mach> {
+impl<'data, Mach, R> MachOFile<'data, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
     /// Parse the raw Mach-O file data.
-    pub fn parse(data: &'data [u8]) -> Result<Self> {
+    pub fn parse(data: R) -> Result<Self> {
         let header = Mach::parse(data)?;
         let endian = header.endian()?;
 
@@ -77,22 +87,28 @@ impl<'data, Mach: MachHeader> MachOFile<'data, Mach> {
     }
 }
 
-impl<'data, Mach: MachHeader> read::private::Sealed for MachOFile<'data, Mach> {}
+impl<'data, Mach, R> read::private::Sealed for MachOFile<'data, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+}
 
-impl<'data, 'file, Mach> Object<'data, 'file> for MachOFile<'data, Mach>
+impl<'data, 'file, Mach, R> Object<'data, 'file> for MachOFile<'data, Mach, R>
 where
     'data: 'file,
     Mach: MachHeader,
+    R: 'file + ReadRef<'data>,
 {
-    type Segment = MachOSegment<'data, 'file, Mach>;
-    type SegmentIterator = MachOSegmentIterator<'data, 'file, Mach>;
-    type Section = MachOSection<'data, 'file, Mach>;
-    type SectionIterator = MachOSectionIterator<'data, 'file, Mach>;
-    type Comdat = MachOComdat<'data, 'file, Mach>;
-    type ComdatIterator = MachOComdatIterator<'data, 'file, Mach>;
-    type Symbol = MachOSymbol<'data, 'file, Mach>;
-    type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach>;
-    type SymbolTable = MachOSymbolTable<'data, 'file, Mach>;
+    type Segment = MachOSegment<'data, 'file, Mach, R>;
+    type SegmentIterator = MachOSegmentIterator<'data, 'file, Mach, R>;
+    type Section = MachOSection<'data, 'file, Mach, R>;
+    type SectionIterator = MachOSectionIterator<'data, 'file, Mach, R>;
+    type Comdat = MachOComdat<'data, 'file, Mach, R>;
+    type ComdatIterator = MachOComdatIterator<'data, 'file, Mach, R>;
+    type Symbol = MachOSymbol<'data, 'file, Mach, R>;
+    type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach, R>;
+    type SymbolTable = MachOSymbolTable<'data, 'file, Mach, R>;
     type DynamicRelocationIterator = NoDynamicRelocationIterator;
 
     fn architecture(&self) -> Architecture {
@@ -116,7 +132,7 @@ where
         self.header.is_type_64()
     }
 
-    fn segments(&'file self) -> MachOSegmentIterator<'data, 'file, Mach> {
+    fn segments(&'file self) -> MachOSegmentIterator<'data, 'file, Mach, R> {
         MachOSegmentIterator {
             file: self,
             commands: self
@@ -130,7 +146,7 @@ where
     fn section_by_name(
         &'file self,
         section_name: &str,
-    ) -> Option<MachOSection<'data, 'file, Mach>> {
+    ) -> Option<MachOSection<'data, 'file, Mach, R>> {
         // Translate the "." prefix to the "__" prefix used by OSX/Mach-O, eg
         // ".debug_info" to "__debug_info", and limit to 16 bytes total.
         let system_name = if section_name.starts_with('.') {
@@ -142,7 +158,7 @@ where
         } else {
             None
         };
-        let cmp_section_name = |section: &MachOSection<Mach>| {
+        let cmp_section_name = |section: &MachOSection<'data, 'file, Mach, R>| {
             section
                 .name()
                 .map(|name| {
@@ -162,7 +178,7 @@ where
     fn section_by_index(
         &'file self,
         index: SectionIndex,
-    ) -> Result<MachOSection<'data, 'file, Mach>> {
+    ) -> Result<MachOSection<'data, 'file, Mach, R>> {
         let internal = *self.section_internal(index)?;
         Ok(MachOSection {
             file: self,
@@ -170,23 +186,26 @@ where
         })
     }
 
-    fn sections(&'file self) -> MachOSectionIterator<'data, 'file, Mach> {
+    fn sections(&'file self) -> MachOSectionIterator<'data, 'file, Mach, R> {
         MachOSectionIterator {
             file: self,
             iter: self.sections.iter(),
         }
     }
 
-    fn comdats(&'file self) -> MachOComdatIterator<'data, 'file, Mach> {
+    fn comdats(&'file self) -> MachOComdatIterator<'data, 'file, Mach, R> {
         MachOComdatIterator { file: self }
     }
 
-    fn symbol_by_index(&'file self, index: SymbolIndex) -> Result<MachOSymbol<'data, 'file, Mach>> {
+    fn symbol_by_index(
+        &'file self,
+        index: SymbolIndex,
+    ) -> Result<MachOSymbol<'data, 'file, Mach, R>> {
         let nlist = self.symbols.symbol(index.0)?;
         MachOSymbol::new(self, index, nlist).read_error("Unsupported Mach-O symbol index")
     }
 
-    fn symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach> {
+    fn symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach, R> {
         MachOSymbolIterator {
             file: self,
             index: 0,
@@ -194,11 +213,11 @@ where
     }
 
     #[inline]
-    fn symbol_table(&'file self) -> Option<MachOSymbolTable<'data, 'file, Mach>> {
+    fn symbol_table(&'file self) -> Option<MachOSymbolTable<'data, 'file, Mach, R>> {
         Some(MachOSymbolTable { file: self })
     }
 
-    fn dynamic_symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach> {
+    fn dynamic_symbols(&'file self) -> MachOSymbolIterator<'data, 'file, Mach, R> {
         MachOSymbolIterator {
             file: self,
             index: self.symbols.len(),
@@ -206,7 +225,7 @@ where
     }
 
     #[inline]
-    fn dynamic_symbol_table(&'file self) -> Option<MachOSymbolTable<'data, 'file, Mach>> {
+    fn dynamic_symbol_table(&'file self) -> Option<MachOSymbolTable<'data, 'file, Mach, R>> {
         None
     }
 
@@ -316,20 +335,28 @@ where
 }
 
 /// An iterator over the COMDAT section groups of a `MachOFile64`.
-pub type MachOComdatIterator32<'data, 'file, Endian = Endianness> =
-    MachOComdatIterator<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachOComdatIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOComdatIterator<'data, 'file, macho::MachHeader32<Endian>, R>;
 /// An iterator over the COMDAT section groups of a `MachOFile64`.
-pub type MachOComdatIterator64<'data, 'file, Endian = Endianness> =
-    MachOComdatIterator<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachOComdatIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOComdatIterator<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// An iterator over the COMDAT section groups of a `MachOFile`.
 #[derive(Debug)]
-pub struct MachOComdatIterator<'data, 'file, Mach: MachHeader> {
-    file: &'file MachOFile<'data, Mach>,
+pub struct MachOComdatIterator<'data, 'file, Mach, R = &'data [u8]>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    file: &'file MachOFile<'data, Mach, R>,
 }
 
-impl<'data, 'file, Mach: MachHeader> Iterator for MachOComdatIterator<'data, 'file, Mach> {
-    type Item = MachOComdat<'data, 'file, Mach>;
+impl<'data, 'file, Mach, R> Iterator for MachOComdatIterator<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    type Item = MachOComdat<'data, 'file, Mach, R>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -338,23 +365,36 @@ impl<'data, 'file, Mach: MachHeader> Iterator for MachOComdatIterator<'data, 'fi
 }
 
 /// A COMDAT section group of a `MachOFile32`.
-pub type MachOComdat32<'data, 'file, Endian = Endianness> =
-    MachOComdat<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachOComdat32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOComdat<'data, 'file, macho::MachHeader32<Endian>, R>;
 
 /// A COMDAT section group of a `MachOFile64`.
-pub type MachOComdat64<'data, 'file, Endian = Endianness> =
-    MachOComdat<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachOComdat64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOComdat<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// A COMDAT section group of a `MachOFile`.
 #[derive(Debug)]
-pub struct MachOComdat<'data, 'file, Mach: MachHeader> {
-    file: &'file MachOFile<'data, Mach>,
+pub struct MachOComdat<'data, 'file, Mach, R = &'data [u8]>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    file: &'file MachOFile<'data, Mach, R>,
 }
 
-impl<'data, 'file, Mach: MachHeader> read::private::Sealed for MachOComdat<'data, 'file, Mach> {}
+impl<'data, 'file, Mach, R> read::private::Sealed for MachOComdat<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+}
 
-impl<'data, 'file, Mach: MachHeader> ObjectComdat<'data> for MachOComdat<'data, 'file, Mach> {
-    type SectionIterator = MachOComdatSectionIterator<'data, 'file, Mach>;
+impl<'data, 'file, Mach, R> ObjectComdat<'data> for MachOComdat<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    type SectionIterator = MachOComdatSectionIterator<'data, 'file, Mach, R>;
 
     #[inline]
     fn kind(&self) -> ComdatKind {
@@ -378,22 +418,28 @@ impl<'data, 'file, Mach: MachHeader> ObjectComdat<'data> for MachOComdat<'data, 
 }
 
 /// An iterator over the sections in a COMDAT section group of a `MachOFile32`.
-pub type MachOComdatSectionIterator32<'data, 'file, Endian = Endianness> =
-    MachOComdatSectionIterator<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachOComdatSectionIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOComdatSectionIterator<'data, 'file, macho::MachHeader32<Endian>, R>;
 /// An iterator over the sections in a COMDAT section group of a `MachOFile64`.
-pub type MachOComdatSectionIterator64<'data, 'file, Endian = Endianness> =
-    MachOComdatSectionIterator<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachOComdatSectionIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOComdatSectionIterator<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// An iterator over the sections in a COMDAT section group of a `MachOFile`.
 #[derive(Debug)]
-pub struct MachOComdatSectionIterator<'data, 'file, Mach: MachHeader>
+pub struct MachOComdatSectionIterator<'data, 'file, Mach, R = &'data [u8]>
 where
     'data: 'file,
+    Mach: MachHeader,
+    R: ReadRef<'data>,
 {
-    file: &'file MachOFile<'data, Mach>,
+    file: &'file MachOFile<'data, Mach, R>,
 }
 
-impl<'data, 'file, Mach: MachHeader> Iterator for MachOComdatSectionIterator<'data, 'file, Mach> {
+impl<'data, 'file, Mach, R> Iterator for MachOComdatSectionIterator<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -5,8 +5,8 @@ use crate::endian::{self, Endianness};
 use crate::macho;
 use crate::pod::Pod;
 use crate::read::{
-    self, CompressedData, ObjectSection, ReadError, ReadRef, Result, SectionFlags, SectionIndex,
-    SectionKind,
+    self, CompressedData, CompressedFileRange, ObjectSection, ReadError, ReadRef, Result,
+    SectionFlags, SectionIndex, SectionKind,
 };
 
 use super::{MachHeader, MachOFile, MachORelocationIterator};
@@ -138,6 +138,11 @@ where
             address,
             size,
         ))
+    }
+
+    #[inline]
+    fn compressed_file_range(&self) -> Result<CompressedFileRange> {
+        Ok(CompressedFileRange::none(self.file_range()))
     }
 
     #[inline]

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -7,7 +7,7 @@ use crate::macho;
 use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
-    self, ObjectMap, ObjectMapEntry, ObjectSymbol, ObjectSymbolTable, ReadError, Result,
+    self, ObjectMap, ObjectMapEntry, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Result,
     SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapEntry,
     SymbolScope, SymbolSection,
 };
@@ -141,28 +141,36 @@ impl<'data, Mach: MachHeader> SymbolTable<'data, Mach> {
 }
 
 /// An iterator over the symbols of a `MachOFile32`.
-pub type MachOSymbolTable32<'data, 'file, Endian = Endianness> =
-    MachOSymbolTable<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachOSymbolTable32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOSymbolTable<'data, 'file, macho::MachHeader32<Endian>, R>;
 /// An iterator over the symbols of a `MachOFile64`.
-pub type MachOSymbolTable64<'data, 'file, Endian = Endianness> =
-    MachOSymbolTable<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachOSymbolTable64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOSymbolTable<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// A symbol table of a `MachOFile`.
 #[derive(Debug, Clone, Copy)]
-pub struct MachOSymbolTable<'data, 'file, Mach: MachHeader> {
-    pub(super) file: &'file MachOFile<'data, Mach>,
+pub struct MachOSymbolTable<'data, 'file, Mach, R = &'data [u8]>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    pub(super) file: &'file MachOFile<'data, Mach, R>,
 }
 
-impl<'data, 'file, Mach: MachHeader> read::private::Sealed
-    for MachOSymbolTable<'data, 'file, Mach>
+impl<'data, 'file, Mach, R> read::private::Sealed for MachOSymbolTable<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
 {
 }
 
-impl<'data, 'file, Mach: MachHeader> ObjectSymbolTable<'data>
-    for MachOSymbolTable<'data, 'file, Mach>
+impl<'data, 'file, Mach, R> ObjectSymbolTable<'data> for MachOSymbolTable<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
 {
-    type Symbol = MachOSymbol<'data, 'file, Mach>;
-    type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach>;
+    type Symbol = MachOSymbol<'data, 'file, Mach, R>;
+    type SymbolIterator = MachOSymbolIterator<'data, 'file, Mach, R>;
 
     fn symbols(&self) -> Self::SymbolIterator {
         MachOSymbolIterator {
@@ -178,26 +186,38 @@ impl<'data, 'file, Mach: MachHeader> ObjectSymbolTable<'data>
 }
 
 /// An iterator over the symbols of a `MachOFile32`.
-pub type MachOSymbolIterator32<'data, 'file, Endian = Endianness> =
-    MachOSymbolIterator<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachOSymbolIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOSymbolIterator<'data, 'file, macho::MachHeader32<Endian>, R>;
 /// An iterator over the symbols of a `MachOFile64`.
-pub type MachOSymbolIterator64<'data, 'file, Endian = Endianness> =
-    MachOSymbolIterator<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachOSymbolIterator64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOSymbolIterator<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// An iterator over the symbols of a `MachOFile`.
-pub struct MachOSymbolIterator<'data, 'file, Mach: MachHeader> {
-    pub(super) file: &'file MachOFile<'data, Mach>,
+pub struct MachOSymbolIterator<'data, 'file, Mach, R = &'data [u8]>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    pub(super) file: &'file MachOFile<'data, Mach, R>,
     pub(super) index: usize,
 }
 
-impl<'data, 'file, Mach: MachHeader> fmt::Debug for MachOSymbolIterator<'data, 'file, Mach> {
+impl<'data, 'file, Mach, R> fmt::Debug for MachOSymbolIterator<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MachOSymbolIterator").finish()
     }
 }
 
-impl<'data, 'file, Mach: MachHeader> Iterator for MachOSymbolIterator<'data, 'file, Mach> {
-    type Item = MachOSymbol<'data, 'file, Mach>;
+impl<'data, 'file, Mach, R> Iterator for MachOSymbolIterator<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    type Item = MachOSymbol<'data, 'file, Mach, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -212,23 +232,31 @@ impl<'data, 'file, Mach: MachHeader> Iterator for MachOSymbolIterator<'data, 'fi
 }
 
 /// A symbol of a `MachOFile32`.
-pub type MachOSymbol32<'data, 'file, Endian = Endianness> =
-    MachOSymbol<'data, 'file, macho::MachHeader32<Endian>>;
+pub type MachOSymbol32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOSymbol<'data, 'file, macho::MachHeader32<Endian>, R>;
 /// A symbol of a `MachOFile64`.
-pub type MachOSymbol64<'data, 'file, Endian = Endianness> =
-    MachOSymbol<'data, 'file, macho::MachHeader64<Endian>>;
+pub type MachOSymbol64<'data, 'file, Endian = Endianness, R = &'data [u8]> =
+    MachOSymbol<'data, 'file, macho::MachHeader64<Endian>, R>;
 
 /// A symbol of a `MachOFile`.
 #[derive(Debug, Clone, Copy)]
-pub struct MachOSymbol<'data, 'file, Mach: MachHeader> {
-    file: &'file MachOFile<'data, Mach>,
+pub struct MachOSymbol<'data, 'file, Mach, R = &'data [u8]>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    file: &'file MachOFile<'data, Mach, R>,
     index: SymbolIndex,
     nlist: &'data Mach::Nlist,
 }
 
-impl<'data, 'file, Mach: MachHeader> MachOSymbol<'data, 'file, Mach> {
+impl<'data, 'file, Mach, R> MachOSymbol<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
     pub(super) fn new(
-        file: &'file MachOFile<'data, Mach>,
+        file: &'file MachOFile<'data, Mach, R>,
         index: SymbolIndex,
         nlist: &'data Mach::Nlist,
     ) -> Option<Self> {
@@ -239,9 +267,18 @@ impl<'data, 'file, Mach: MachHeader> MachOSymbol<'data, 'file, Mach> {
     }
 }
 
-impl<'data, 'file, Mach: MachHeader> read::private::Sealed for MachOSymbol<'data, 'file, Mach> {}
+impl<'data, 'file, Mach, R> read::private::Sealed for MachOSymbol<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+}
 
-impl<'data, 'file, Mach: MachHeader> ObjectSymbol<'data> for MachOSymbol<'data, 'file, Mach> {
+impl<'data, 'file, Mach, R> ObjectSymbol<'data> for MachOSymbol<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
     #[inline]
     fn index(&self) -> SymbolIndex {
         self.index

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -10,6 +10,11 @@ use crate::{ByteString, Endianness};
 mod read_ref;
 pub use read_ref::*;
 
+#[cfg(feature = "std")]
+mod read_cache;
+#[cfg(feature = "std")]
+pub use read_cache::*;
+
 mod util;
 pub use util::StringTable;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -7,6 +7,9 @@ use core::{fmt, result};
 use crate::common::*;
 use crate::{ByteString, Bytes};
 
+mod read_ref;
+pub use read_ref::*;
+
 mod util;
 pub use util::StringTable;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::{fmt, result};
 
 use crate::common::*;
-use crate::{ByteString, Bytes};
+use crate::ByteString;
 
 mod read_ref;
 pub use read_ref::*;
@@ -508,12 +508,6 @@ impl Relocation {
     pub fn has_implicit_addend(&self) -> bool {
         self.implicit_addend
     }
-}
-
-fn data_range(data: Bytes, data_address: u64, range_address: u64, size: u64) -> Option<&[u8]> {
-    let offset = range_address.checked_sub(data_address)?;
-    let data = data.read_bytes_at(offset as usize, size as usize).ok()?;
-    Some(data.0)
 }
 
 /// Data that may be compressed.

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -5,7 +5,7 @@ use core::{mem, str};
 use crate::read::coff::{CoffCommon, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, SymbolTable};
 use crate::read::{
     self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
-    Object, ObjectComdat, ReadError, Result, SectionIndex, SymbolIndex,
+    Object, ObjectComdat, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
 };
 use crate::{pe, ByteString, Bytes, LittleEndian as LE, Pod, U16Bytes, U32Bytes, U32, U64};
 
@@ -23,16 +23,16 @@ pub struct PeFile<'data, Pe: ImageNtHeaders> {
     pub(super) nt_headers: &'data Pe,
     pub(super) data_directories: &'data [pe::ImageDataDirectory],
     pub(super) common: CoffCommon<'data>,
-    pub(super) data: Bytes<'data>,
+    pub(super) data: &'data [u8],
 }
 
 impl<'data, Pe: ImageNtHeaders> PeFile<'data, Pe> {
     /// Parse the raw PE file data.
     pub fn parse(data: &'data [u8]) -> Result<Self> {
-        let data = Bytes(data);
         let dos_header = pe::ImageDosHeader::parse(data)?;
-        let (nt_headers, data_directories, nt_tail) = dos_header.nt_headers::<Pe>(data)?;
-        let sections = nt_headers.sections(nt_tail)?;
+        let mut offset = dos_header.nt_headers_offset().into();
+        let (nt_headers, data_directories) = Pe::parse(data, &mut offset)?;
+        let sections = nt_headers.sections(data, offset)?;
         let symbols = nt_headers.symbols(data)?;
         let image_base = u64::from(nt_headers.optional_header().image_base());
 
@@ -70,7 +70,7 @@ impl<'data, Pe: ImageNtHeaders> PeFile<'data, Pe> {
     }
 
     fn data_at(&self, va: u32) -> Option<Bytes<'data>> {
-        self.common.sections.pe_data_at(self.data, va)
+        self.common.sections.pe_data_at(self.data, va).map(Bytes)
     }
 }
 
@@ -191,7 +191,7 @@ where
             Some(data_dir) => data_dir,
             None => return Ok(Vec::new()),
         };
-        let mut import_descriptors = data_dir.data(self.data, &self.common.sections)?;
+        let mut import_descriptors = data_dir.data(self.data, &self.common.sections).map(Bytes)?;
         let mut imports = Vec::new();
         loop {
             let import_desc = import_descriptors
@@ -261,7 +261,7 @@ where
         };
         let export_va = data_dir.virtual_address.get(LE);
         let export_size = data_dir.size.get(LE);
-        let export_data = data_dir.data(self.data, &self.common.sections)?;
+        let export_data = data_dir.data(self.data, &self.common.sections).map(Bytes)?;
         let export_dir = export_data
             .read_at::<pe::ImageExportDirectory>(0)
             .read_error("Invalid PE export dir size")?;
@@ -411,7 +411,7 @@ impl pe::ImageDosHeader {
     /// Read the DOS header.
     ///
     /// Also checks that the `e_magic` field in the header is valid.
-    pub fn parse<'data>(data: Bytes<'data>) -> read::Result<&'data Self> {
+    pub fn parse<'data, R: ReadRef<'data>>(data: R) -> read::Result<&'data Self> {
         // DOS header comes first.
         let dos_header = data
             .read_at::<pe::ImageDosHeader>(0)
@@ -422,18 +422,10 @@ impl pe::ImageDosHeader {
         Ok(dos_header)
     }
 
-    /// Read the NT headers, including the data directories.
-    ///
-    /// The given data must be for the entire file.  Returns the data following the NT headers,
-    /// which will contain the section headers.
-    ///
-    /// Also checks that the `signature` and `magic` fields in the headers are valid.
+    /// Return the file offset of the nt_headers.
     #[inline]
-    pub fn nt_headers<'data, Pe: ImageNtHeaders>(
-        &self,
-        data: Bytes<'data>,
-    ) -> read::Result<(&'data Pe, &'data [pe::ImageDataDirectory], Bytes<'data>)> {
-        Pe::parse(self, data)
+    pub fn nt_headers_offset(&self) -> u32 {
+        self.e_lfanew.get(LE)
     }
 }
 
@@ -441,14 +433,14 @@ impl pe::ImageDosHeader {
 ///
 /// It can be useful to know this magic value before trying to
 /// fully parse the NT headers.
-pub fn optional_header_magic(data: &[u8]) -> Result<u16> {
-    let data = Bytes(data);
+pub fn optional_header_magic<'data, R: ReadRef<'data>>(data: R) -> Result<u16> {
     let dos_header = pe::ImageDosHeader::parse(data)?;
     // NT headers are at an offset specified in the DOS header.
+    let offset = dos_header.nt_headers_offset().into();
     // It doesn't matter which NT header type is used for the purpose
     // of reading the optional header magic.
     let nt_headers = data
-        .read_at::<pe::ImageNtHeaders32>(dos_header.e_lfanew.get(LE) as usize)
+        .read_at::<pe::ImageNtHeaders32>(offset)
         .read_error("Invalid NT headers offset, size, or alignment")?;
     if nt_headers.signature() != pe::IMAGE_NT_SIGNATURE {
         return Err(Error("Invalid PE magic"));
@@ -482,22 +474,20 @@ pub trait ImageNtHeaders: Debug + Pod {
 
     /// Read the NT headers, including the data directories.
     ///
-    /// The DOS header is required to determine the NT headers offset.
+    /// `data` must be for the entire file.
     ///
-    /// The given data must be for the entire file.  Returns the data following the NT headers,
-    /// which will contain the section headers.
+    /// `offset` must be headers offset, which can be obtained from `ImageDosHeader::nt_headers_offset`.
+    /// It is updated to point after the optional header, which is where the section headers are located.
     ///
     /// Also checks that the `signature` and `magic` fields in the headers are valid.
-    fn parse<'data>(
-        dos_header: &pe::ImageDosHeader,
-        mut data: Bytes<'data>,
-    ) -> read::Result<(&'data Self, &'data [pe::ImageDataDirectory], Bytes<'data>)> {
-        data.skip(dos_header.e_lfanew.get(LE) as usize)
-            .read_error("Invalid PE headers offset")?;
+    fn parse<'data, R: ReadRef<'data>>(
+        data: R,
+        offset: &mut u64,
+    ) -> read::Result<(&'data Self, &'data [pe::ImageDataDirectory])> {
         // Note that this does not include the data directories in the optional header.
         let nt_headers = data
-            .read::<Self>()
-            .read_error("Invalid PE headers size or alignment")?;
+            .read::<Self>(offset)
+            .read_error("Invalid PE headers offset or size")?;
         if nt_headers.signature() != pe::IMAGE_NT_SIGNATURE {
             return Err(Error("Invalid PE magic"));
         }
@@ -506,33 +496,39 @@ pub trait ImageNtHeaders: Debug + Pod {
         }
 
         // Read the rest of the optional header, and then read the data directories from that.
-        let optional_data_size = (nt_headers.file_header().size_of_optional_header.get(LE)
-            as usize)
-            .checked_sub(mem::size_of::<Self::ImageOptionalHeader>())
-            .read_error("PE optional header size is too small")?;
+        let optional_data_size =
+            u64::from(nt_headers.file_header().size_of_optional_header.get(LE))
+                .checked_sub(mem::size_of::<Self::ImageOptionalHeader>() as u64)
+                .read_error("PE optional header size is too small")?;
         let mut optional_data = data
-            .read_bytes(optional_data_size)
-            .read_error("Invalid PE optional header size")?;
+            .read_bytes(offset, optional_data_size)
+            .read_error("Invalid PE optional header size")
+            .map(Bytes)?;
         let data_directories = optional_data
             .read_slice(nt_headers.optional_header().number_of_rva_and_sizes() as usize)
             .read_error("Invalid PE number of RVA and sizes")?;
 
-        Ok((nt_headers, data_directories, data))
+        Ok((nt_headers, data_directories))
     }
 
     /// Read the section table.
     ///
-    /// `nt_tail` must be the data following the NT headers.
+    /// `data` must be for the entire file.
+    /// `offset` must be after the optional file header.
     #[inline]
-    fn sections<'data>(&self, nt_tail: Bytes<'data>) -> read::Result<SectionTable<'data>> {
-        SectionTable::parse(self.file_header(), nt_tail)
+    fn sections<'data, R: ReadRef<'data>>(
+        &self,
+        data: R,
+        offset: u64,
+    ) -> read::Result<SectionTable<'data>> {
+        SectionTable::parse(self.file_header(), data, offset)
     }
 
     /// Read the symbol table and string table.
     ///
     /// `data` must be the entire file data.
     #[inline]
-    fn symbols<'data>(&self, data: Bytes<'data>) -> read::Result<SymbolTable<'data>> {
+    fn symbols<'data, R: ReadRef<'data>>(&self, data: R) -> read::Result<SymbolTable<'data>> {
         SymbolTable::parse(self.file_header(), data)
     }
 }
@@ -930,13 +926,13 @@ impl pe::ImageDataDirectory {
     /// Get the data referenced by this directory entry.
     pub fn data<'data>(
         &self,
-        data: Bytes<'data>,
+        data: &'data [u8],
         sections: &SectionTable<'data>,
-    ) -> Result<Bytes<'data>> {
+    ) -> Result<&'data [u8]> {
         sections
             .pe_data_at(data, self.virtual_address.get(LE))
-            .read_error("Invalid data dir virtual address")?
-            .read_bytes(self.size.get(LE) as usize)
+            .read_error("Invalid data dir virtual address or size")?
+            .get(..self.size.get(LE) as usize)
             .read_error("Invalid data dir size")
     }
 }

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -11,23 +11,29 @@ use crate::read::{
 use super::{ImageNtHeaders, PeFile, SectionTable};
 
 /// An iterator over the loadable sections of a `PeFile32`.
-pub type PeSegmentIterator32<'data, 'file> = PeSegmentIterator<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeSegmentIterator32<'data, 'file, R = &'data [u8]> =
+    PeSegmentIterator<'data, 'file, pe::ImageNtHeaders32, R>;
 /// An iterator over the loadable sections of a `PeFile64`.
-pub type PeSegmentIterator64<'data, 'file> = PeSegmentIterator<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeSegmentIterator64<'data, 'file, R = &'data [u8]> =
+    PeSegmentIterator<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// An iterator over the loadable sections of a `PeFile`.
 #[derive(Debug)]
-pub struct PeSegmentIterator<'data, 'file, Pe>
+pub struct PeSegmentIterator<'data, 'file, Pe, R = &'data [u8]>
 where
-    'data: 'file,
     Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
 {
-    pub(super) file: &'file PeFile<'data, Pe>,
+    pub(super) file: &'file PeFile<'data, Pe, R>,
     pub(super) iter: slice::Iter<'file, pe::ImageSectionHeader>,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeSegmentIterator<'data, 'file, Pe> {
-    type Item = PeSegment<'data, 'file, Pe>;
+impl<'data, 'file, Pe, R> Iterator for PeSegmentIterator<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
+    type Item = PeSegment<'data, 'file, Pe, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|section| PeSegment {
@@ -38,22 +44,28 @@ impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeSegmentIterator<'data, 'fi
 }
 
 /// A loadable section of a `PeFile32`.
-pub type PeSegment32<'data, 'file> = PeSegment<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeSegment32<'data, 'file, R = &'data [u8]> =
+    PeSegment<'data, 'file, pe::ImageNtHeaders32, R>;
 /// A loadable section of a `PeFile64`.
-pub type PeSegment64<'data, 'file> = PeSegment<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeSegment64<'data, 'file, R = &'data [u8]> =
+    PeSegment<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// A loadable section of a `PeFile`.
 #[derive(Debug)]
-pub struct PeSegment<'data, 'file, Pe>
+pub struct PeSegment<'data, 'file, Pe, R = &'data [u8]>
 where
-    'data: 'file,
     Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
 {
-    file: &'file PeFile<'data, Pe>,
+    file: &'file PeFile<'data, Pe, R>,
     section: &'file pe::ImageSectionHeader,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> PeSegment<'data, 'file, Pe> {
+impl<'data, 'file, Pe, R> PeSegment<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
     fn bytes(&self) -> Result<&'data [u8]> {
         self.section
             .pe_data(self.file.data)
@@ -61,9 +73,18 @@ impl<'data, 'file, Pe: ImageNtHeaders> PeSegment<'data, 'file, Pe> {
     }
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> read::private::Sealed for PeSegment<'data, 'file, Pe> {}
+impl<'data, 'file, Pe, R> read::private::Sealed for PeSegment<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
+}
 
-impl<'data, 'file, Pe: ImageNtHeaders> ObjectSegment<'data> for PeSegment<'data, 'file, Pe> {
+impl<'data, 'file, Pe, R> ObjectSegment<'data> for PeSegment<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
     #[inline]
     fn address(&self) -> u64 {
         u64::from(self.section.virtual_address.get(LE))
@@ -110,23 +131,30 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSegment<'data> for PeSegment<'data,
 }
 
 /// An iterator over the sections of a `PeFile32`.
-pub type PeSectionIterator32<'data, 'file> = PeSectionIterator<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeSectionIterator32<'data, 'file, R = &'data [u8]> =
+    PeSectionIterator<'data, 'file, pe::ImageNtHeaders32, R>;
 /// An iterator over the sections of a `PeFile64`.
-pub type PeSectionIterator64<'data, 'file> = PeSectionIterator<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeSectionIterator64<'data, 'file, R = &'data [u8]> =
+    PeSectionIterator<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// An iterator over the sections of a `PeFile`.
 #[derive(Debug)]
-pub struct PeSectionIterator<'data, 'file, Pe>
+pub struct PeSectionIterator<'data, 'file, Pe, R = &'data [u8]>
 where
     'data: 'file,
     Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
 {
-    pub(super) file: &'file PeFile<'data, Pe>,
+    pub(super) file: &'file PeFile<'data, Pe, R>,
     pub(super) iter: iter::Enumerate<slice::Iter<'file, pe::ImageSectionHeader>>,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeSectionIterator<'data, 'file, Pe> {
-    type Item = PeSection<'data, 'file, Pe>;
+impl<'data, 'file, Pe, R> Iterator for PeSectionIterator<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
+    type Item = PeSection<'data, 'file, Pe, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, section)| PeSection {
@@ -138,23 +166,30 @@ impl<'data, 'file, Pe: ImageNtHeaders> Iterator for PeSectionIterator<'data, 'fi
 }
 
 /// A section of a `PeFile32`.
-pub type PeSection32<'data, 'file> = PeSection<'data, 'file, pe::ImageNtHeaders32>;
+pub type PeSection32<'data, 'file, R = &'data [u8]> =
+    PeSection<'data, 'file, pe::ImageNtHeaders32, R>;
 /// A section of a `PeFile64`.
-pub type PeSection64<'data, 'file> = PeSection<'data, 'file, pe::ImageNtHeaders64>;
+pub type PeSection64<'data, 'file, R = &'data [u8]> =
+    PeSection<'data, 'file, pe::ImageNtHeaders64, R>;
 
 /// A section of a `PeFile`.
 #[derive(Debug)]
-pub struct PeSection<'data, 'file, Pe>
+pub struct PeSection<'data, 'file, Pe, R = &'data [u8]>
 where
     'data: 'file,
     Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
 {
-    pub(super) file: &'file PeFile<'data, Pe>,
+    pub(super) file: &'file PeFile<'data, Pe, R>,
     pub(super) index: SectionIndex,
     pub(super) section: &'file pe::ImageSectionHeader,
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> PeSection<'data, 'file, Pe> {
+impl<'data, 'file, Pe, R> PeSection<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
     fn bytes(&self) -> Result<&'data [u8]> {
         self.section
             .pe_data(self.file.data)
@@ -162,10 +197,19 @@ impl<'data, 'file, Pe: ImageNtHeaders> PeSection<'data, 'file, Pe> {
     }
 }
 
-impl<'data, 'file, Pe: ImageNtHeaders> read::private::Sealed for PeSection<'data, 'file, Pe> {}
+impl<'data, 'file, Pe, R> read::private::Sealed for PeSection<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
+}
 
-impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data, 'file, Pe> {
-    type RelocationIterator = PeRelocationIterator<'data, 'file>;
+impl<'data, 'file, Pe, R> ObjectSection<'data> for PeSection<'data, 'file, Pe, R>
+where
+    Pe: ImageNtHeaders,
+    R: ReadRef<'data>,
+{
+    type RelocationIterator = PeRelocationIterator<'data, 'file, R>;
 
     #[inline]
     fn index(&self) -> SectionIndex {
@@ -233,8 +277,8 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
         self.section.kind()
     }
 
-    fn relocations(&self) -> PeRelocationIterator<'data, 'file> {
-        PeRelocationIterator::default()
+    fn relocations(&self) -> PeRelocationIterator<'data, 'file, R> {
+        PeRelocationIterator(PhantomData)
     }
 
     fn flags(&self) -> SectionFlags {
@@ -246,7 +290,7 @@ impl<'data, 'file, Pe: ImageNtHeaders> ObjectSection<'data> for PeSection<'data,
 
 impl<'data> SectionTable<'data> {
     /// Return the data at the given virtual address in a PE file.
-    pub fn pe_data_at(&self, data: &'data [u8], va: u32) -> Option<&'data [u8]> {
+    pub fn pe_data_at<R: ReadRef<'data>>(&self, data: R, va: u32) -> Option<&'data [u8]> {
         self.iter()
             .filter_map(|section| section.pe_data_at(data, va))
             .next()
@@ -280,10 +324,12 @@ impl pe::ImageSectionHeader {
 }
 
 /// An iterator over the relocations in an `PeSection`.
-#[derive(Debug, Default)]
-pub struct PeRelocationIterator<'data, 'file>(PhantomData<(&'data (), &'file ())>);
+#[derive(Debug)]
+pub struct PeRelocationIterator<'data, 'file, R = &'data [u8]>(
+    PhantomData<(&'data (), &'file (), R)>,
+);
 
-impl<'data, 'file> Iterator for PeRelocationIterator<'data, 'file> {
+impl<'data, 'file, R> Iterator for PeRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -4,8 +4,8 @@ use core::{cmp, iter, result, slice, str};
 use crate::endian::LittleEndian as LE;
 use crate::pe;
 use crate::read::{
-    self, CompressedData, ObjectSection, ObjectSegment, ReadError, ReadRef, Relocation, Result,
-    SectionFlags, SectionIndex, SectionKind,
+    self, CompressedData, CompressedFileRange, ObjectSection, ObjectSegment, ReadError, ReadRef,
+    Relocation, Result, SectionFlags, SectionIndex, SectionKind,
 };
 
 use super::{ImageNtHeaders, PeFile, SectionTable};
@@ -252,6 +252,11 @@ where
             address,
             size,
         ))
+    }
+
+    #[inline]
+    fn compressed_file_range(&self) -> Result<CompressedFileRange> {
+        Ok(CompressedFileRange::none(self.file_range()))
     }
 
     #[inline]

--- a/src/read/read_cache.rs
+++ b/src/read/read_cache.rs
@@ -1,0 +1,130 @@
+use std::boxed::Box;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::io::{Read, Seek, SeekFrom};
+use std::mem;
+
+use crate::read::ReadRef;
+
+/// An implementation of `ReadRef` for data in a stream that implements
+/// `Read + Seek`.
+///
+/// Contains a cache of read-only blocks of data, allowing references to
+/// them to be returned. Entries in the cache are never removed.
+/// Entries are keyed on the offset and size of the read.
+/// Currently overlapping reads are considered separate reads.
+#[derive(Debug)]
+pub struct ReadCache<R: Read + Seek> {
+    cache: RefCell<ReadCacheInternal<R>>,
+}
+
+#[derive(Debug)]
+struct ReadCacheInternal<R: Read + Seek> {
+    read: R,
+    bufs: HashMap<(u64, u64), Box<[u8]>>,
+}
+
+impl<R: Read + Seek> ReadCache<R> {
+    /// Create an empty `ReadCache` for the given stream.
+    pub fn new(read: R) -> Self {
+        ReadCache {
+            cache: RefCell::new(ReadCacheInternal {
+                read,
+                bufs: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Return an implementation of `ReadRef` that restricts reads
+    /// to the given range of the stream.
+    pub fn range<'a>(&'a self, offset: u64, size: u64) -> ReadCacheRange<'a, R> {
+        ReadCacheRange {
+            r: self,
+            offset,
+            size,
+        }
+    }
+
+    /// Free buffers used by the cache.
+    pub fn clear(&mut self) {
+        self.cache.borrow_mut().bufs.clear();
+    }
+
+    /// Unwrap this `ReadCache<R>`, returning the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.cache.into_inner().read
+    }
+}
+
+impl<'a, R: Read + Seek> ReadRef<'a> for &'a ReadCache<R> {
+    fn len(self) -> Result<u64, ()> {
+        let cache = &mut *self.cache.borrow_mut();
+        cache.read.seek(SeekFrom::End(0)).map_err(|_| ())
+    }
+
+    fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8], ()> {
+        if size == 0 {
+            return Ok(&[]);
+        }
+        let cache = &mut *self.cache.borrow_mut();
+        let buf = match cache.bufs.entry((offset, size)) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let size = size.try_into().map_err(|_| ())?;
+                cache
+                    .read
+                    .seek(SeekFrom::Start(offset as u64))
+                    .map_err(|_| ())?;
+                let mut bytes = vec![0; size].into_boxed_slice();
+                cache.read.read_exact(&mut bytes).map_err(|_| ())?;
+                entry.insert(bytes)
+            }
+        };
+        // Extend the lifetime to that of self.
+        // This is OK because we never mutate or remove entries.
+        Ok(unsafe { mem::transmute::<&[u8], &[u8]>(buf) })
+    }
+}
+
+/// An implementation of `ReadRef` for a range of data in a stream that
+/// implements `Read + Seek`.
+///
+/// Shares an underlying `ReadCache` with a lifetime of `'a`.
+#[derive(Debug)]
+pub struct ReadCacheRange<'a, R: Read + Seek> {
+    r: &'a ReadCache<R>,
+    offset: u64,
+    size: u64,
+}
+
+impl<'a, R: Read + Seek> Clone for ReadCacheRange<'a, R> {
+    fn clone(&self) -> Self {
+        Self {
+            r: self.r,
+            offset: self.offset,
+            size: self.size,
+        }
+    }
+}
+
+impl<'a, R: Read + Seek> Copy for ReadCacheRange<'a, R> {}
+
+impl<'a, R: Read + Seek> ReadRef<'a> for ReadCacheRange<'a, R> {
+    fn len(self) -> Result<u64, ()> {
+        Ok(self.size)
+    }
+
+    fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8], ()> {
+        if size == 0 {
+            return Ok(&[]);
+        }
+        let end = offset.checked_add(size).ok_or(())?;
+        if end > self.size {
+            return Err(());
+        }
+        let r_offset = self.offset.checked_add(offset).ok_or(())?;
+        self.r.read_bytes_at(r_offset, size)
+    }
+}

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -1,0 +1,126 @@
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use core::{mem, result};
+
+use crate::pod::{from_bytes, slice_from_bytes, Pod};
+
+type Result<T> = result::Result<T, ()>;
+
+/// A trait for reading references to `Pod` types from a block of data.
+///
+/// This allows parsers to handle both of these cases:
+/// - the block of data exists in memory, and it is desirable
+///   to use references to this block instead of copying it,
+/// - the block of data exists in storage, and it is desirable
+///   to read on demand to minimize I/O and memory usage.
+///
+/// The methods accept `self` by value because `Self` is expected to behave
+/// similar to a reference: it may be a reference with a lifetime of `'a`,
+/// or it may be a wrapper of a reference.
+///
+/// The `Clone` and `Copy` bounds are for convenience, and since `Self` is
+/// expected to be similar to a reference, these are easily satisfied.
+///
+/// Object file parsers typically use offsets to locate the structures
+/// in the block, and will most commonly use the `*_at` methods to
+/// read a structure at a known offset.
+///
+/// Occasionally file parsers will need to treat the block as a stream,
+/// and so convenience methods are provided that update an offset with
+/// the size that was read.
+//
+// An alternative would be for methods to accept `&mut self` and use a
+// `seek` method instead of the `offset` parameters, but this is less
+// convenient for implementers.
+pub trait ReadRef<'a>: Clone + Copy {
+    /// The total size of the block of data.
+    fn len(self) -> Result<u64>;
+
+    /// Get a reference to a `u8` slice at the given offset.
+    ///
+    /// Returns an error if offset or size are out of bounds.
+    fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8]>;
+
+    /// Get a reference to a `u8` slice at the given offset, and update the offset.
+    ///
+    /// Returns an error if offset or size are out of bounds.
+    fn read_bytes(self, offset: &mut u64, size: u64) -> Result<&'a [u8]> {
+        let bytes = self.read_bytes_at(*offset, size)?;
+        *offset = offset.wrapping_add(size);
+        Ok(bytes)
+    }
+
+    /// Get a reference to a `Pod` type at the given offset, and update the offset.
+    ///
+    /// Returns an error if offset or size are out of bounds.
+    ///
+    /// The default implementation uses `read_bytes`, and returns an error if
+    /// `read_bytes` does not return bytes with the correct alignment for `T`.
+    /// Implementors may want to provide their own implementation that ensures
+    /// the alignment can be satisified. Alternatively, only use this method with
+    /// types that do not need alignment (see the `unaligned` feature of this crate).
+    fn read<T: Pod>(self, offset: &mut u64) -> Result<&'a T> {
+        let size = mem::size_of::<T>().try_into().map_err(|_| ())?;
+        let bytes = self.read_bytes(offset, size)?;
+        let (t, _) = from_bytes(bytes)?;
+        Ok(t)
+    }
+
+    /// Get a reference to a `Pod` type at the given offset.
+    ///
+    /// Returns an error if offset or size are out of bounds.
+    ///
+    /// Also see the `read` method for information regarding alignment of `T`.
+    fn read_at<T: Pod>(self, mut offset: u64) -> Result<&'a T> {
+        self.read(&mut offset)
+    }
+
+    /// Get a reference to a slice of a `Pod` type at the given offset, and update the offset.
+    ///
+    /// Returns an error if offset or size are out of bounds.
+    ///
+    /// Also see the `read` method for information regarding alignment of `T`.
+    fn read_slice<T: Pod>(self, offset: &mut u64, count: usize) -> Result<&'a [T]> {
+        let size = count
+            .checked_mul(mem::size_of::<T>())
+            .ok_or(())?
+            .try_into()
+            .map_err(|_| ())?;
+        let bytes = self.read_bytes(offset, size)?;
+        let (t, _) = slice_from_bytes(bytes, count)?;
+        Ok(t)
+    }
+
+    /// Get a reference to a slice of a `Pod` type at the given offset.
+    ///
+    /// Returns an error if offset or size are out of bounds.
+    ///
+    /// Also see the `read` method for information regarding alignment of `T`.
+    fn read_slice_at<T: Pod>(self, mut offset: u64, count: usize) -> Result<&'a [T]> {
+        self.read_slice(&mut offset, count)
+    }
+}
+
+impl<'a> ReadRef<'a> for &'a [u8] {
+    fn len(self) -> Result<u64> {
+        self.len().try_into().map_err(|_| ())
+    }
+
+    fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8]> {
+        let offset: usize = offset.try_into().map_err(|_| ())?;
+        let size: usize = size.try_into().map_err(|_| ())?;
+        self.get(offset..).ok_or(())?.get(..size).ok_or(())
+    }
+}
+
+impl<'a> ReadRef<'a> for &'a Vec<u8> {
+    fn len(self) -> Result<u64> {
+        self.len().try_into().map_err(|_| ())
+    }
+
+    fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8]> {
+        let offset: usize = offset.try_into().map_err(|_| ())?;
+        let size: usize = size.try_into().map_err(|_| ())?;
+        self.get(offset..).ok_or(())?.get(..size).ok_or(())
+    }
+}

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -2,9 +2,9 @@ use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use crate::read::{
-    self, Architecture, ComdatKind, CompressedData, Export, FileFlags, Import, ObjectMap,
-    Relocation, Result, SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex,
-    SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
+    self, Architecture, ComdatKind, CompressedData, CompressedFileRange, Export, FileFlags, Import,
+    ObjectMap, Relocation, Result, SectionFlags, SectionIndex, SectionKind, SymbolFlags,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
 };
 use crate::Endianness;
 
@@ -272,6 +272,10 @@ pub trait ObjectSection<'data>: read::private::Sealed {
     ///
     /// Returns `Ok(None)` if the section does not contain the given range.
     fn data_range(&self, address: u64, size: u64) -> Result<Option<&'data [u8]>>;
+
+    /// Returns the potentially compressed file range of the section,
+    /// along with information about the compression.
+    fn compressed_file_range(&self) -> Result<CompressedFileRange>;
 
     /// Returns the potentially compressed contents of the section,
     /// along with information about the compression.

--- a/src/read/util.rs
+++ b/src/read/util.rs
@@ -1,9 +1,22 @@
+use core::convert::TryInto;
+
 use crate::pod::Bytes;
 
 #[allow(unused)]
 #[inline]
 pub(crate) fn align(offset: usize, size: usize) -> usize {
     (offset + (size - 1)) & !(size - 1)
+}
+
+pub(crate) fn data_range(
+    data: &[u8],
+    data_address: u64,
+    range_address: u64,
+    size: u64,
+) -> Option<&[u8]> {
+    let offset = range_address.checked_sub(data_address)?;
+    data.get(offset.try_into().ok()?..)?
+        .get(..size.try_into().ok()?)
 }
 
 /// A table of zero-terminated strings.
@@ -16,8 +29,8 @@ pub struct StringTable<'data> {
 
 impl<'data> StringTable<'data> {
     /// Interpret the given data as a string table.
-    pub fn new(data: Bytes<'data>) -> Self {
-        StringTable { data }
+    pub fn new(data: &'data [u8]) -> Self {
+        StringTable { data: Bytes(data) }
     }
 
     /// Return the string at the given offset.

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -12,8 +12,8 @@ use wasmparser as wp;
 use crate::read::{
     self, Architecture, ComdatKind, CompressedData, Error, Export, FileFlags, Import,
     NoDynamicRelocationIterator, Object, ObjectComdat, ObjectSection, ObjectSegment, ObjectSymbol,
-    ObjectSymbolTable, ReadError, Relocation, Result, SectionFlags, SectionIndex, SectionKind,
-    SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
+    ObjectSymbolTable, ReadError, ReadRef, Relocation, Result, SectionFlags, SectionIndex,
+    SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;
@@ -33,8 +33,8 @@ const SECTION_DATA_COUNT: usize = 12;
 const MAX_SECTION_ID: usize = SECTION_DATA_COUNT;
 
 /// A WebAssembly object file.
-#[derive(Debug, Default)]
-pub struct WasmFile<'data> {
+#[derive(Debug)]
+pub struct WasmFile<'data, R = &'data [u8]> {
     // All sections, including custom sections.
     sections: Vec<wp::Section<'data>>,
     // Indices into `sections` of sections with a non-zero id.
@@ -45,6 +45,7 @@ pub struct WasmFile<'data> {
     symbols: Vec<WasmSymbolInternal<'data>>,
     // Address of the function body for the entry point.
     entry: u64,
+    marker: PhantomData<R>,
 }
 
 #[derive(Clone)]
@@ -60,12 +61,21 @@ impl<T> ReadError<T> for wasmparser::Result<T> {
     }
 }
 
-impl<'data> WasmFile<'data> {
+impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
     /// Parse the raw wasm data.
-    pub fn parse(data: &'data [u8]) -> Result<Self> {
+    pub fn parse(data: R) -> Result<Self> {
+        let len = data.len().read_error("Unknown Wasm file size")?;
+        let data = data.read_bytes_at(0, len).read_error("Wasm read failed")?;
         let module = wp::ModuleReader::new(data).read_error("Invalid Wasm header")?;
 
-        let mut file = WasmFile::default();
+        let mut file = WasmFile {
+            sections: Vec::new(),
+            id_sections: Default::default(),
+            has_debug_symbols: false,
+            symbols: Vec::new(),
+            entry: 0,
+            marker: PhantomData,
+        };
 
         let mut main_file_symbol = Some(WasmSymbolInternal {
             name: "",
@@ -283,18 +293,19 @@ impl<'data> WasmFile<'data> {
     }
 }
 
-impl<'data> read::private::Sealed for WasmFile<'data> {}
+impl<'data, R> read::private::Sealed for WasmFile<'data, R> {}
 
-impl<'data, 'file> Object<'data, 'file> for WasmFile<'data>
+impl<'data, 'file, R> Object<'data, 'file> for WasmFile<'data, R>
 where
     'data: 'file,
+    R: 'file,
 {
-    type Segment = WasmSegment<'data, 'file>;
-    type SegmentIterator = WasmSegmentIterator<'data, 'file>;
-    type Section = WasmSection<'data, 'file>;
-    type SectionIterator = WasmSectionIterator<'data, 'file>;
-    type Comdat = WasmComdat<'data, 'file>;
-    type ComdatIterator = WasmComdatIterator<'data, 'file>;
+    type Segment = WasmSegment<'data, 'file, R>;
+    type SegmentIterator = WasmSegmentIterator<'data, 'file, R>;
+    type Section = WasmSection<'data, 'file, R>;
+    type SectionIterator = WasmSectionIterator<'data, 'file, R>;
+    type Comdat = WasmComdat<'data, 'file, R>;
+    type ComdatIterator = WasmComdatIterator<'data, 'file, R>;
     type Symbol = WasmSymbol<'data, 'file>;
     type SymbolIterator = WasmSymbolIterator<'data, 'file>;
     type SymbolTable = WasmSymbolTable<'data, 'file>;
@@ -324,12 +335,12 @@ where
         self.entry
     }
 
-    fn section_by_name(&'file self, section_name: &str) -> Option<WasmSection<'data, 'file>> {
+    fn section_by_name(&'file self, section_name: &str) -> Option<WasmSection<'data, 'file, R>> {
         self.sections()
             .find(|section| section.name() == Ok(section_name))
     }
 
-    fn section_by_index(&'file self, index: SectionIndex) -> Result<WasmSection<'data, 'file>> {
+    fn section_by_index(&'file self, index: SectionIndex) -> Result<WasmSection<'data, 'file, R>> {
         // TODO: Missing sections should return an empty section.
         let id_section = self
             .id_sections
@@ -337,12 +348,16 @@ where
             .and_then(|x| *x)
             .read_error("Invalid Wasm section index")?;
         let section = self.sections.get(id_section).unwrap();
-        Ok(WasmSection { section })
+        Ok(WasmSection {
+            section,
+            marker: PhantomData,
+        })
     }
 
     fn sections(&'file self) -> Self::SectionIterator {
         WasmSectionIterator {
             sections: self.sections.iter(),
+            marker: PhantomData,
         }
     }
 
@@ -409,12 +424,12 @@ where
 
 /// An iterator over the segments of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSegmentIterator<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmSegmentIterator<'data, 'file, R = &'data [u8]> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> Iterator for WasmSegmentIterator<'data, 'file> {
-    type Item = WasmSegment<'data, 'file>;
+impl<'data, 'file, R> Iterator for WasmSegmentIterator<'data, 'file, R> {
+    type Item = WasmSegment<'data, 'file, R>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -424,13 +439,13 @@ impl<'data, 'file> Iterator for WasmSegmentIterator<'data, 'file> {
 
 /// A segment of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSegment<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmSegment<'data, 'file, R = &'data [u8]> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> read::private::Sealed for WasmSegment<'data, 'file> {}
+impl<'data, 'file, R> read::private::Sealed for WasmSegment<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectSegment<'data> for WasmSegment<'data, 'file> {
+impl<'data, 'file, R> ObjectSegment<'data> for WasmSegment<'data, 'file, R> {
     #[inline]
     fn address(&self) -> u64 {
         unreachable!()
@@ -467,29 +482,34 @@ impl<'data, 'file> ObjectSegment<'data> for WasmSegment<'data, 'file> {
 
 /// An iterator over the sections of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSectionIterator<'data, 'file> {
+pub struct WasmSectionIterator<'data, 'file, R = &'data [u8]> {
     sections: slice::Iter<'file, wp::Section<'data>>,
+    marker: PhantomData<R>,
 }
 
-impl<'data, 'file> Iterator for WasmSectionIterator<'data, 'file> {
-    type Item = WasmSection<'data, 'file>;
+impl<'data, 'file, R> Iterator for WasmSectionIterator<'data, 'file, R> {
+    type Item = WasmSection<'data, 'file, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let section = self.sections.next()?;
-        Some(WasmSection { section })
+        Some(WasmSection {
+            section,
+            marker: PhantomData,
+        })
     }
 }
 
 /// A section of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmSection<'data, 'file> {
+pub struct WasmSection<'data, 'file, R = &'data [u8]> {
     section: &'file wp::Section<'data>,
+    marker: PhantomData<R>,
 }
 
-impl<'data, 'file> read::private::Sealed for WasmSection<'data, 'file> {}
+impl<'data, 'file, R> read::private::Sealed for WasmSection<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
-    type RelocationIterator = WasmRelocationIterator<'data, 'file>;
+impl<'data, 'file, R> ObjectSection<'data> for WasmSection<'data, 'file, R> {
+    type RelocationIterator = WasmRelocationIterator<'data, 'file, R>;
 
     #[inline]
     fn index(&self) -> SectionIndex {
@@ -586,8 +606,8 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
     }
 
     #[inline]
-    fn relocations(&self) -> WasmRelocationIterator<'data, 'file> {
-        WasmRelocationIterator::default()
+    fn relocations(&self) -> WasmRelocationIterator<'data, 'file, R> {
+        WasmRelocationIterator(PhantomData)
     }
 
     #[inline]
@@ -598,12 +618,12 @@ impl<'data, 'file> ObjectSection<'data> for WasmSection<'data, 'file> {
 
 /// An iterator over the COMDAT section groups of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmComdatIterator<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmComdatIterator<'data, 'file, R = &'data [u8]> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> Iterator for WasmComdatIterator<'data, 'file> {
-    type Item = WasmComdat<'data, 'file>;
+impl<'data, 'file, R> Iterator for WasmComdatIterator<'data, 'file, R> {
+    type Item = WasmComdat<'data, 'file, R>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -613,14 +633,14 @@ impl<'data, 'file> Iterator for WasmComdatIterator<'data, 'file> {
 
 /// A COMDAT section group of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmComdat<'data, 'file> {
-    file: &'file WasmFile<'data>,
+pub struct WasmComdat<'data, 'file, R = &'data [u8]> {
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> read::private::Sealed for WasmComdat<'data, 'file> {}
+impl<'data, 'file, R> read::private::Sealed for WasmComdat<'data, 'file, R> {}
 
-impl<'data, 'file> ObjectComdat<'data> for WasmComdat<'data, 'file> {
-    type SectionIterator = WasmComdatSectionIterator<'data, 'file>;
+impl<'data, 'file, R> ObjectComdat<'data> for WasmComdat<'data, 'file, R> {
+    type SectionIterator = WasmComdatSectionIterator<'data, 'file, R>;
 
     #[inline]
     fn kind(&self) -> ComdatKind {
@@ -645,14 +665,14 @@ impl<'data, 'file> ObjectComdat<'data> for WasmComdat<'data, 'file> {
 
 /// An iterator over the sections in a COMDAT section group of a `WasmFile`.
 #[derive(Debug)]
-pub struct WasmComdatSectionIterator<'data, 'file>
+pub struct WasmComdatSectionIterator<'data, 'file, R = &'data [u8]>
 where
     'data: 'file,
 {
-    file: &'file WasmFile<'data>,
+    file: &'file WasmFile<'data, R>,
 }
 
-impl<'data, 'file> Iterator for WasmComdatSectionIterator<'data, 'file> {
+impl<'data, 'file, R> Iterator for WasmComdatSectionIterator<'data, 'file, R> {
     type Item = SectionIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -797,10 +817,12 @@ impl<'data, 'file> ObjectSymbol<'data> for WasmSymbol<'data, 'file> {
 }
 
 /// An iterator over the relocations in a `WasmSection`.
-#[derive(Debug, Default)]
-pub struct WasmRelocationIterator<'data, 'file>(PhantomData<(&'data (), &'file ())>);
+#[derive(Debug)]
+pub struct WasmRelocationIterator<'data, 'file, R = &'data [u8]>(
+    PhantomData<(&'data (), &'file (), R)>,
+);
 
-impl<'data, 'file> Iterator for WasmRelocationIterator<'data, 'file> {
+impl<'data, 'file, R> Iterator for WasmRelocationIterator<'data, 'file, R> {
     type Item = (u64, Relocation);
 
     #[inline]

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -10,10 +10,10 @@ use core::{slice, str};
 use wasmparser as wp;
 
 use crate::read::{
-    self, Architecture, ComdatKind, CompressedData, Error, Export, FileFlags, Import,
-    NoDynamicRelocationIterator, Object, ObjectComdat, ObjectSection, ObjectSegment, ObjectSymbol,
-    ObjectSymbolTable, ReadError, ReadRef, Relocation, Result, SectionFlags, SectionIndex,
-    SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
+    self, Architecture, ComdatKind, CompressedData, CompressedFileRange, Error, Export, FileFlags,
+    Import, NoDynamicRelocationIterator, Object, ObjectComdat, ObjectSection, ObjectSegment,
+    ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Relocation, Result, SectionFlags,
+    SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;
@@ -550,6 +550,11 @@ impl<'data, 'file, R> ObjectSection<'data> for WasmSection<'data, 'file, R> {
 
     fn data_range(&self, _address: u64, _size: u64) -> Result<Option<&'data [u8]>> {
         unimplemented!()
+    }
+
+    #[inline]
+    fn compressed_file_range(&self) -> Result<CompressedFileRange> {
+        Ok(CompressedFileRange::none(self.file_range()))
     }
 
     #[inline]

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -6,7 +6,20 @@ use std::{env, fs};
 fn parse_self() {
     let exe = env::current_exe().unwrap();
     let data = fs::read(exe).unwrap();
-    let object = File::parse(&data).unwrap();
+    let object = File::parse(&*data).unwrap();
+    assert!(object.entry() != 0);
+    assert!(object.sections().count() != 0);
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn parse_self_cache() {
+    use object::read::{ReadCache, ReadRef};
+    let exe = env::current_exe().unwrap();
+    let file = fs::File::open(exe).unwrap();
+    let cache = ReadCache::new(file);
+    let data = cache.range(0, cache.len().unwrap());
+    let object = File::parse(data).unwrap();
     assert!(object.entry() != 0);
     assert!(object.sections().count() != 0);
 }

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -1,7 +1,7 @@
 use object::read::elf::{FileHeader, SectionHeader};
 use object::read::{Object, ObjectSymbol};
 use object::{
-    elf, read, write, Architecture, BinaryFormat, Bytes, Endianness, LittleEndian, SectionIndex,
+    elf, read, write, Architecture, BinaryFormat, Endianness, LittleEndian, SectionIndex,
     SectionKind, SymbolFlags, SymbolKind, SymbolScope, SymbolSection, U32,
 };
 use std::io::Write;
@@ -180,11 +180,10 @@ fn note() {
     let section = object.add_section(Vec::new(), b".note8".to_vec(), SectionKind::Note);
     object.section_mut(section).set_data(buffer, 8);
 
-    let bytes = object.write().unwrap();
+    let bytes = &*object.write().unwrap();
 
     //std::fs::write(&"note.o", &bytes).unwrap();
 
-    let bytes = Bytes(&bytes);
     let header = elf::FileHeader64::parse(bytes).unwrap();
     let endian: LittleEndian = header.endian().unwrap();
     let sections = header.sections(endian, bytes).unwrap();

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -180,7 +180,7 @@ fn note() {
     let section = object.add_section(Vec::new(), b".note8".to_vec(), SectionKind::Note);
     object.section_mut(section).set_data(buffer, 8);
 
-    let bytes = &*object.write().unwrap();
+    let bytes = &object.write().unwrap();
 
     //std::fs::write(&"note.o", &bytes).unwrap();
 

--- a/tests/round_trip/macho.rs
+++ b/tests/round_trip/macho.rs
@@ -1,5 +1,5 @@
 use object::read::macho::MachHeader;
-use object::{macho, write, Architecture, BinaryFormat, Bytes, Endianness};
+use object::{macho, write, Architecture, BinaryFormat, Endianness};
 
 #[test]
 // Test that segment size is valid when the first section needs alignment.
@@ -13,8 +13,7 @@ fn issue_286_segment_file_size() {
     let text = object.section_id(write::StandardSection::Text);
     object.append_section_data(text, &[1; 30], 0x1000);
 
-    let data = object.write().unwrap();
-    let bytes = Bytes(&data);
+    let bytes = &*object.write().unwrap();
     let header = macho::MachHeader64::parse(bytes).unwrap();
     let endian: Endianness = header.endian().unwrap();
     let mut commands = header.load_commands(endian, bytes).unwrap();


### PR DESCRIPTION
Allows reading from `Read + Seek` instead of `&[u8]`.

Fixes #269 