### PR TITLE
read: delete impl ReadRef for Vec

### DIFF
--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::convert::TryInto;
 use core::{mem, result};
 
@@ -102,18 +101,6 @@ pub trait ReadRef<'a>: Clone + Copy {
 }
 
 impl<'a> ReadRef<'a> for &'a [u8] {
-    fn len(self) -> Result<u64> {
-        self.len().try_into().map_err(|_| ())
-    }
-
-    fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8]> {
-        let offset: usize = offset.try_into().map_err(|_| ())?;
-        let size: usize = size.try_into().map_err(|_| ())?;
-        self.get(offset..).ok_or(())?.get(..size).ok_or(())
-    }
-}
-
-impl<'a> ReadRef<'a> for &'a Vec<u8> {
     fn len(self) -> Result<u64> {
         self.len().try_into().map_err(|_| ())
     }

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -56,10 +56,7 @@ fn coff_x86_64_bss() {
     assert_eq!(bss.data(), Ok(&[][..]));
 
     let section = sections.next();
-    assert!(
-        section.is_none(),
-        format!("unexpected section {:?}", section)
-    );
+    assert!(section.is_none(), "unexpected section {:?}", section);
 
     let mut symbols = object.symbols();
 
@@ -84,7 +81,7 @@ fn coff_x86_64_bss() {
     assert_eq!(symbol.address(), 24);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 }
 
 #[test]
@@ -172,7 +169,7 @@ fn elf_x86_64_bss() {
     assert_eq!(symbol.size(), 34);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 }
 
 #[test]
@@ -229,10 +226,7 @@ fn macho_x86_64_bss() {
     assert_eq!(bss.data(), Ok(&[][..]));
 
     let section = sections.next();
-    assert!(
-        section.is_none(),
-        format!("unexpected section {:?}", section)
-    );
+    assert!(section.is_none(), "unexpected section {:?}", section);
 
     let mut symbols = object.symbols();
 
@@ -257,5 +251,5 @@ fn macho_x86_64_bss() {
     assert_eq!(symbol.address(), 24);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 }

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -41,7 +41,7 @@ fn coff_x86_64_bss() {
 
     //std::fs::write(&"bss.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Coff);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -122,7 +122,7 @@ fn elf_x86_64_bss() {
 
     //std::fs::write(&"bss.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -213,7 +213,7 @@ fn macho_x86_64_bss() {
 
     //std::fs::write(&"bss.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
 

--- a/tests/round_trip/comdat.rs
+++ b/tests/round_trip/comdat.rs
@@ -41,7 +41,7 @@ fn coff_x86_64_comdat() {
 
     //std::fs::write(&"comdat.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Coff);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -158,7 +158,7 @@ fn elf_x86_64_common() {
 
     //std::fs::write(&"comdat.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 

--- a/tests/round_trip/comdat.rs
+++ b/tests/round_trip/comdat.rs
@@ -112,7 +112,7 @@ fn coff_x86_64_comdat() {
     assert_eq!(symbol.address(), 0);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 
     let mut comdats = object.comdats();
 
@@ -209,7 +209,7 @@ fn elf_x86_64_common() {
     assert_eq!(symbol.address(), 0);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 
     let mut comdats = object.comdats();
 

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -52,7 +52,7 @@ fn coff_x86_64_common() {
 
     //std::fs::write(&"common.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Coff);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -128,7 +128,7 @@ fn elf_x86_64_common() {
 
     //std::fs::write(&"common.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -200,7 +200,7 @@ fn macho_x86_64_common() {
 
     //std::fs::write(&"common.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
 

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -92,7 +92,7 @@ fn coff_x86_64_common() {
     assert_eq!(symbol.size(), 0);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn elf_x86_64_common() {
     assert_eq!(symbol.size(), 8);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 }
 
 #[test]
@@ -216,10 +216,7 @@ fn macho_x86_64_common() {
     assert_eq!(common.data(), Ok(&[][..]));
 
     let section = sections.next();
-    assert!(
-        section.is_none(),
-        format!("unexpected section {:?}", section)
-    );
+    assert!(section.is_none(), "unexpected section {:?}", section);
 
     let mut symbols = object.symbols();
 
@@ -244,5 +241,5 @@ fn macho_x86_64_common() {
     assert_eq!(symbol.address(), 8);
 
     let symbol = symbols.next();
-    assert!(symbol.is_none(), format!("unexpected symbol {:?}", symbol));
+    assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
 }

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -30,7 +30,7 @@ fn symtab_shndx() {
 
     //std::fs::write(&"symtab_shndx.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -77,7 +77,7 @@ fn compression_zlib() {
 
     //std::fs::write(&"compression.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -114,7 +114,7 @@ fn compression_gnu() {
 
     //std::fs::write(&"compression.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -180,7 +180,7 @@ fn note() {
     let section = object.add_section(Vec::new(), b".note8".to_vec(), SectionKind::Note);
     object.section_mut(section).set_data(buffer, 8);
 
-    let bytes = &object.write().unwrap();
+    let bytes = &*object.write().unwrap();
 
     //std::fs::write(&"note.o", &bytes).unwrap();
 

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -51,7 +51,7 @@ fn coff_x86_64() {
         .unwrap();
 
     let bytes = object.write().unwrap();
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Coff);
     assert_eq!(object.architecture(), Architecture::X86_64);
     assert_eq!(object.endianness(), Endianness::Little);
@@ -148,7 +148,7 @@ fn elf_x86_64() {
         .unwrap();
 
     let bytes = object.write().unwrap();
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
     assert_eq!(object.endianness(), Endianness::Little);
@@ -278,7 +278,7 @@ fn macho_x86_64() {
         .unwrap();
 
     let bytes = object.write().unwrap();
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
     assert_eq!(object.endianness(), Endianness::Little);

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -29,7 +29,7 @@ fn coff_x86_64_tls() {
 
     //std::fs::write(&"tls.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Coff);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -90,7 +90,7 @@ fn elf_x86_64_tls() {
 
     //std::fs::write(&"tls.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
@@ -181,7 +181,7 @@ fn macho_x86_64_tls() {
 
     //std::fs::write(&"tls.o", &bytes).unwrap();
 
-    let object = read::File::parse(&bytes).unwrap();
+    let object = read::File::parse(&*bytes).unwrap();
     assert_eq!(object.format(), BinaryFormat::MachO);
     assert_eq!(object.architecture(), Architecture::X86_64);
 


### PR DESCRIPTION
While it has a slight convenience, this may result in code bloat.

