### PR TITLE
Disable wasm feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ memmap = "0.7"
 # Core read support. You will need to enable some file formats too.
 read_core = []
 # Read support for all file formats (including unaligned files).
-read = ["read_core", "archive", "coff", "elf", "macho", "pe", "wasm", "unaligned"]
+read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned"]
 # Core write support. You will need to enable some file formats too.
 write_core = ["crc32fast", "indexmap", "std"]
 # Write support for all file formats.


### PR DESCRIPTION
This avoids a dependency that is out of date and which most users do not need.