### PR TITLE
Add ability to parse pdb info from PE file

### DIFF
--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -111,6 +111,16 @@ fn dump_object(data: &[u8]) {
         Ok(None) => {}
         Err(e) => println!("Failed to parse GNU debug alt link: {}", e),
     }
+    match file.pdb_info() {
+        Ok(Some(info)) => println!(
+            "PDB file: {}, GUID: {:x?}, Age: {}",
+            String::from_utf8_lossy(info.path()),
+            info.guid(),
+            info.age()
+        ),
+        Ok(None) => {}
+        Err(e) => println!("Failed to parse PE CodeView info: {}", e),
+    }
 
     for segment in file.segments() {
         println!("{:x?}", segment);

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -13,8 +13,8 @@ use crate::read::pe;
 #[cfg(feature = "wasm")]
 use crate::read::wasm;
 use crate::read::{
-    self, Architecture, BinaryFormat, ComdatKind, CompressedData, CompressedFileRange, Error,
-    Export, FileFlags, FileKind, Import, Object, ObjectComdat, ObjectMap, ObjectSection,
+    self, Architecture, BinaryFormat, CodeView, ComdatKind, CompressedData, CompressedFileRange,
+    Error, Export, FileFlags, FileKind, Import, Object, ObjectComdat, ObjectMap, ObjectSection,
     ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadRef, Relocation, Result, SectionFlags,
     SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName,
     SymbolScope, SymbolSection,
@@ -397,6 +397,11 @@ where
     #[inline]
     fn gnu_debugaltlink(&self) -> Result<Option<(&'data [u8], &'data [u8])>> {
         with_inner!(self.inner, FileInternal, |x| x.gnu_debugaltlink())
+    }
+
+    #[inline]
+    fn pdb_info(&self) -> Result<Option<CodeView>> {
+        with_inner!(self.inner, FileInternal, |x| x.pdb_info())
     }
 
     fn entry(&self) -> u64 {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -452,7 +452,7 @@ impl<'data> Export<'data> {
 /// PDB Information
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CodeView<'data> {
-    guid: &'data [u8; 16],
+    guid: [u8; 16],
     path: ByteString<'data>,
     age: u32,
 }
@@ -472,7 +472,7 @@ impl<'data> CodeView<'data> {
 
     /// The GUID of the PDB.
     #[inline]
-    pub fn guid(&self) -> &'data [u8; 16] {
+    pub fn guid(&self) -> [u8; 16] {
         self.guid
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::{fmt, result};
 
 use crate::common::*;
-use crate::{ByteString, Bytes, Endianness};
+use crate::{ByteString, Endianness};
 
 mod read_ref;
 pub use read_ref::*;
@@ -452,7 +452,7 @@ impl<'data> Export<'data> {
 /// PDB Information
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CodeView<'data> {
-    guid: Bytes<'data>,
+    guid: &'data [u8; 16],
     path: ByteString<'data>,
     age: u32,
 }
@@ -472,8 +472,8 @@ impl<'data> CodeView<'data> {
 
     /// The GUID of the PDB.
     #[inline]
-    pub fn guid(&self) -> &'data [u8] {
-        self.guid.0
+    pub fn guid(&self) -> &'data [u8; 16] {
+        self.guid
     }
 }
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -470,7 +470,7 @@ impl<'data> CodeView<'data> {
         self.age
     }
 
-    /// The PDB of the guid
+    /// The GUID of the PDB.
     #[inline]
     pub fn guid(&self) -> &'data [u8] {
         self.guid.0

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::{fmt, result};
 
 use crate::common::*;
-use crate::{ByteString, Endianness};
+use crate::{ByteString, Bytes, Endianness};
 
 mod read_ref;
 pub use read_ref::*;
@@ -446,6 +446,34 @@ impl<'data> Export<'data> {
     #[inline]
     pub fn address(&self) -> u64 {
         self.address
+    }
+}
+
+/// PDB Information
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodeView<'data> {
+    guid: Bytes<'data>,
+    path: ByteString<'data>,
+    age: u32,
+}
+
+impl<'data> CodeView<'data> {
+    /// The path to the PDB as stored in CodeView
+    #[inline]
+    pub fn path(&self) -> &'data [u8] {
+        self.path.0
+    }
+
+    /// The age of the PDB
+    #[inline]
+    pub fn age(&self) -> u32 {
+        self.age
+    }
+
+    /// The PDB of the guid
+    #[inline]
+    pub fn guid(&self) -> &'data [u8] {
+        self.guid.0
     }
 }
 

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -358,7 +358,7 @@ where
             .read_bytes(4)
             .read_error("Invalid CodeView signature")?;
         if sig.0 != b"RSDS" {
-            return Err(Error("Invalid CodeView Signature"));
+            return Ok(None);
         }
 
         let guid = info.read_bytes(16).read_error("Invalid CodeView GUID")?;

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
 
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use crate::read::coff::{CoffCommon, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, SymbolTable};
 use crate::read::{

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -363,7 +363,7 @@ where
             return Ok(None);
         }
 
-        let guid: &[u8; 16] = info
+        let guid: [u8; 16] = info
             .read_bytes(16)
             .read_error("Invalid CodeView GUID")?
             .0

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -7,7 +7,9 @@ use crate::read::{
     self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
     Object, ObjectComdat, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
 };
-use crate::{pe, ByteString, Bytes, LittleEndian as LE, Pod, U16Bytes, U32Bytes, U32, U64};
+use crate::{
+    pe, ByteString, Bytes, CodeView, LittleEndian as LE, Pod, U16Bytes, U32Bytes, U32, U64,
+};
 
 use super::{PeSection, PeSectionIterator, PeSegment, PeSegmentIterator, SectionTable};
 
@@ -326,6 +328,52 @@ where
             }
         }
         Ok(exports)
+    }
+
+    fn pdb_info(&self) -> Result<Option<CodeView>> {
+        let data_dir = match self.data_directory(pe::IMAGE_DIRECTORY_ENTRY_DEBUG) {
+            Some(data_dir) => data_dir,
+            None => return Ok(None),
+        };
+        let debug_data = data_dir.data(self.data, &self.common.sections).map(Bytes)?;
+        let debug_dir = debug_data
+            .read_at::<pe::ImageDebugDirectory>(0)
+            .read_error("Invalid PE debug dir size")?;
+
+        if debug_dir.typ.get(LE) != pe::IMAGE_DEBUG_TYPE_CODEVIEW {
+            return Ok(None);
+        }
+
+        let info = self
+            .data
+            .read_slice_at::<u8>(
+                debug_dir.pointer_to_raw_data.get(LE) as u64,
+                debug_dir.size_of_data.get(LE) as usize,
+            )
+            .read_error("Invalid CodeView Info address")?;
+
+        let mut info = Bytes(info);
+
+        let sig = info
+            .read_bytes(4)
+            .read_error("Invalid CodeView signature")?;
+        if sig.0 != b"RSDS" {
+            return Err(Error("Invalid CodeView Signature"));
+        }
+
+        let guid = info.read_bytes(16).read_error("Invalid CodeView GUID")?;
+
+        let age = info.read::<U32<LE>>().read_error("Invalid CodeView Age")?;
+
+        let path = info
+            .read_string()
+            .read_error("Invalid CodeView file path")?;
+
+        Ok(Some(CodeView {
+            path: ByteString(path),
+            guid,
+            age: age.get(LE),
+        }))
     }
 
     fn has_debug_symbols(&self) -> bool {

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -2,6 +2,8 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
 
+use std::convert::TryInto;
+
 use crate::read::coff::{CoffCommon, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, SymbolTable};
 use crate::read::{
     self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
@@ -361,7 +363,12 @@ where
             return Ok(None);
         }
 
-        let guid = info.read_bytes(16).read_error("Invalid CodeView GUID")?;
+        let guid: &[u8; 16] = info
+            .read_bytes(16)
+            .read_error("Invalid CodeView GUID")?
+            .0
+            .try_into()
+            .unwrap();
 
         let age = info.read::<U32<LE>>().read_error("Invalid CodeView Age")?;
 

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -2,9 +2,9 @@ use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use crate::read::{
-    self, Architecture, ComdatKind, CompressedData, CompressedFileRange, Export, FileFlags, Import,
-    ObjectMap, Relocation, Result, SectionFlags, SectionIndex, SectionKind, SymbolFlags,
-    SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
+    self, Architecture, CodeView, ComdatKind, CompressedData, CompressedFileRange, Export,
+    FileFlags, Import, ObjectMap, Relocation, Result, SectionFlags, SectionIndex, SectionKind,
+    SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
 };
 use crate::Endianness;
 
@@ -196,6 +196,12 @@ pub trait Object<'data: 'file, 'file>: read::private::Sealed {
     /// The filename and build ID from a `.gnu_debugaltlink` section.
     #[inline]
     fn gnu_debugaltlink(&self) -> Result<Option<(&'data [u8], &'data [u8])>> {
+        Ok(None)
+    }
+
+    /// The filename and GUID from the PE CodeView section
+    #[inline]
+    fn pdb_info(&self) -> Result<Option<CodeView>> {
         Ok(None)
     }
 


### PR DESCRIPTION
Just like we can get the UUID from macho files and the build-id from ELF
files, this change allows users to pull out the PDB info (path, age, and
GUID) from PE files.

macho and ELF files will return `Ok(None)`