### PR TITLE
Add a missing clause for writing sparc64 objects

### DIFF
--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -83,6 +83,7 @@ impl Object {
             Architecture::PowerPc64 => false,
             Architecture::Riscv64 => false,
             Architecture::Riscv32 => false,
+            Architecture::Sparc64 => false,
             _ => {
                 return Err(Error(format!(
                     "unimplemented architecture {:?}",


### PR DESCRIPTION
Just a missing branch of the `match`!