### PR TITLE
Add native support for writing ELF R_AARCH64_CALL26 relocations

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -336,6 +336,11 @@ pub enum RelocationEncoding {
     ///
     /// The `RelocationKind` must be PC relative.
     S390xDbl,
+
+    /// AArch64 call target.
+    ///
+    /// The `RelocationKind` must be PC relative.
+    AArch64Call,
 }
 
 /// File flags that are specific to each file format.

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -247,6 +247,10 @@ fn parse_relocation<Elf: FileHeader>(
             elf::R_AARCH64_PREL64 => (RelocationKind::Relative, 64),
             elf::R_AARCH64_PREL32 => (RelocationKind::Relative, 32),
             elf::R_AARCH64_PREL16 => (RelocationKind::Relative, 16),
+            elf::R_AARCH64_CALL26 => {
+                encoding = RelocationEncoding::AArch64Call;
+                (RelocationKind::Relative, 26)
+            }
             r_type => (RelocationKind::Elf(r_type), 0),
         },
         elf::EM_ARM => match reloc.r_type(endian, false) {

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -249,7 +249,7 @@ fn parse_relocation<Elf: FileHeader>(
             elf::R_AARCH64_PREL16 => (RelocationKind::Relative, 16),
             elf::R_AARCH64_CALL26 => {
                 encoding = RelocationEncoding::AArch64Call;
-                (RelocationKind::Relative, 26)
+                (RelocationKind::PltRelative, 26)
             }
             r_type => (RelocationKind::Elf(r_type), 0),
         },

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -597,6 +597,9 @@ impl Object {
                             (RelocationKind::Relative, RelocationEncoding::Generic, 16) => {
                                 elf::R_AARCH64_PREL16
                             }
+                            (RelocationKind::Relative, RelocationEncoding::AArch64Call, 26) => {
+                                elf::R_AARCH64_CALL26
+                            }
                             (RelocationKind::Elf(x), _, _) => x,
                             _ => {
                                 return Err(Error(format!("unimplemented relocation {:?}", reloc)));

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -597,7 +597,8 @@ impl Object {
                             (RelocationKind::Relative, RelocationEncoding::Generic, 16) => {
                                 elf::R_AARCH64_PREL16
                             }
-                            (RelocationKind::Relative, RelocationEncoding::AArch64Call, 26) => {
+                            (RelocationKind::Relative, RelocationEncoding::AArch64Call, 26)
+                            | (RelocationKind::PltRelative, RelocationEncoding::AArch64Call, 26) => {
                                 elf::R_AARCH64_CALL26
                             }
                             (RelocationKind::Elf(x), _, _) => x,


### PR DESCRIPTION
Necessary for AArch64 support in cranelift-object.