### PR TITLE
Expose PeFile data, section_table and data_directory

### DIFF
--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -75,7 +75,13 @@ where
         self.nt_headers
     }
 
-    fn data_directory(&self, id: usize) -> Option<&'data pe::ImageDataDirectory> {
+    /// Returns the section table of this binary.
+    pub fn section_table(&self) -> SectionTable<'data> {
+        self.common.sections
+    }
+
+    /// Returns the data directory at the given index.
+    pub fn data_directory(&self, id: usize) -> Option<&'data pe::ImageDataDirectory> {
         self.data_directories
             .get(id)
             .filter(|d| d.size.get(LE) != 0)
@@ -83,6 +89,11 @@ where
 
     fn data_at(&self, va: u32) -> Option<Bytes<'data>> {
         self.common.sections.pe_data_at(self.data, va).map(Bytes)
+    }
+
+    /// Returns this binary data.
+    pub fn data(&self) -> R {
+        self.data
     }
 }
 


### PR DESCRIPTION
Having those exposed allows the user to explore the full internals of a `PeFile`, while simultaneously using the higher-level convenience functions exposed by the `Object` trait.

All the types (the `SectionTable` and pe `ImageDataDirectory`) are already public, so the increase in API surface is fairly minimal.

I'm personally using this to parse the Import table myself, in order to better handle certain edge scenarios (such as being able to tell the difference between a missing import directory from an empty directory).