### PR TITLE
Various fixes for writing ET_DYN ELF objects

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -172,7 +172,7 @@ pub enum SectionKind {
     ///
     /// This is the `sh_type` field in the section header.
     /// The meaning may be dependent on the architecture.
-    Elf(u32),
+    Elf(u32, Option<u32>),
 }
 
 impl SectionKind {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -705,6 +705,8 @@ pub const SHT_HIPROC: u32 = 0x7fff_ffff;
 pub const SHT_LOUSER: u32 = 0x8000_0000;
 /// End of application-specific section types.
 pub const SHT_HIUSER: u32 = 0x8fff_ffff;
+/// Symbol versions.
+pub const SHT_GNU_versym: u32 = 0x6fff_ffff;
 
 // Values for `SectionHeader*::sh_flags`.
 /// Section is writable.

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -706,6 +706,7 @@ pub const SHT_LOUSER: u32 = 0x8000_0000;
 /// End of application-specific section types.
 pub const SHT_HIUSER: u32 = 0x8fff_ffff;
 /// Symbol versions.
+pub const SHT_GNU_verdef: u32 = 0x6fff_fffd;
 pub const SHT_GNU_versym: u32 = 0x6fff_ffff;
 
 // Values for `SectionHeader*::sh_flags`.

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -387,7 +387,7 @@ where
             | elf::SHT_REL
             | elf::SHT_DYNSYM
             | elf::SHT_GROUP => SectionKind::Metadata,
-            _ => SectionKind::Elf(sh_type),
+            _ => SectionKind::Elf(sh_type, None),
         }
     }
 

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -334,7 +334,7 @@ impl Object {
                 | SectionKind::Note
                 | SectionKind::Unknown
                 | SectionKind::Metadata
-                | SectionKind::Elf(_) => {
+                | SectionKind::Elf(_, _) => {
                     return Err(Error(format!(
                         "unimplemented section `{}` kind {:?}",
                         section.name().unwrap_or(""),

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -936,6 +936,7 @@ impl Object {
                 SectionKind::ReadOnlyString | SectionKind::OtherString => 1,
                 SectionKind::Elf(typ) if typ == elf::SHT_DYNSYM => elf.symbol_size() as u64,
                 SectionKind::Elf(typ) if typ == elf::SHT_DYNAMIC => elf.dynamic_entsize() as u64,
+                SectionKind::Elf(typ) if typ == elf::SHT_GNU_versym => std::mem::size_of::<U16<Endianness>>() as u64,
                 _ => 0,
             };
             let sh_name = section_offsets[index]

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -954,7 +954,7 @@ impl Object {
                     sh_size: section.size,
                     // Link dynsyn and dynamic sections to the dynstr section.
                     sh_link: match section.kind {
-                        SectionKind::Elf(typ, _) if typ == elf::SHT_DYNSYM || typ == elf::SHT_DYNAMIC =>
+                        SectionKind::Elf(typ, _) if typ == elf::SHT_DYNSYM || typ == elf::SHT_DYNAMIC || typ == elf::SHT_GNU_verdef =>
                             dynstr_index.unwrap() as u32,
                         _ => 0,
                     },

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -353,7 +353,14 @@ impl Object {
             abi_version: 0,
             padding: [0; 7],
         };
-        let e_type = elf::ET_REL;
+        // Currently there's no way for user to determine what type of object
+        // is produced.  So, try inferring from the presence of the dynamic
+        // section type (which is only slightly better).
+        let e_type = if self.sections.iter().find(|s| s.kind == SectionKind::Elf(elf::SHT_DYNAMIC)).is_some() {
+            elf::ET_DYN
+        } else {
+            elf::ET_REL
+        };
         let e_machine = match self.architecture {
             Architecture::Aarch64 => elf::EM_AARCH64,
             Architecture::Arm => elf::EM_ARM,

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -934,6 +934,8 @@ impl Object {
             // TODO: not sure if this is correct, maybe user should determine this
             let sh_entsize = match section.kind {
                 SectionKind::ReadOnlyString | SectionKind::OtherString => 1,
+                SectionKind::Elf(typ) if typ == elf::SHT_DYNSYM => elf.symbol_size() as u64,
+                SectionKind::Elf(typ) if typ == elf::SHT_DYNAMIC => elf.dynamic_entsize() as u64,
                 _ => 0,
             };
             let sh_name = section_offsets[index]
@@ -1114,6 +1116,7 @@ trait Elf {
     fn file_header_size(&self) -> usize;
     fn section_header_size(&self) -> usize;
     fn symbol_size(&self) -> usize;
+    fn dynamic_entsize(&self) -> usize;
     fn rel_size(&self, is_rela: bool) -> usize;
     fn write_file_header(&self, buffer: &mut dyn WritableBuffer, section: FileHeader);
     fn write_section_header(&self, buffer: &mut dyn WritableBuffer, section: SectionHeader);
@@ -1142,6 +1145,10 @@ impl<E: Endian> Elf for Elf32<E> {
 
     fn symbol_size(&self) -> usize {
         mem::size_of::<elf::Sym32<E>>()
+    }
+
+    fn dynamic_entsize(&self) -> usize {
+        mem::size_of::<elf::Dyn32<E>>()
     }
 
     fn rel_size(&self, is_rela: bool) -> usize {
@@ -1243,6 +1250,10 @@ impl<E: Endian> Elf for Elf64<E> {
 
     fn symbol_size(&self) -> usize {
         mem::size_of::<elf::Sym64<E>>()
+    }
+
+    fn dynamic_entsize(&self) -> usize {
+        mem::size_of::<elf::Dyn64<E>>()
     }
 
     fn rel_size(&self, is_rela: bool) -> usize {

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -408,7 +408,7 @@ impl Object {
                     SectionKind::Debug => macho::S_ATTR_DEBUG,
                     SectionKind::OtherString => macho::S_CSTRING_LITERALS,
                     SectionKind::Other | SectionKind::Linker | SectionKind::Metadata => 0,
-                    SectionKind::Note | SectionKind::Unknown | SectionKind::Elf(_) => {
+                    SectionKind::Note | SectionKind::Unknown | SectionKind::Elf(_, _) => {
                         return Err(Error(format!(
                             "unimplemented section `{}` kind {:?}",
                             section.name().unwrap_or(""),


### PR DESCRIPTION
This fixes few issue seen when writing shared objects:
- When we have a `.dynamic` section set the ELF type to `ET_DYN` (instead of the hard-coded `ET_REL`).
- Properly `sh_link` `.dynsym` and `.dynamic` to `.dynstr`.
- Set correct `sh_entsize` for `.dynsym` and `.dynamic`.
- Set the first non-local `.dynsym` symbol index in `sh_info`.