### PR TITLE
Support partial reading of string tables

### DIFF
--- a/examples/readobj.rs
+++ b/examples/readobj.rs
@@ -437,7 +437,7 @@ mod elf {
             let mut dynstr = object::StringTable::default();
             for s in segments {
                 if let Ok(Some(data)) = s.data_range(endian, data, strtab, strsz) {
-                    dynstr = object::StringTable::new(data);
+                    dynstr = object::StringTable::new(data, 0, data.len() as u64);
                     break;
                 }
             }

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -890,11 +890,21 @@ where
     R: ReadRef<'data>,
 {
     #[cfg(feature = "coff")]
-    Coff((coff::CoffSymbolTable<'data, 'file>, PhantomData<R>)),
+    Coff((coff::CoffSymbolTable<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "elf")]
-    Elf32((elf::ElfSymbolTable32<'data, 'file>, PhantomData<R>)),
+    Elf32(
+        (
+            elf::ElfSymbolTable32<'data, 'file, Endianness, R>,
+            PhantomData<R>,
+        ),
+    ),
     #[cfg(feature = "elf")]
-    Elf64((elf::ElfSymbolTable64<'data, 'file>, PhantomData<R>)),
+    Elf64(
+        (
+            elf::ElfSymbolTable64<'data, 'file, Endianness, R>,
+            PhantomData<R>,
+        ),
+    ),
     #[cfg(feature = "macho")]
     MachO32(
         (
@@ -910,9 +920,9 @@ where
         ),
     ),
     #[cfg(feature = "pe")]
-    Pe32((coff::CoffSymbolTable<'data, 'file>, PhantomData<R>)),
+    Pe32((coff::CoffSymbolTable<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "pe")]
-    Pe64((coff::CoffSymbolTable<'data, 'file>, PhantomData<R>)),
+    Pe64((coff::CoffSymbolTable<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "wasm")]
     Wasm((wasm::WasmSymbolTable<'data, 'file>, PhantomData<R>)),
 }
@@ -960,11 +970,21 @@ where
     R: ReadRef<'data>,
 {
     #[cfg(feature = "coff")]
-    Coff((coff::CoffSymbolIterator<'data, 'file>, PhantomData<R>)),
+    Coff((coff::CoffSymbolIterator<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "elf")]
-    Elf32((elf::ElfSymbolIterator32<'data, 'file>, PhantomData<R>)),
+    Elf32(
+        (
+            elf::ElfSymbolIterator32<'data, 'file, Endianness, R>,
+            PhantomData<R>,
+        ),
+    ),
     #[cfg(feature = "elf")]
-    Elf64((elf::ElfSymbolIterator64<'data, 'file>, PhantomData<R>)),
+    Elf64(
+        (
+            elf::ElfSymbolIterator64<'data, 'file, Endianness, R>,
+            PhantomData<R>,
+        ),
+    ),
     #[cfg(feature = "macho")]
     MachO32(
         (
@@ -980,9 +1000,9 @@ where
         ),
     ),
     #[cfg(feature = "pe")]
-    Pe32((coff::CoffSymbolIterator<'data, 'file>, PhantomData<R>)),
+    Pe32((coff::CoffSymbolIterator<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "pe")]
-    Pe64((coff::CoffSymbolIterator<'data, 'file>, PhantomData<R>)),
+    Pe64((coff::CoffSymbolIterator<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "wasm")]
     Wasm((wasm::WasmSymbolIterator<'data, 'file>, PhantomData<R>)),
 }
@@ -1013,11 +1033,21 @@ where
     R: ReadRef<'data>,
 {
     #[cfg(feature = "coff")]
-    Coff((coff::CoffSymbol<'data, 'file>, PhantomData<R>)),
+    Coff((coff::CoffSymbol<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "elf")]
-    Elf32((elf::ElfSymbol32<'data, 'file>, PhantomData<R>)),
+    Elf32(
+        (
+            elf::ElfSymbol32<'data, 'file, Endianness, R>,
+            PhantomData<R>,
+        ),
+    ),
     #[cfg(feature = "elf")]
-    Elf64((elf::ElfSymbol64<'data, 'file>, PhantomData<R>)),
+    Elf64(
+        (
+            elf::ElfSymbol64<'data, 'file, Endianness, R>,
+            PhantomData<R>,
+        ),
+    ),
     #[cfg(feature = "macho")]
     MachO32(
         (
@@ -1033,9 +1063,9 @@ where
         ),
     ),
     #[cfg(feature = "pe")]
-    Pe32((coff::CoffSymbol<'data, 'file>, PhantomData<R>)),
+    Pe32((coff::CoffSymbol<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "pe")]
-    Pe64((coff::CoffSymbol<'data, 'file>, PhantomData<R>)),
+    Pe64((coff::CoffSymbol<'data, 'file, R>, PhantomData<R>)),
     #[cfg(feature = "wasm")]
     Wasm((wasm::WasmSymbol<'data, 'file>, PhantomData<R>)),
 }

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -66,9 +66,9 @@ impl<'data> SectionTable<'data> {
     /// The returned index is 1-based.
     ///
     /// Ignores sections with invalid names.
-    pub fn section_by_name(
+    pub fn section_by_name<R: ReadRef<'data>>(
         &self,
-        strings: StringTable<'data>,
+        strings: StringTable<'data, R>,
         name: &[u8],
     ) -> Option<(usize, &'data pe::ImageSectionHeader)> {
         self.sections
@@ -310,7 +310,10 @@ impl pe::ImageSectionHeader {
     /// Return the section name.
     ///
     /// This handles decoding names that are offsets into the symbol string table.
-    pub fn name<'data>(&'data self, strings: StringTable<'data>) -> Result<&'data [u8]> {
+    pub fn name<'data, R: ReadRef<'data>>(
+        &'data self,
+        strings: StringTable<'data, R>,
+    ) -> Result<&'data [u8]> {
         let bytes = &self.name;
         Ok(if bytes[0] == b'/' {
             let mut offset = 0;

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -23,9 +23,9 @@ impl RelocationSections {
     /// Create a new mapping using the section table.
     ///
     /// Skips relocation sections that do not use the given symbol table section.
-    pub fn parse<Elf: FileHeader>(
+    pub fn parse<'data, Elf: FileHeader, R: ReadRef<'data>>(
         endian: Elf::Endian,
-        sections: &SectionTable<Elf>,
+        sections: &SectionTable<'data, Elf, R>,
         symbol_section: usize,
     ) -> read::Result<Self> {
         let mut relocations = vec![0; sections.len()];

--- a/src/read/macho/dyld_cache.rs
+++ b/src/read/macho/dyld_cache.rs
@@ -192,7 +192,9 @@ impl<E: Endian> macho::DyldCacheHeader<E> {
 impl<E: Endian> macho::DyldCacheImageInfo<E> {
     /// The file system path of this image.
     pub fn path<'data, R: ReadRef<'data>>(&self, endian: E, data: R) -> Result<&'data [u8]> {
-        data.read_bytes_at_until(self.path_file_offset.get(endian).into(), 0)
+        let r_start = self.path_file_offset.get(endian).into();
+        let r_end = data.len().read_error("Couldn't get data len()")?;
+        data.read_bytes_at_until(r_start..r_end, 0)
             .read_error("Couldn't read dyld cache image path")
     }
 

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -36,7 +36,7 @@ where
     pub(super) header_offset: u64,
     pub(super) header: &'data Mach,
     pub(super) sections: Vec<MachOSectionInternal<'data, Mach>>,
-    pub(super) symbols: SymbolTable<'data, Mach>,
+    pub(super) symbols: SymbolTable<'data, Mach, R>,
 }
 
 impl<'data, Mach, R> MachOFile<'data, Mach, R>

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -331,20 +331,18 @@ impl<E: Endian> macho::SymtabCommand<E> {
         &self,
         endian: E,
         data: R,
-    ) -> Result<SymbolTable<'data, Mach>> {
+    ) -> Result<SymbolTable<'data, Mach, R>> {
         let symbols = data
             .read_slice_at(
                 self.symoff.get(endian).into(),
                 self.nsyms.get(endian) as usize,
             )
             .read_error("Invalid Mach-O symbol table offset or size")?;
-        let strings = data
-            .read_bytes_at(
-                self.stroff.get(endian).into(),
-                self.strsize.get(endian).into(),
-            )
-            .read_error("Invalid Mach-O string table offset or size")?;
-        let strings = StringTable::new(strings);
+        let str_start: u64 = self.stroff.get(endian).into();
+        let str_end = str_start
+            .checked_add(self.strsize.get(endian).into())
+            .read_error("Invalid Mach-O string table length")?;
+        let strings = StringTable::new(data, str_start, str_end);
         Ok(SymbolTable::new(symbols, strings))
     }
 }

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -25,7 +25,7 @@ where
     R: ReadRef<'data>,
 {
     pub(super) file: &'file PeFile<'data, Pe, R>,
-    pub(super) iter: slice::Iter<'file, pe::ImageSectionHeader>,
+    pub(super) iter: slice::Iter<'data, pe::ImageSectionHeader>,
 }
 
 impl<'data, 'file, Pe, R> Iterator for PeSegmentIterator<'data, 'file, Pe, R>
@@ -58,7 +58,7 @@ where
     R: ReadRef<'data>,
 {
     file: &'file PeFile<'data, Pe, R>,
-    section: &'file pe::ImageSectionHeader,
+    section: &'data pe::ImageSectionHeader,
 }
 
 impl<'data, 'file, Pe, R> PeSegment<'data, 'file, Pe, R>
@@ -146,7 +146,7 @@ where
     R: ReadRef<'data>,
 {
     pub(super) file: &'file PeFile<'data, Pe, R>,
-    pub(super) iter: iter::Enumerate<slice::Iter<'file, pe::ImageSectionHeader>>,
+    pub(super) iter: iter::Enumerate<slice::Iter<'data, pe::ImageSectionHeader>>,
 }
 
 impl<'data, 'file, Pe, R> Iterator for PeSectionIterator<'data, 'file, Pe, R>
@@ -182,7 +182,7 @@ where
 {
     pub(super) file: &'file PeFile<'data, Pe, R>,
     pub(super) index: SectionIndex,
-    pub(super) section: &'file pe::ImageSectionHeader,
+    pub(super) section: &'data pe::ImageSectionHeader,
 }
 
 impl<'data, 'file, Pe, R> PeSection<'data, 'file, Pe, R>


### PR DESCRIPTION
Before this PR, StringTables are read in their entirety and do not make use of the partial read ability of `ReadRef`. This is fine in most cases, but it is problematic for the dyld shared cache.
The dyld shared cache has a shared string table which is about 340MB big. Only a fraction of those strings are needed by each embedded library. For example, if I dump all AppKit symbols with their names from the dyld shared cache on macOS 11.3, this patch reduces the number of bytes read from 347.4 MB to 4.8 MB.

This patch makes use of the relatively new `read_bytes_at_until` method. But it also extends it by one parameter, `upper_bound`, so that the string table's size can be honored.

We currently have a hardcoded limit of 4096 bytes for the string length in the ReadCache. It's possible that this limit is not appropriate in all the cases where `read_bytes_at_until` is now called. But I'm not changing it in this patch.