### PR TITLE
Add read support for big archive

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -12,6 +12,8 @@ pub const MAGIC: [u8; 8] = *b"!<arch>\n";
 ///
 /// A thin archive only contains a symbol table and file names.
 pub const THIN_MAGIC: [u8; 8] = *b"!<thin>\n";
+/// Big archive magic
+pub const BIG_MAGIC: [u8; 8] = *b"<bigaf>\n";
 
 /// The terminator for each archive member header.
 pub const TERMINATOR: [u8; 2] = *b"`\n";
@@ -36,4 +38,49 @@ pub struct Header {
     pub terminator: [u8; 2],
 }
 
+/// The fixed length header at the start of a big archive.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct BigFixedLengthHeader {
+    /// Offset to member table.
+    pub memoff: [u8; 20],
+    /// Offset to global symbol table.
+    pub gstoff: [u8; 20],
+    /// Offset global symbol table for 64-bit objects.
+    pub gst64off: [u8; 20],
+    /// Offset to first archive member.
+    pub fstmoff: [u8; 20],
+    /// Offset to last archive member.
+    pub lstmoff: [u8; 20],
+    /// Offset to last archive member.
+    pub freeoff: [u8; 20],
+}
+
+/// The header at the start of a big archive member.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct BigHeader {
+    /// File size in decimal.
+    pub size: [u8; 20],
+    /// Next member offset in decimal.
+    pub nxtmem: [u8; 20],
+    /// Previous member offset in decimal.
+    pub prvmem: [u8; 20],
+    /// File modification timestamp in decimal.
+    pub date: [u8; 12],
+    /// User ID in decimal.
+    pub uid: [u8; 12],
+    /// Group ID in decimal.
+    pub gid: [u8; 12],
+    /// File mode in octal.
+    pub mode: [u8; 12],
+    /// Name length in decimal.
+    pub namelen: [u8; 4],
+    // Begining of name, or TERMINATOR.
+    // We deal with it manually.
+    // pub name: [u8; 2]
+}
+
 unsafe_impl_pod!(Header);
+unsafe_impl_pod!(BigHeader);
+unsafe_impl_pod!(BigFixedLengthHeader);


### PR DESCRIPTION
This pull request adds read support of [big archive](https://www.ibm.com/docs/en/aix/7.2?topic=formats-ar-file-format-big). Global symbol table support is not implemented. Member table is unused.

In big archive, the first header has a different size than object header, so first read is different than other archive. Moreover, object header size is 114 for big archive and 60 for other kind of archive. I have added a generic to deal with, using ``Box``.

As Rust compiler now uses ``object`` to read archive, support of big archive in ``object`` is needed to add support of AIX in Rust.

A test for basis support has been added, and I have tested these changes with real files during Rust compiler build.