### PR TITLE
read/elf: symbol hash and version support

### DIFF
--- a/examples/readobj.rs
+++ b/examples/readobj.rs
@@ -1173,6 +1173,16 @@ mod elf {
         SHT_PREINIT_ARRAY,
         SHT_GROUP,
         SHT_SYMTAB_SHNDX,
+        SHT_GNU_ATTRIBUTES,
+        SHT_GNU_HASH,
+        SHT_GNU_LIBLIST,
+        SHT_CHECKSUM,
+        SHT_SUNW_move,
+        SHT_SUNW_COMDAT,
+        SHT_SUNW_syminfo,
+        SHT_GNU_VERDEF,
+        SHT_GNU_VERNEED,
+        SHT_GNU_VERSYM,
     );
     static FLAGS_SHT_MIPS: &[Flag<u32>] = &flags!(
         SHT_MIPS_LIBLIST,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -695,6 +695,33 @@ pub const SHT_GROUP: u32 = 17;
 pub const SHT_SYMTAB_SHNDX: u32 = 18;
 /// Start of OS-specific section types.
 pub const SHT_LOOS: u32 = 0x6000_0000;
+/// Object attributes.
+pub const SHT_GNU_ATTRIBUTES: u32 = 0x6fff_fff5;
+/// GNU-style hash table.
+pub const SHT_GNU_HASH: u32 = 0x6fff_fff6;
+/// Prelink library list
+pub const SHT_GNU_LIBLIST: u32 = 0x6fff_fff7;
+/// Checksum for DSO content.
+pub const SHT_CHECKSUM: u32 = 0x6fff_fff8;
+/// Sun-specific low bound.
+pub const SHT_LOSUNW: u32 = 0x6fff_fffa;
+#[allow(missing_docs, non_upper_case_globals)]
+pub const SHT_SUNW_move: u32 = 0x6fff_fffa;
+#[allow(missing_docs)]
+pub const SHT_SUNW_COMDAT: u32 = 0x6fff_fffb;
+#[allow(missing_docs, non_upper_case_globals)]
+pub const SHT_SUNW_syminfo: u32 = 0x6fff_fffc;
+/// Version definition section.
+#[allow(non_upper_case_globals)]
+pub const SHT_GNU_VERDEF: u32 = 0x6fff_fffd;
+/// Version needs section.
+#[allow(non_upper_case_globals)]
+pub const SHT_GNU_VERNEED: u32 = 0x6fff_fffe;
+/// Version symbol table.
+#[allow(non_upper_case_globals)]
+pub const SHT_GNU_VERSYM: u32 = 0x6fff_ffff;
+/// Sun-specific high bound.
+pub const SHT_HISUNW: u32 = 0x6fff_ffff;
 /// End of OS-specific section types.
 pub const SHT_HIOS: u32 = 0x6fff_ffff;
 /// Start of processor-specific section types.

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1696,10 +1696,99 @@ pub const DF_1_STUB: u32 = 0x0400_0000;
 #[allow(missing_docs)]
 pub const DF_1_PIE: u32 = 0x0800_0000;
 
-// TODO: ELF*_Verdef, VER_DEF_*, VER_FLG_*, VER_NDX_*
-// TODO: Elf*_Verdaux
-// TODO: Elf*_Verneed, VER_NEED_*
-// TODO: Elf*_Vernaux, VER_FLG_*
+/// Version symbol information
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Versym<E: Endian>(pub U16<E>);
+
+/// Version definition sections
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Verdef<E: Endian> {
+    /// Version revision
+    pub vd_version: U16<E>,
+    /// Version information
+    pub vd_flags: U16<E>,
+    /// Version Index
+    pub vd_ndx: U16<E>,
+    /// Number of associated aux entries
+    pub vd_cnt: U16<E>,
+    /// Version name hash value
+    pub vd_hash: U32<E>,
+    /// Offset in bytes to verdaux array
+    pub vd_aux: U32<E>,
+    /// Offset in bytes to next verdef entry
+    pub vd_next: U32<E>,
+}
+
+// Legal values for vd_version (version revision).
+/// No version
+pub const VER_DEF_NONE: u16 = 0;
+/// Current version
+pub const VER_DEF_CURRENT: u16 = 1;
+
+// Legal values for vd_flags and vna_flags (version information flags).
+/// Version definition of file itself
+pub const VER_FLG_BASE: u16 = 0x1;
+/// Weak version identifier
+pub const VER_FLG_WEAK: u16 = 0x2;
+
+// Versym symbol index values.
+/// Symbol is local.
+pub const VER_NDX_LOCAL: u16 = 0;
+/// Symbol is global.
+pub const VER_NDX_GLOBAL: u16 = 1;
+/// Symbol is hidden.
+pub const VER_NDX_HIDDEN: u16 = 0x8000;
+
+/// Auxiliary version information.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Verdaux<E: Endian> {
+    /// Version or dependency names
+    pub vda_name: U32<E>,
+    /// Offset in bytes to next verdaux
+    pub vda_next: U32<E>,
+}
+
+/// Version dependency.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Verneed<E: Endian> {
+    /// Version of structure
+    pub vn_version: U16<E>,
+    /// Number of associated aux entries
+    pub vn_cnt: U16<E>,
+    /// Offset of filename for this dependency
+    pub vn_file: U32<E>,
+    /// Offset in bytes to vernaux array
+    pub vn_aux: U32<E>,
+    /// Offset in bytes to next verneed entry
+    pub vn_next: U32<E>,
+}
+
+// Legal values for vn_version (version revision).
+/// No version
+pub const VER_NEED_NONE: u16 = 0;
+/// Current version
+pub const VER_NEED_CURRENT: u16 = 1;
+
+/// Auxiliary needed version information.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Vernaux<E: Endian> {
+    /// Hash value of dependency name
+    pub vna_hash: U32<E>,
+    /// Dependency specific information
+    pub vna_flags: U16<E>,
+    /// Version Index
+    pub vna_other: U16<E>,
+    /// Dependency name string offset
+    pub vna_name: U32<E>,
+    /// Offset in bytes to next vernaux entry
+    pub vna_next: U32<E>,
+}
+
 // TODO: Elf*_auxv_t, AT_*
 
 /// Note section entry header.
@@ -6154,6 +6243,11 @@ unsafe_impl_endian_pod!(
     ProgramHeader64,
     Dyn32,
     Dyn64,
+    Versym,
+    Verdef,
+    Verdaux,
+    Verneed,
+    Vernaux,
     NoteHeader32,
     NoteHeader64,
     HashHeader,

--- a/src/read/elf/hash.rs
+++ b/src/read/elf/hash.rs
@@ -1,0 +1,211 @@
+use core::mem;
+
+use crate::elf;
+use crate::read::{ReadError, ReadRef, Result};
+use crate::{U32, U64};
+
+use super::{FileHeader, Sym, SymbolTable};
+
+/// A SysV symbol hash table in an ELF file.
+#[derive(Debug)]
+pub struct HashTable<'data, Elf: FileHeader> {
+    buckets: &'data [U32<Elf::Endian>],
+    chains: &'data [U32<Elf::Endian>],
+}
+
+impl<'data, Elf: FileHeader> HashTable<'data, Elf> {
+    /// Parse a SysV hash table.
+    ///
+    /// `data` should be from a `SHT_HASH` section, or from a
+    /// segment pointed to via the `DT_HASH` entry.
+    ///
+    /// The header is read at offset 0 in the given `data`.
+    pub fn parse(endian: Elf::Endian, data: &'data [u8]) -> Result<Self> {
+        let mut offset = 0;
+        let header = data
+            .read::<elf::HashHeader<Elf::Endian>>(&mut offset)
+            .read_error("Invalid hash header")?;
+        let buckets = data
+            .read_slice(&mut offset, header.bucket_count.get(endian) as usize)
+            .read_error("Invalid hash buckets")?;
+        let chains = data
+            .read_slice(&mut offset, header.chain_count.get(endian) as usize)
+            .read_error("Invalid hash chains")?;
+        Ok(HashTable { buckets, chains })
+    }
+
+    /// Return the symbol table length.
+    pub fn symbol_table_length(&self) -> u32 {
+        self.chains.len() as u32
+    }
+
+    /// Use the hash table to find the symbol table entry with the given name and hash.
+    pub fn find<R: ReadRef<'data>>(
+        &self,
+        endian: Elf::Endian,
+        name: &[u8],
+        hash: u32,
+        symbols: &SymbolTable<'data, Elf, R>,
+    ) -> Option<&'data Elf::Sym> {
+        // Get the chain start from the bucket for this hash.
+        let mut index = self.buckets[(hash as usize) % self.buckets.len()].get(endian) as usize;
+        // Avoid infinite loop.
+        let mut i = 0;
+        let strings = symbols.strings();
+        while index != 0 && i < self.chains.len() {
+            if let Ok(symbol) = symbols.symbol(index) {
+                if symbol.name(endian, strings) == Ok(name) {
+                    return Some(symbol);
+                }
+            }
+            index = self.chains.get(index)?.get(endian) as usize;
+            i += 1;
+        }
+        None
+    }
+}
+
+/// A GNU symbol hash table in an ELF file.
+#[derive(Debug)]
+pub struct GnuHashTable<'data, Elf: FileHeader> {
+    symbol_base: u32,
+    bloom_shift: u32,
+    bloom_filters: &'data [u8],
+    buckets: &'data [U32<Elf::Endian>],
+    values: &'data [U32<Elf::Endian>],
+}
+
+impl<'data, Elf: FileHeader> GnuHashTable<'data, Elf> {
+    /// Parse a GNU hash table.
+    ///
+    /// `data` should be from a `SHT_GNU_HASH` section, or from a
+    /// segment pointed to via the `DT_GNU_HASH` entry.
+    ///
+    /// The header is read at offset 0 in the given `data`.
+    ///
+    /// The header does not contain a length field, and so all of `data`
+    /// will be used as the hash table values. It does not matter if this
+    /// is longer than needed, and this will often the case when accessing
+    /// the hash table via the `DT_GNU_HASH` entry.
+    pub fn parse(endian: Elf::Endian, data: &'data [u8]) -> Result<Self> {
+        let mut offset = 0;
+        let header = data
+            .read::<elf::GnuHashHeader<Elf::Endian>>(&mut offset)
+            .read_error("Invalid GNU hash header")?;
+        let bloom_len =
+            u64::from(header.bloom_count.get(endian)) * mem::size_of::<Elf::Word>() as u64;
+        let bloom_filters = data
+            .read_bytes(&mut offset, bloom_len)
+            .read_error("Invalid GNU hash bloom filters")?;
+        let buckets = data
+            .read_slice(&mut offset, header.bucket_count.get(endian) as usize)
+            .read_error("Invalid GNU hash buckets")?;
+        let chain_count = (data.len() - offset as usize) / 4;
+        let values = data
+            .read_slice(&mut offset, chain_count)
+            .read_error("Invalid GNU hash values")?;
+        Ok(GnuHashTable {
+            symbol_base: header.symbol_base.get(endian),
+            bloom_shift: header.bloom_shift.get(endian),
+            bloom_filters,
+            buckets,
+            values,
+        })
+    }
+
+    /// Return the symbol table index of the first symbol in the hash table.
+    pub fn symbol_base(&self) -> u32 {
+        self.symbol_base
+    }
+
+    /// Determine the symbol table length by finding the last entry in the hash table.
+    ///
+    /// Returns `None` if the hash table is empty or invalid.
+    pub fn symbol_table_length(&self, endian: Elf::Endian) -> Option<u32> {
+        // Ensure we find a non-empty bucket.
+        if self.symbol_base == 0 {
+            return None;
+        }
+
+        // Find the highest chain index in a bucket.
+        let mut max_symbol = 0;
+        for bucket in self.buckets {
+            let bucket = bucket.get(endian);
+            if max_symbol < bucket {
+                max_symbol = bucket;
+            }
+        }
+
+        // Find the end of the chain.
+        for value in self
+            .values
+            .get(max_symbol.checked_sub(self.symbol_base)? as usize..)?
+        {
+            max_symbol += 1;
+            if value.get(endian) & 1 != 0 {
+                return Some(max_symbol);
+            }
+        }
+
+        None
+    }
+
+    /// Use the hash table to find the symbol table entry with the given name and hash.
+    pub fn find<R: ReadRef<'data>>(
+        &self,
+        endian: Elf::Endian,
+        name: &[u8],
+        hash: u32,
+        symbols: &SymbolTable<'data, Elf, R>,
+    ) -> Option<&'data Elf::Sym> {
+        let word_bits = mem::size_of::<Elf::Word>() as u32 * 8;
+
+        // Test against bloom filter.
+        let bloom_count = self.bloom_filters.len() / mem::size_of::<Elf::Word>();
+        let offset =
+            ((hash / word_bits) & (bloom_count as u32 - 1)) * mem::size_of::<Elf::Word>() as u32;
+        let filter = if word_bits == 64 {
+            self.bloom_filters
+                .read_at::<U64<Elf::Endian>>(offset.into())
+                .ok()?
+                .get(endian)
+        } else {
+            self.bloom_filters
+                .read_at::<U32<Elf::Endian>>(offset.into())
+                .ok()?
+                .get(endian)
+                .into()
+        };
+        if filter & (1 << (hash % word_bits)) == 0 {
+            return None;
+        }
+        if filter & (1 << ((hash >> self.bloom_shift) % word_bits)) == 0 {
+            return None;
+        }
+
+        // Get the chain start from the bucket for this hash.
+        let index = self.buckets[(hash as usize) % self.buckets.len()].get(endian) as usize;
+        if index == 0 {
+            return None;
+        }
+
+        // Test symbols in the chain.
+        let strings = symbols.strings();
+        let symbols = symbols.symbols().get(index..)?;
+        let values = self
+            .values
+            .get(index.checked_sub(self.symbol_base as usize)?..)?;
+        for (symbol, value) in symbols.iter().zip(values.iter()) {
+            let value = value.get(endian);
+            if value | 1 == hash | 1 {
+                if symbol.name(endian, strings) == Ok(name) {
+                    return Some(symbol);
+                }
+            }
+            if value & 1 != 0 {
+                break;
+            }
+        }
+        None
+    }
+}

--- a/src/read/elf/mod.rs
+++ b/src/read/elf/mod.rs
@@ -34,3 +34,6 @@ pub use note::*;
 
 mod hash;
 pub use hash::*;
+
+mod version;
+pub use version::*;

--- a/src/read/elf/mod.rs
+++ b/src/read/elf/mod.rs
@@ -31,3 +31,6 @@ pub use compression::*;
 
 mod note;
 pub use note::*;
+
+mod hash;
+pub use hash::*;

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -457,9 +457,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> Result<&'data [u8], ()> {
+    ) -> read::Result<&'data [u8]> {
         if let Some((offset, size)) = self.file_range(endian) {
             data.read_bytes_at(offset, size)
+                .read_error("Invalid ELF section size or offset")
         } else {
             Ok(&[])
         }
@@ -474,9 +475,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> Result<&'data [T], ()> {
+    ) -> read::Result<&'data [T]> {
         let mut data = self.data(endian, data).map(Bytes)?;
         data.read_slice(data.len() / mem::size_of::<T>())
+            .read_error("Invalid ELF section size or offset")
     }
 
     /// Return the symbols in the section.

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -102,6 +102,12 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SymbolTable<'data, Elf, R> {
         self.strings
     }
 
+    /// Return the symbol table.
+    #[inline]
+    pub fn symbols(&self) -> &'data [Elf::Sym] {
+        self.symbols
+    }
+
     /// Iterate over the symbols.
     #[inline]
     pub fn iter(&self) -> slice::Iter<'data, Elf::Sym> {

--- a/src/read/elf/version.rs
+++ b/src/read/elf/version.rs
@@ -1,0 +1,176 @@
+use crate::elf;
+use crate::pod::Bytes;
+use crate::read::{ReadError, Result};
+
+use super::FileHeader;
+
+/// An iterator over the entries in an ELF `SHT_GNU_verdef` section.
+#[derive(Debug, Clone)]
+pub struct VerdefIterator<'data, Elf: FileHeader> {
+    endian: Elf::Endian,
+    data: Bytes<'data>,
+}
+
+impl<'data, Elf: FileHeader> VerdefIterator<'data, Elf> {
+    pub(super) fn new(endian: Elf::Endian, data: &'data [u8]) -> Self {
+        VerdefIterator {
+            endian,
+            data: Bytes(data),
+        }
+    }
+
+    /// Return the next `Verdef` entry.
+    pub fn next(
+        &mut self,
+    ) -> Result<Option<(&'data elf::Verdef<Elf::Endian>, VerdauxIterator<'data, Elf>)>> {
+        if self.data.is_empty() {
+            return Ok(None);
+        }
+
+        let verdef = self
+            .data
+            .read_at::<elf::Verdef<_>>(0)
+            .read_error("ELF verdef is too short")?;
+
+        let mut verdaux_data = self.data;
+        verdaux_data
+            .skip(verdef.vd_aux.get(self.endian) as usize)
+            .read_error("Invalid ELF vd_aux")?;
+        let verdaux =
+            VerdauxIterator::new(self.endian, verdaux_data.0, verdef.vd_cnt.get(self.endian));
+
+        let next = verdef.vd_next.get(self.endian);
+        if next != 0 {
+            self.data
+                .skip(next as usize)
+                .read_error("Invalid ELF vd_next")?;
+        } else {
+            self.data = Bytes(&[]);
+        }
+        Ok(Some((verdef, verdaux)))
+    }
+}
+
+/// An iterator over the auxiliary records for an entry in an ELF `SHT_GNU_verdef` section.
+#[derive(Debug, Clone)]
+pub struct VerdauxIterator<'data, Elf: FileHeader> {
+    endian: Elf::Endian,
+    data: Bytes<'data>,
+    count: u16,
+}
+
+impl<'data, Elf: FileHeader> VerdauxIterator<'data, Elf> {
+    pub(super) fn new(endian: Elf::Endian, data: &'data [u8], count: u16) -> Self {
+        VerdauxIterator {
+            endian,
+            data: Bytes(data),
+            count,
+        }
+    }
+
+    /// Return the next `Verdaux` entry.
+    pub fn next(&mut self) -> Result<Option<&'data elf::Verdaux<Elf::Endian>>> {
+        if self.count == 0 {
+            return Ok(None);
+        }
+
+        let verdaux = self
+            .data
+            .read_at::<elf::Verdaux<_>>(0)
+            .read_error("ELF verdaux is too short")?;
+
+        self.data
+            .skip(verdaux.vda_next.get(self.endian) as usize)
+            .read_error("Invalid ELF vda_next")?;
+        self.count -= 1;
+        Ok(Some(verdaux))
+    }
+}
+
+/// An iterator over the entries in an ELF `SHT_GNU_verneed` section.
+#[derive(Debug, Clone)]
+pub struct VerneedIterator<'data, Elf: FileHeader> {
+    endian: Elf::Endian,
+    data: Bytes<'data>,
+}
+
+impl<'data, Elf: FileHeader> VerneedIterator<'data, Elf> {
+    pub(super) fn new(endian: Elf::Endian, data: &'data [u8]) -> Self {
+        VerneedIterator {
+            endian,
+            data: Bytes(data),
+        }
+    }
+
+    /// Return the next `Verneed` entry.
+    pub fn next(
+        &mut self,
+    ) -> Result<
+        Option<(
+            &'data elf::Verneed<Elf::Endian>,
+            VernauxIterator<'data, Elf>,
+        )>,
+    > {
+        if self.data.is_empty() {
+            return Ok(None);
+        }
+
+        let verneed = self
+            .data
+            .read_at::<elf::Verneed<_>>(0)
+            .read_error("ELF verneed is too short")?;
+
+        let mut vernaux_data = self.data;
+        vernaux_data
+            .skip(verneed.vn_aux.get(self.endian) as usize)
+            .read_error("Invalid ELF vn_aux")?;
+        let vernaux =
+            VernauxIterator::new(self.endian, vernaux_data.0, verneed.vn_cnt.get(self.endian));
+
+        let next = verneed.vn_next.get(self.endian);
+        if next != 0 {
+            self.data
+                .skip(next as usize)
+                .read_error("Invalid ELF vn_next")?;
+        } else {
+            self.data = Bytes(&[]);
+        }
+        Ok(Some((verneed, vernaux)))
+    }
+}
+
+/// An iterator over the auxiliary records for an entry in an ELF `SHT_GNU_verneed` section.
+#[derive(Debug, Clone)]
+pub struct VernauxIterator<'data, Elf: FileHeader> {
+    endian: Elf::Endian,
+    data: Bytes<'data>,
+    count: u16,
+}
+
+impl<'data, Elf: FileHeader> VernauxIterator<'data, Elf> {
+    pub(super) fn new(endian: Elf::Endian, data: &'data [u8], count: u16) -> Self {
+        VernauxIterator {
+            endian,
+            data: Bytes(data),
+            count,
+        }
+    }
+
+    /// Return the next `Vernaux` entry.
+    pub fn next(&mut self) -> Result<Option<&'data elf::Vernaux<Elf::Endian>>> {
+        if self.count == 0 {
+            return Ok(None);
+        }
+
+        let vernaux = self
+            .data
+            .read_at::<elf::Vernaux<_>>(0)
+            .read_error("ELF vernaux is too short")?;
+
+        self.data
+            .skip(vernaux.vna_next.get(self.endian) as usize)
+            .read_error("Invalid ELF vna_next")?;
+        self.count -= 1;
+        Ok(Some(vernaux))
+    }
+}

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -87,6 +87,12 @@ impl<T> ReadError<T> for result::Result<T, ()> {
     }
 }
 
+impl<T> ReadError<T> for result::Result<T, Error> {
+    fn read_error(self, error: &'static str) -> Result<T> {
+        self.map_err(|_| Error(error))
+    }
+}
+
 impl<T> ReadError<T> for Option<T> {
     fn read_error(self, error: &'static str) -> Result<T> {
         self.ok_or(Error(error))


### PR DESCRIPTION
Symbol version support is good enough for the readobj example to dump the raw values, but it will need some higher level support later.