### PR TITLE
read/elf: add support for .dynamic sections

### DIFF
--- a/src/read/elf/dynamic.rs
+++ b/src/read/elf/dynamic.rs
@@ -1,3 +1,4 @@
+use core::convert::TryInto;
 use core::fmt::Debug;
 
 use crate::elf;
@@ -12,6 +13,58 @@ pub trait Dyn: Debug + Pod {
 
     fn d_tag(&self, endian: Self::Endian) -> Self::Word;
     fn d_val(&self, endian: Self::Endian) -> Self::Word;
+
+    /// Try to convert the tag to a `u32`.
+    fn tag32(&self, endian: Self::Endian) -> Option<u32> {
+        self.d_tag(endian).into().try_into().ok()
+    }
+
+    /// Return true if the value is an offset in the dynamic string table.
+    fn is_string(&self, endian: Self::Endian) -> bool {
+        if let Some(tag) = self.tag32(endian) {
+            match tag {
+                elf::DT_NEEDED
+                | elf::DT_SONAME
+                | elf::DT_RPATH
+                | elf::DT_RUNPATH
+                | elf::DT_AUXILIARY
+                | elf::DT_FILTER => true,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Return true if the value is an address.
+    fn is_address(&self, endian: Self::Endian) -> bool {
+        if let Some(tag) = self.tag32(endian) {
+            match tag {
+                elf::DT_PLTGOT
+                | elf::DT_HASH
+                | elf::DT_STRTAB
+                | elf::DT_SYMTAB
+                | elf::DT_RELA
+                | elf::DT_INIT
+                | elf::DT_FINI
+                | elf::DT_SYMBOLIC
+                | elf::DT_REL
+                | elf::DT_DEBUG
+                | elf::DT_JMPREL
+                | elf::DT_FINI_ARRAY
+                | elf::DT_INIT_ARRAY
+                | elf::DT_PREINIT_ARRAY
+                | elf::DT_SYMTAB_SHNDX
+                | elf::DT_VERDEF
+                | elf::DT_VERNEED
+                | elf::DT_VERSYM
+                | elf::DT_ADDRRNGLO..=elf::DT_ADDRRNGHI => true,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
 }
 
 impl<Endian: endian::Endian> Dyn for elf::Dyn32<Endian> {


### PR DESCRIPTION
Previously we only supported segments.

Also add helpers for determining the value type of dynamic entries.