### PR TITLE
Introduce a StreamingBuffer

### DIFF
--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -579,7 +579,7 @@ impl Object {
                     debug_assert!(aux_len >= symbol.name.len());
                     let old_len = buffer.len();
                     buffer.write_bytes(&symbol.name);
-                    buffer.resize(old_len + aux_len, 0);
+                    buffer.resize(old_len + aux_len);
                 }
                 SymbolKind::Section => {
                     debug_assert_eq!(number_of_aux_symbols, 1);

--- a/src/write/elf.rs
+++ b/src/write/elf.rs
@@ -178,7 +178,9 @@ impl Object {
             .sections
             .iter()
             .map(|section| {
-                let mut reloc_name = Vec::new();
+                let mut reloc_name = Vec::with_capacity(
+                    if is_rela { ".rela".len() } else { ".rel".len() } + section.name.len(),
+                );
                 if !section.relocations.is_empty() {
                     reloc_name.extend_from_slice(if is_rela {
                         &b".rela"[..]
@@ -416,7 +418,7 @@ impl Object {
 
         // Write section data.
         for (index, comdat) in self.comdats.iter().enumerate() {
-            let mut data = Vec::new();
+            let mut data = Vec::with_capacity(comdat_offsets[index].len);
             data.write_pod(&U32::new(self.endian, elf::GRP_COMDAT));
             for section in &comdat.sections {
                 data.write_pod(&U32::new(
@@ -453,7 +455,7 @@ impl Object {
                 st_size: 0,
             },
         );
-        let mut symtab_shndx = Vec::new();
+        let mut symtab_shndx = Vec::with_capacity(symtab_shndx_len);
         if need_symtab_shndx {
             symtab_shndx.write_pod(&U32::new(endian, 0));
         }

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -11,9 +11,9 @@ pub trait WritableBuffer {
     /// Reserves specified number of bytes in the buffer.
     fn reserve(&mut self, additional: usize) -> Result<(), ()>;
 
-    /// Writes the specified value at the end of the buffer
-    /// until the buffer has the specified length.
-    fn resize(&mut self, new_len: usize, value: u8);
+    /// Writes zero bytes at the end of the buffer until the buffer
+    /// has the specified length.
+    fn resize(&mut self, new_len: usize);
 
     /// Writes the specified slice of bytes at the end of the buffer.
     fn write_bytes(&mut self, val: &[u8]);
@@ -60,8 +60,9 @@ impl WritableBuffer for Vec<u8> {
     }
 
     #[inline]
-    fn resize(&mut self, new_len: usize, value: u8) {
-        self.resize(new_len, value);
+    fn resize(&mut self, new_len: usize) {
+        debug_assert!(new_len >= self.len());
+        self.resize(new_len, 0);
     }
 
     #[inline]
@@ -99,7 +100,7 @@ pub(crate) fn align_u64(offset: u64, size: u64) -> u64 {
 
 pub(crate) fn write_align(buffer: &mut dyn WritableBuffer, size: usize) {
     let new_len = align(buffer.len(), size);
-    buffer.resize(new_len, 0);
+    buffer.resize(new_len);
 }
 
 #[cfg(test)]

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -6,10 +6,14 @@ use crate::pod::{bytes_of, bytes_of_slice, Pod};
 #[allow(clippy::len_without_is_empty)]
 pub trait WritableBuffer {
     /// Returns position/offset for data to be written at.
+    /// Should only be used in debug assertions
     fn len(&self) -> usize;
 
     /// Reserves specified number of bytes in the buffer.
-    fn reserve(&mut self, additional: usize) -> Result<(), ()>;
+    /// Must be called exactly once before writing anything to the buffer.
+    /// Must be given the exact of the buffer after writing everything, calling with a smaller size
+    /// may result in a panic, while calling with a bigger size may result in trailing garbage.
+    fn reserve(&mut self, size: usize) -> Result<(), ()>;
 
     /// Writes zero bytes at the end of the buffer until the buffer
     /// has the specified length.
@@ -54,8 +58,9 @@ impl WritableBuffer for Vec<u8> {
     }
 
     #[inline]
-    fn reserve(&mut self, additional: usize) -> Result<(), ()> {
-        self.reserve(additional);
+    fn reserve(&mut self, size: usize) -> Result<(), ()> {
+        assert_eq!(self.len(), 0, "Buffer must be empty");
+        self.reserve(size);
         Ok(())
     }
 
@@ -67,6 +72,7 @@ impl WritableBuffer for Vec<u8> {
 
     #[inline]
     fn write_bytes(&mut self, val: &[u8]) {
+        debug_assert!(self.len() + val.len() <= self.capacity());
         self.extend_from_slice(val)
     }
 }


### PR DESCRIPTION
This streams an object file to the given writer without keeping it all in memory at once. This avoids an unnecessary copy of all data when you want to write the object file to the disk immediately afterwards anyway. I also made the api contract of `WritableBuffer` a bit stricter to for example allow writing to a file using memory mapping by requiring that the size given to `.reserve()` matches matches the final size of the object file. Finally I pre-allocated a couple of vecs with the final size to prevent re-allocations.