### PR TITLE
read: add `Object::kind`

### DIFF
--- a/examples/objcopy.rs
+++ b/examples/objcopy.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::{env, fs, process};
 
 use object::{
-    write, Object, ObjectComdat, ObjectSection, ObjectSymbol, RelocationTarget, SectionKind,
-    SymbolFlags, SymbolKind, SymbolSection,
+    write, Object, ObjectComdat, ObjectKind, ObjectSection, ObjectSymbol, RelocationTarget,
+    SectionKind, SymbolFlags, SymbolKind, SymbolSection,
 };
 
 fn main() {
@@ -38,6 +38,10 @@ fn main() {
             process::exit(1);
         }
     };
+    if in_object.kind() != ObjectKind::Relocatable {
+        eprintln!("Unsupported object kind: {:?}", in_object.kind());
+        process::exit(1);
+    }
 
     let mut out_object = write::Object::new(
         in_object.format(),

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -120,6 +120,7 @@ fn dump_parsed_object(file: &object::File) {
         file.endianness(),
         if file.is_64() { "64" } else { "32" }
     );
+    println!("Kind: {:?}", file.kind());
     println!("Architecture: {:?}", file.architecture());
     println!("Flags: {:x?}", file.flags());
     println!("Relative Address Base: {:x?}", file.relative_address_base());

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -14,10 +14,10 @@ use crate::read::pe;
 use crate::read::wasm;
 use crate::read::{
     self, Architecture, BinaryFormat, CodeView, ComdatKind, CompressedData, CompressedFileRange,
-    Error, Export, FileFlags, FileKind, Import, Object, ObjectComdat, ObjectMap, ObjectSection,
-    ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadRef, Relocation, Result, SectionFlags,
-    SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName,
-    SymbolScope, SymbolSection,
+    Error, Export, FileFlags, FileKind, Import, Object, ObjectComdat, ObjectKind, ObjectMap,
+    ObjectSection, ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadRef, Relocation, Result,
+    SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap,
+    SymbolMapName, SymbolScope, SymbolSection,
 };
 #[allow(unused_imports)]
 use crate::Endianness;
@@ -284,6 +284,10 @@ where
 
     fn is_64(&self) -> bool {
         with_inner!(self.inner, FileInternal, |x| x.is_64())
+    }
+
+    fn kind(&self) -> ObjectKind {
+        with_inner!(self.inner, FileInternal, |x| x.kind())
     }
 
     fn segments(&'file self) -> SegmentIterator<'data, 'file, R> {

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use crate::read::{
-    self, Architecture, Export, FileFlags, Import, NoDynamicRelocationIterator, Object,
+    self, Architecture, Export, FileFlags, Import, NoDynamicRelocationIterator, Object, ObjectKind,
     ObjectSection, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
 };
 use crate::{pe, LittleEndian as LE};
@@ -86,6 +86,10 @@ where
     fn is_64(&self) -> bool {
         // Windows COFF is always 32-bit, even for 64-bit architectures. This could be confusing.
         false
+    }
+
+    fn kind(&self) -> ObjectKind {
+        ObjectKind::Relocatable
     }
 
     fn segments(&'file self) -> CoffSegmentIterator<'data, 'file, R> {

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -4,8 +4,8 @@ use core::{mem, str};
 
 use crate::read::{
     self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
-    Object, ObjectComdat, ObjectMap, ObjectSection, ReadError, ReadRef, Result, SectionIndex,
-    SymbolIndex,
+    Object, ObjectComdat, ObjectKind, ObjectMap, ObjectSection, ReadError, ReadRef, Result,
+    SectionIndex, SymbolIndex,
 };
 use crate::{endian, macho, BigEndian, ByteString, Endian, Endianness, Pod};
 
@@ -140,6 +140,16 @@ where
     #[inline]
     fn is_64(&self) -> bool {
         self.header.is_type_64()
+    }
+
+    fn kind(&self) -> ObjectKind {
+        match self.header.filetype(self.endian) {
+            macho::MH_OBJECT => ObjectKind::Relocatable,
+            macho::MH_EXECUTE => ObjectKind::Executable,
+            macho::MH_CORE => ObjectKind::Core,
+            macho::MH_DYLIB => ObjectKind::Dynamic,
+            _ => ObjectKind::Unknown,
+        }
     }
 
     fn segments(&'file self) -> MachOSegmentIterator<'data, 'file, Mach, R> {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -136,7 +136,7 @@ pub type NativeFile<'data, R = &'data [u8]> = pe::PeFile64<'data, R>;
 #[cfg(all(feature = "wasm", target_arch = "wasm32", feature = "wasm"))]
 pub type NativeFile<'data, R = &'data [u8]> = wasm::WasmFile<'data, R>;
 
-/// An object file kind.
+/// A file format kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum FileKind {
@@ -240,6 +240,22 @@ impl FileKind {
         };
         Ok(kind)
     }
+}
+
+/// An object kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ObjectKind {
+    /// The object kind is unknown.
+    Unknown,
+    /// Relocatable object.
+    Relocatable,
+    /// Executable.
+    Executable,
+    /// Dynamic shared object.
+    Dynamic,
+    /// Core.
+    Core,
 }
 
 /// The index used to identify a section of a file.

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -3,8 +3,9 @@ use alloc::vec::Vec;
 
 use crate::read::{
     self, Architecture, CodeView, ComdatKind, CompressedData, CompressedFileRange, Export,
-    FileFlags, Import, ObjectMap, Relocation, Result, SectionFlags, SectionIndex, SectionKind,
-    SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
+    FileFlags, Import, ObjectKind, ObjectMap, Relocation, Result, SectionFlags, SectionIndex,
+    SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope,
+    SymbolSection,
 };
 use crate::Endianness;
 
@@ -65,6 +66,9 @@ pub trait Object<'data: 'file, 'file>: read::private::Sealed {
 
     /// Return true if the file can contain 64-bit addresses.
     fn is_64(&self) -> bool;
+
+    /// Return the kind of this object.
+    fn kind(&self) -> ObjectKind;
 
     /// Get an iterator over the segments in the file.
     fn segments(&'file self) -> Self::SegmentIterator;

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -11,9 +11,10 @@ use wasmparser as wp;
 
 use crate::read::{
     self, Architecture, ComdatKind, CompressedData, CompressedFileRange, Error, Export, FileFlags,
-    Import, NoDynamicRelocationIterator, Object, ObjectComdat, ObjectSection, ObjectSegment,
-    ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Relocation, Result, SectionFlags,
-    SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
+    Import, NoDynamicRelocationIterator, Object, ObjectComdat, ObjectKind, ObjectSection,
+    ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Relocation, Result,
+    SectionFlags, SectionIndex, SectionKind, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope,
+    SymbolSection,
 };
 
 const SECTION_CUSTOM: usize = 0;
@@ -324,6 +325,11 @@ where
     #[inline]
     fn is_64(&self) -> bool {
         false
+    }
+
+    fn kind(&self) -> ObjectKind {
+        // TODO: check for `linking` custom section
+        ObjectKind::Unknown
     }
 
     fn segments(&'file self) -> Self::SegmentIterator {


### PR DESCRIPTION
Use this to check for supported object kind in `objcopy` example.