### PR TITLE
Fixed a URL in a doc comment

### DIFF
--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -80,8 +80,8 @@ impl<'data> SectionTable<'data> {
 
     /// Compute the maximum file offset used by sections.
     ///
-    /// This will usually match the end of file, unless the PE file has a [data overlay]
-    /// (https://security.stackexchange.com/questions/77336/how-is-the-file-overlay-read-by-an-exe-virus)
+    /// This will usually match the end of file, unless the PE file has a
+    /// [data overlay](https://security.stackexchange.com/questions/77336/how-is-the-file-overlay-read-by-an-exe-virus)
     pub fn max_section_file_offset(&self) -> u64 {
         let mut max = 0;
         for section in self.iter() {


### PR DESCRIPTION
Because newlines break the Markdown URL syntax