### PR TITLE
Activate memchr's dep-of-std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crc32fast = { version = "1.2", optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
 wasmparser = { version = "0.57", optional = true }
-memchr = { version = "2.4", default-features = false }
+memchr = { version = "2.4.1", default-features = false }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
@@ -81,7 +81,7 @@ cargo-all = []
 #=======================================
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc']
+rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc', 'memchr/rustc-dep-of-std']
 
 [[example]]
 name = "ar"


### PR DESCRIPTION
This accompanies BurntSushi/memchr#89 to help resolve
rust-lang/backtrace-rs#432

Note that this can't actually land until https://github.com/BurntSushi/memchr/pull/89 is published