### PR TITLE
Allow access to section contents while building

### DIFF
--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -696,6 +696,22 @@ impl Section {
         self.size += size;
         offset as u64
     }
+
+    /// Returns the section as-built so far.
+    ///
+    /// This requires that the section is not a bss section.
+    pub fn data(&self) -> &[u8] {
+        debug_assert!(!self.is_bss());
+        &self.data
+    }
+
+    /// Returns the section as-built so far.
+    ///
+    /// This requires that the section is not a bss section.
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        debug_assert!(!self.is_bss());
+        &mut self.data
+    }
 }
 
 /// The section where a symbol is defined.


### PR DESCRIPTION
This commit adds `Section::{data, data_mut}` accessors to
`write::Section` to allow accessing data after it's been appended. The
motivation for this is that in Wasmtime we build an `Object` but we try
to patch relocations after the locations of all symbols are known,
handling them before load-time. Currently the logic of
appending-with-alignment is duplicated in Wasmtime but allowing access
to the underlying section data as-been-appended-so-far should enable us
to remove that duplication.