### PR TITLE
write: use Cow for Section::data

### DIFF
--- a/crates/examples/src/bin/objcopy.rs
+++ b/crates/examples/src/bin/objcopy.rs
@@ -70,7 +70,7 @@ fn main() {
         if out_section.is_bss() {
             out_section.append_bss(in_section.size(), in_section.align());
         } else {
-            out_section.set_data(in_section.data().unwrap().into(), in_section.align());
+            out_section.set_data(in_section.data().unwrap(), in_section.align());
         }
         out_section.flags = in_section.flags();
         out_sections.insert(in_section.index(), section_id);

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -23,7 +23,7 @@ struct SymbolOffsets {
     aux_count: u8,
 }
 
-impl Object {
+impl<'a> Object<'a> {
     pub(crate) fn coff_section_info(
         &self,
         section: StandardSection,
@@ -589,7 +589,7 @@ impl Object {
                         length: U32Bytes::new(LE, section.size as u32),
                         number_of_relocations: U16Bytes::new(LE, section.relocations.len() as u16),
                         number_of_linenumbers: U16Bytes::default(),
-                        check_sum: U32Bytes::new(LE, checksum(section.data.as_slice())),
+                        check_sum: U32Bytes::new(LE, checksum(section.data())),
                         number: U16Bytes::new(
                             LE,
                             section_offsets[section_index].associative_section,

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -27,7 +27,7 @@ struct SymbolOffsets {
     str_id: Option<StringId>,
 }
 
-impl Object {
+impl<'a> Object<'a> {
     pub(crate) fn elf_section_info(
         &self,
         section: StandardSection,

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -22,7 +22,7 @@ struct SymbolOffsets {
     str_id: Option<StringId>,
 }
 
-impl Object {
+impl<'a> Object<'a> {
     pub(crate) fn macho_set_subsections_via_symbols(&mut self) {
         let flags = match self.flags {
             FileFlags::MachO { flags } => flags,


### PR DESCRIPTION
@bjorn3 Will this fix https://github.com/gimli-rs/object/pull/348#issuecomment-894684012? You'll need to use `set_section_data` instead of `append_section_data`. The cost is that other users may need to specify `'static` for the lifetime. Maybe it's worth using `Cow` for the section and symbol names too.