### PR TITLE
Make `std` imply `indexmap/std`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ write = ["write_core", "coff", "elf", "macho"]
 
 # Enable things that require libstd.
 # Currently, this provides an `Error` implementation.
-std = ["memchr/std"]
+std = ["memchr/std", "indexmap/std"]
 # Enable decompression of compressed sections.
 # This feature is not required if you want to do your own decompression.
 compression = ["flate2", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ read_core = []
 # Read support for all file formats (including unaligned files).
 read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned"]
 # Core write support. You will need to enable some file formats too.
-write_core = ["crc32fast", "indexmap", "std"]
+write_core = ["crc32fast", "indexmap", "std", "indexmap/std"]
 # Write support for all file formats.
 write = ["write_core", "coff", "elf", "macho"]
 
@@ -45,7 +45,7 @@ write = ["write_core", "coff", "elf", "macho"]
 
 # Enable things that require libstd.
 # Currently, this provides an `Error` implementation.
-std = ["memchr/std", "indexmap/std"]
+std = ["memchr/std"]
 # Enable decompression of compressed sections.
 # This feature is not required if you want to do your own decompression.
 compression = ["flate2", "std"]


### PR DESCRIPTION
In src/write/string.rs, `StringTable` uses `IndexSet` with one generic
parameter. `IndexSet` only supports being passed one generic parameter
[when `indexmap`'s `std` feature is enabled]. `indexmap`
[attempts to autodetect] whether `std` is supported, but it doesn't
always succeed. This patch explicitly enables `indexmap/std` when
`object`'s own `std` feature is enabled, to avoid the autodetection
path.

[when `indexmap`'s `std` feature is enabled]: https://github.com/bluss/indexmap/blob/master/src/set.rs#L62
[attempts to autodetect]: https://github.com/bluss/indexmap/blob/master/build.rs#L3