### PR TITLE
Iterating import directory entry stops at a (completely) null iterm

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1917,6 +1917,18 @@ pub struct ImageImportDescriptor {
     pub first_thunk: U32Bytes<LE>,
 }
 
+impl ImageImportDescriptor {
+    /// Tell whether this import descriptor is the null descriptor
+    /// (used to mark the end of the iterator array in a PE)
+    pub fn is_null(&self) -> bool {
+        self.original_first_thunk.get(LE) == 0
+            && self.time_date_stamp.get(LE) == 0
+            && self.forwarder_chain.get(LE) == 0
+            && self.name.get(LE) == 0
+            && self.first_thunk.get(LE) == 0
+    }
+}
+
 //
 // New format import descriptors pointed to by DataDirectory[ IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT ]
 //

--- a/src/read/pe/import.rs
+++ b/src/read/pe/import.rs
@@ -108,7 +108,7 @@ impl<'data> ImportDescriptorIterator<'data> {
             .data
             .read::<pe::ImageImportDescriptor>()
             .read_error("Missing PE null import descriptor")?;
-        if import_desc.original_first_thunk.get(LE) == 0 {
+        if import_desc.is_null() {
             Ok(None)
         } else {
             Ok(Some(import_desc))


### PR DESCRIPTION
Currently, the iterator for PE imports stop at the first item where `original_first_thunk == 0`. However, we should stop at a (totally) null item, as (more-or-less clearly) stated in the [PE file specification](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#the-idata-section) 