### PR TITLE
Add support for split dyld shared cache.

### DIFF
--- a/crates/examples/src/bin/objdump.rs
+++ b/crates/examples/src/bin/objdump.rs
@@ -18,6 +18,7 @@ fn main() {
             process::exit(1);
         }
     };
+    let extra_files = open_subcaches_if_exist(&file_path);
     let file = match unsafe { memmap2::Mmap::map(&file) } {
         Ok(mmap) => mmap,
         Err(err) => {
@@ -25,8 +26,50 @@ fn main() {
             process::exit(1);
         }
     };
+    let extra_files: Vec<_> = extra_files
+        .into_iter()
+        .map(
+            |subcache_file| match unsafe { memmap2::Mmap::map(&subcache_file) } {
+                Ok(mmap) => mmap,
+                Err(err) => {
+                    eprintln!("Failed to map file '{}': {}", file_path, err,);
+                    process::exit(1);
+                }
+            },
+        )
+        .collect();
+    let extra_file_data: Vec<&[u8]> = extra_files.iter().map(|f| &**f).collect();
 
     let stdout = io::stdout();
     let stderr = io::stderr();
-    objdump::print(&mut stdout.lock(), &mut stderr.lock(), &*file, member_names).unwrap();
+    objdump::print(
+        &mut stdout.lock(),
+        &mut stderr.lock(),
+        &*file,
+        &extra_file_data,
+        member_names,
+    )
+    .unwrap();
+}
+
+// If the file is a dyld shared cache, and we're on macOS 12 or later,
+// then there will be one or more "subcache" files next to this file,
+// with the names filename.1, filename.2 etc.
+// Read those files now, if they exist, even if we don't know that
+// we're dealing with a dyld shared cache. By the time we know what
+// we're dealing with, it's too late to read more files.
+fn open_subcaches_if_exist(path: &str) -> Vec<fs::File> {
+    let mut files = Vec::new();
+    for i in 1.. {
+        let subcache_path = format!("{}.{}", path, i);
+        match fs::File::open(&subcache_path) {
+            Ok(subcache_file) => files.push(subcache_file),
+            Err(_) => break,
+        };
+    }
+    let symbols_subcache_path = format!("{}.symbols", path);
+    if let Ok(subcache_file) = fs::File::open(&symbols_subcache_path) {
+        files.push(subcache_file);
+    };
+    files
 }

--- a/crates/examples/src/objdump.rs
+++ b/crates/examples/src/objdump.rs
@@ -7,6 +7,7 @@ pub fn print<W: Write, E: Write>(
     w: &mut W,
     e: &mut E,
     file: &[u8],
+    extra_files: &[&[u8]],
     member_names: Vec<String>,
 ) -> Result<()> {
     let mut member_names: Vec<_> = member_names.into_iter().map(|name| (name, false)).collect();
@@ -47,7 +48,7 @@ pub fn print<W: Write, E: Write>(
                 Err(err) => writeln!(e, "Failed to parse Fat 64 data: {}", err)?,
             }
         }
-    } else if let Ok(cache) = DyldCache::<Endianness>::parse(&*file) {
+    } else if let Ok(cache) = DyldCache::<Endianness>::parse(&*file, extra_files) {
         writeln!(w, "Format: dyld cache {:?}-endian", cache.endianness())?;
         writeln!(w, "Architecture: {:?}", cache.architecture())?;
         for image in cache.images() {

--- a/crates/examples/tests/testfiles.rs
+++ b/crates/examples/tests/testfiles.rs
@@ -28,7 +28,7 @@ fn testfiles() {
             println!("File {}", path);
             let data = fs::read(&path).unwrap();
             fail |= testfile(path, &data, "objdump", |mut out, mut err, data| {
-                objdump::print(&mut out, &mut err, data, vec![]).unwrap()
+                objdump::print(&mut out, &mut err, data, &[], vec![]).unwrap()
             });
             fail |= testfile(path, &data, "readobj", readobj::print);
             println!();

--- a/src/read/macho/dyld_cache.rs
+++ b/src/read/macho/dyld_cache.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::slice;
 
 use crate::read::{Error, File, ReadError, ReadRef, Result};
@@ -12,11 +13,27 @@ where
 {
     endian: E,
     data: R,
+    subcaches: Vec<DyldSubCache<'data, E, R>>,
+    symbols_subcache: Option<DyldSubCache<'data, E, R>>,
     header: &'data macho::DyldCacheHeader<E>,
     mappings: &'data [macho::DyldCacheMappingInfo<E>],
     images: &'data [macho::DyldCacheImageInfo<E>],
     arch: Architecture,
 }
+
+/// Information about a subcache.
+#[derive(Debug)]
+pub struct DyldSubCache<'data, E = Endianness, R = &'data [u8]>
+where
+    E: Endian,
+    R: ReadRef<'data>,
+{
+    data: R,
+    mappings: &'data [macho::DyldCacheMappingInfo<E>],
+}
+
+// This is the offset of the images_across_all_subcaches_count field.
+const MIN_HEADER_SIZE_SUBCACHES: u32 = 0x1c4;
 
 impl<'data, E, R> DyldCache<'data, E, R>
 where
@@ -24,14 +41,61 @@ where
     R: ReadRef<'data>,
 {
     /// Parse the raw dyld shared cache data.
-    pub fn parse(data: R) -> Result<Self> {
+    /// For shared caches from macOS 12 / iOS 15 and above, the subcache files need to be
+    /// supplied as well, in the correct order, with the .symbols subcache last (if present).
+    /// For example, data would be the data for dyld_shared_cache_x86_64,
+    /// and subcache_data would be the data for [dyld_shared_cache_x86_64.1, dyld_shared_cache_x86_64.2, ...]
+    pub fn parse(data: R, subcache_data: &[R]) -> Result<Self> {
         let header = macho::DyldCacheHeader::parse(data)?;
         let (arch, endian) = header.parse_magic()?;
         let mappings = header.mappings(endian, data)?;
+
+        let symbols_subcache_uuid = header.symbols_subcache_uuid(endian);
+        let subcaches_info = header.subcaches(endian, data)?.unwrap_or(&[]);
+
+        if subcache_data.len() != subcaches_info.len() + symbols_subcache_uuid.is_some() as usize {
+            return Err(Error("Incorrect number of SubCaches"));
+        }
+
+        // Split out the .symbols subcache data from the other subcaches.
+        let (symbols_subcache_data_and_uuid, subcache_data) =
+            if let Some(symbols_uuid) = symbols_subcache_uuid {
+                let (sym_data, rest_data) = subcache_data.split_last().unwrap();
+                (Some((*sym_data, symbols_uuid)), rest_data)
+            } else {
+                (None, subcache_data)
+            };
+
+        // Read the regular SubCaches (.1, .2, ...), if present.
+        let mut subcaches = Vec::new();
+        for (&data, info) in subcache_data.iter().zip(subcaches_info.iter()) {
+            let sc_header = macho::DyldCacheHeader::<E>::parse(data)?;
+            if sc_header.uuid != info.uuid {
+                return Err(Error("Unexpected SubCache UUID"));
+            }
+            let mappings = sc_header.mappings(endian, data)?;
+            subcaches.push(DyldSubCache { data, mappings });
+        }
+
+        // Read the .symbols SubCache, if present.
+        let symbols_subcache = match symbols_subcache_data_and_uuid {
+            Some((data, uuid)) => {
+                let sc_header = macho::DyldCacheHeader::<E>::parse(data)?;
+                if sc_header.uuid != uuid {
+                    return Err(Error("Unexpected .symbols SubCache UUID"));
+                }
+                let mappings = sc_header.mappings(endian, data)?;
+                Some(DyldSubCache { data, mappings })
+            }
+            None => None,
+        };
+
         let images = header.images(endian, data)?;
         Ok(DyldCache {
             endian,
             data,
+            subcaches,
+            symbols_subcache,
             header,
             mappings,
             images,
@@ -66,6 +130,22 @@ where
             iter: self.images.iter(),
         }
     }
+
+    /// Find the address in a mapping and return the cache or subcache data it was found in,
+    /// together with the translated file offset.
+    pub fn data_and_offset_for_address(&self, address: u64) -> Option<(R, u64)> {
+        if let Some(file_offset) = address_to_file_offset(address, self.endian, self.mappings) {
+            return Some((self.data, file_offset));
+        }
+        for subcache in &self.subcaches {
+            if let Some(file_offset) =
+                address_to_file_offset(address, self.endian, subcache.mappings)
+            {
+                return Some((subcache.data, file_offset));
+            }
+        }
+        None
+    }
 }
 
 /// An iterator over all the images (dylibs) in the dyld shared cache.
@@ -84,14 +164,12 @@ where
     E: Endian,
     R: ReadRef<'data>,
 {
-    type Item = DyldCacheImage<'data, E, R>;
+    type Item = DyldCacheImage<'data, 'cache, E, R>;
 
-    fn next(&mut self) -> Option<DyldCacheImage<'data, E, R>> {
+    fn next(&mut self) -> Option<DyldCacheImage<'data, 'cache, E, R>> {
         let image_info = self.iter.next()?;
         Some(DyldCacheImage {
-            endian: self.cache.endian,
-            data: self.cache.data,
-            mappings: self.cache.mappings,
+            cache: self.cache,
             image_info,
         })
     }
@@ -99,38 +177,40 @@ where
 
 /// One image (dylib) from inside the dyld shared cache.
 #[derive(Debug)]
-pub struct DyldCacheImage<'data, E = Endianness, R = &'data [u8]>
+pub struct DyldCacheImage<'data, 'cache, E = Endianness, R = &'data [u8]>
 where
     E: Endian,
     R: ReadRef<'data>,
 {
-    endian: E,
-    data: R,
-    mappings: &'data [macho::DyldCacheMappingInfo<E>],
+    pub(crate) cache: &'cache DyldCache<'data, E, R>,
     image_info: &'data macho::DyldCacheImageInfo<E>,
 }
 
-impl<'data, E, R> DyldCacheImage<'data, E, R>
+impl<'data, 'cache, E, R> DyldCacheImage<'data, 'cache, E, R>
 where
     E: Endian,
     R: ReadRef<'data>,
 {
     /// The file system path of this image.
     pub fn path(&self) -> Result<&'data str> {
-        let path = self.image_info.path(self.endian, self.data)?;
+        let path = self.image_info.path(self.cache.endian, self.cache.data)?;
         // The path should always be ascii, so from_utf8 should alway succeed.
         let path = core::str::from_utf8(path).map_err(|_| Error("Path string not valid utf-8"))?;
         Ok(path)
     }
 
-    /// The offset in the dyld cache file where this image starts.
-    pub fn file_offset(&self) -> Result<u64> {
-        self.image_info.file_offset(self.endian, self.mappings)
+    /// The subcache data which contains the Mach-O header for this image,
+    /// together with the file offset at which this image starts.
+    pub fn image_data_and_offset(&self) -> Result<(R, u64)> {
+        let address = self.image_info.address.get(self.cache.endian);
+        self.cache
+            .data_and_offset_for_address(address)
+            .ok_or(Error("Address not found in any mapping"))
     }
 
     /// Parse this image into an Object.
     pub fn parse_object(&self) -> Result<File<'data, R>> {
-        File::parse_at(self.data, self.file_offset()?)
+        File::parse_dyld_cache_image(self)
     }
 }
 
@@ -175,17 +255,55 @@ impl<E: Endian> macho::DyldCacheHeader<E> {
         .read_error("Invalid dyld cache mapping size or alignment")
     }
 
+    /// Return the information about subcaches, if present.
+    pub fn subcaches<'data, R: ReadRef<'data>>(
+        &self,
+        endian: E,
+        data: R,
+    ) -> Result<Option<&'data [macho::DyldSubCacheInfo<E>]>> {
+        if self.mapping_offset.get(endian) >= MIN_HEADER_SIZE_SUBCACHES {
+            let subcaches = data
+                .read_slice_at::<macho::DyldSubCacheInfo<E>>(
+                    self.subcaches_offset.get(endian).into(),
+                    self.subcaches_count.get(endian) as usize,
+                )
+                .read_error("Invalid dyld subcaches size or alignment")?;
+            Ok(Some(subcaches))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Return the UUID for the .symbols subcache, if present.
+    pub fn symbols_subcache_uuid(&self, endian: E) -> Option<[u8; 16]> {
+        if self.mapping_offset.get(endian) >= MIN_HEADER_SIZE_SUBCACHES {
+            let uuid = self.symbols_subcache_uuid;
+            if uuid != [0; 16] {
+                return Some(uuid);
+            }
+        }
+        None
+    }
+
     /// Return the image information table.
     pub fn images<'data, R: ReadRef<'data>>(
         &self,
         endian: E,
         data: R,
     ) -> Result<&'data [macho::DyldCacheImageInfo<E>]> {
-        data.read_slice_at::<macho::DyldCacheImageInfo<E>>(
-            self.images_offset.get(endian).into(),
-            self.images_count.get(endian) as usize,
-        )
-        .read_error("Invalid dyld cache image size or alignment")
+        if self.mapping_offset.get(endian) >= MIN_HEADER_SIZE_SUBCACHES {
+            data.read_slice_at::<macho::DyldCacheImageInfo<E>>(
+                self.images_across_all_subcaches_offset.get(endian).into(),
+                self.images_across_all_subcaches_count.get(endian) as usize,
+            )
+            .read_error("Invalid dyld cache image size or alignment")
+        } else {
+            data.read_slice_at::<macho::DyldCacheImageInfo<E>>(
+                self.images_offset.get(endian).into(),
+                self.images_count.get(endian) as usize,
+            )
+            .read_error("Invalid dyld cache image size or alignment")
+        }
     }
 }
 
@@ -205,14 +323,24 @@ impl<E: Endian> macho::DyldCacheImageInfo<E> {
         mappings: &[macho::DyldCacheMappingInfo<E>],
     ) -> Result<u64> {
         let address = self.address.get(endian);
-        for mapping in mappings {
-            let mapping_address = mapping.address.get(endian);
-            if address >= mapping_address
-                && address < mapping_address.wrapping_add(mapping.size.get(endian))
-            {
-                return Ok(address - mapping_address + mapping.file_offset.get(endian));
-            }
-        }
-        Err(Error("Invalid dyld cache image address"))
+        address_to_file_offset(address, endian, mappings)
+            .read_error("Invalid dyld cache image address")
     }
+}
+
+/// Find the file offset of the image by looking up its address in the mappings.
+pub fn address_to_file_offset<E: Endian>(
+    address: u64,
+    endian: E,
+    mappings: &[macho::DyldCacheMappingInfo<E>],
+) -> Option<u64> {
+    for mapping in mappings {
+        let mapping_address = mapping.address.get(endian);
+        if address >= mapping_address
+            && address < mapping_address.wrapping_add(mapping.size.get(endian))
+        {
+            return Some(address - mapping_address + mapping.file_offset.get(endian));
+        }
+    }
+    None
 }


### PR DESCRIPTION
Fixes #358.

This adds support for the dyld cache format that is used on macOS 12 and
iOS 15. The cache is split over multiple files, with a "root" cache
and one or more subcaches, for example:

```
/System/Library/dyld/dyld_shared_cache_x86_64
/System/Library/dyld/dyld_shared_cache_x86_64.1
/System/Library/dyld/dyld_shared_cache_x86_64.2
/System/Library/dyld/dyld_shared_cache_x86_64.3
```

Additionally, on iOS, there is a separate .symbols subcache, which
contains local symbols.

Each file has a set of mappings. For each image in the cache, the
segments of that image can be distributed over multiple files: For
example, on macOS 12.0.1, the image for libsystem_malloc.dylib for the
arm64e architecture has its __TEXT segment in the root cache and the
__LINKEDIT segment in the .1 subcache - there's a single __LINKEDIT
segment which is shared between all images across both files. The
remaining libsystem_malloc.dylib segments are in the same file as the
__TEXT segment.

The DyldCache API now requires the data for all subcaches to be supplied
to the constructor.

The parse_at methods have been removed and been replaced with a
parse_dyld_cache_image method.

With this patch, the following command outputs correct symbols for
libsystem_malloc.dylib:

```
cargo run --release --bin objdump -- /System/Library/dyld/dyld_shared_cache_arm64e /usr/lib/system/libsystem_malloc.dylib
```

Support for local symbols is not implemented. But, as a first step,
DyldCache::parse requires the .symbols subcache to be supplied (if the
root cache expects one to be present) and checks that its UUID is correct.
MachOFile doesn't do anything with ilocalsym and nlocalsym yet, and we
don't yet have the struct definitions for dyld_cache_local_symbols_info
and dyld_cache_local_symbols_entry.