### PR TITLE
Make the `write_core` (and optionally `write`) features `no_std` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ description = "A unified interface for reading and writing object file formats."
 features = ['doc']
 
 [dependencies]
-crc32fast = { version = "1.2", optional = true }
+crc32fast = { version = "1.2", default-features = false, optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
 wasmparser = { version = "0.57", optional = true }
 memchr = { version = "2.4.1", default-features = false }
+hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
@@ -34,7 +35,7 @@ read_core = []
 # Read support for all file formats (including unaligned files).
 read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned"]
 # Core write support. You will need to enable some file formats too.
-write_core = ["crc32fast", "indexmap/std", "std"]
+write_core = ["crc32fast", "indexmap", "hashbrown"]
 # Write support for all file formats.
 write = ["write_core", "coff", "elf", "macho", "pe"]
 
@@ -43,7 +44,7 @@ write = ["write_core", "coff", "elf", "macho", "pe"]
 
 # Enable things that require libstd.
 # Currently, this provides an `Error` implementation.
-std = ["memchr/std"]
+std = ["memchr/std", "indexmap/std", "crc32fast/std"]
 # Enable decompression of compressed sections.
 # This feature is not required if you want to do your own decompression.
 compression = ["flate2", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ flate2 = { version = "1", optional = true }
 indexmap = { version = "1.1", optional = true }
 wasmparser = { version = "0.57", optional = true }
 memchr = { version = "2.4.1", default-features = false }
-hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false, optional = true }
+hashbrown = { version = "0.11", features = ["ahash"], default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned"]
 write_core = ["crc32fast", "indexmap", "hashbrown"]
 # Core write support with libstd features. You will need to enable some file formats too.
 write_std = ["write_core", "std", "indexmap/std", "crc32fast/std"]
-# Write support for all file formats.
-write = ["write_core", "coff", "elf", "macho", "pe"]
+# Write support for all file formats, including libstd features.
+write = ["write_std", "coff", "elf", "macho", "pe"]
 
 #=======================================
 # Misc features.
@@ -82,7 +82,7 @@ cargo-all = []
 #=======================================
 # Documentation should be generated with everything in "all" except for "unaligned".
 doc = [
-  "read_core", "write_core",
+  "read_core", "write_std",
   "std", "compression",
   "archive", "coff", "elf", "macho", "pe", "wasm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ read_core = []
 read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned"]
 # Core write support. You will need to enable some file formats too.
 write_core = ["crc32fast", "indexmap", "hashbrown"]
+# Core write support with libstd features. You will need to enable some file formats too.
+write_std = ["write_core", "std", "indexmap/std", "crc32fast/std"]
 # Write support for all file formats.
 write = ["write_core", "coff", "elf", "macho", "pe"]
 
@@ -44,7 +46,7 @@ write = ["write_core", "coff", "elf", "macho", "pe"]
 
 # Enable things that require libstd.
 # Currently, this provides an `Error` implementation.
-std = ["memchr/std", "indexmap/std", "crc32fast/std"]
+std = ["memchr/std"]
 # Enable decompression of compressed sections.
 # This feature is not required if you want to do your own decompression.
 compression = ["flate2", "std"]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -48,7 +48,7 @@ required-features = ["object/read"]
 
 [[bin]]
 name = "pecopy"
-required-features = ["object/read_core", "object/write_core", "object/pe", "object/elf", "object/std"]
+required-features = ["object/read_core", "object/write_core", "object/pe", "object/std"]
 
 [[bin]]
 name = "readobj"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -24,11 +24,11 @@ required-features = ["object/read"]
 
 [[bin]]
 name = "elfcopy"
-required-features = ["object/read_core", "object/write_core", "object/elf"]
+required-features = ["object/read_core", "object/write_core", "object/elf", "object/std"]
 
 [[bin]]
 name = "elftoefi"
-required-features = ["object/read_core", "object/write_core", "object/elf", "object/pe"]
+required-features = ["object/read_core", "object/write_core", "object/elf", "object/pe", "object/std"]
 
 [[bin]]
 name = "objcopy"
@@ -48,7 +48,7 @@ required-features = ["object/read"]
 
 [[bin]]
 name = "pecopy"
-required-features = ["object/read_core", "object/write_core", "object/pe"]
+required-features = ["object/read_core", "object/write_core", "object/pe", "object/elf", "object/std"]
 
 [[bin]]
 name = "readobj"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 #[cfg(feature = "cargo-all")]
 compile_error!("'--all-features' is not supported; use '--features all' instead");
 
-#[cfg(feature = "read_core")]
+#[cfg(any(feature = "read_core", feature = "write_core"))]
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -1,5 +1,5 @@
-use core::mem;
 use alloc::vec::Vec;
+use core::mem;
 
 use crate::endian::{LittleEndian as LE, U16Bytes, U32Bytes, U16, U32};
 use crate::pe as coff;

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -1,5 +1,5 @@
-use std::mem;
-use std::vec::Vec;
+use core::mem;
+use alloc::vec::Vec;
 
 use crate::endian::{LittleEndian as LE, U16Bytes, U32Bytes, U16, U32};
 use crate::pe as coff;

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -1,4 +1,4 @@
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::elf;
 use crate::write::elf::writer::*;

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -1,7 +1,7 @@
 //! Helper for writing ELF files.
-use std::mem;
-use std::string::String;
-use std::vec::Vec;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::mem;
 
 use crate::elf;
 use crate::endian::*;

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 
 use crate::endian::*;
 use crate::macho;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -1,11 +1,12 @@
 //! Interface for writing object files.
 
-use std::borrow::Cow;
-use std::boxed::Box;
-use std::collections::HashMap;
-use std::string::String;
-use std::vec::Vec;
-use std::{error, fmt, io, result, str};
+use alloc::borrow::Cow;
+use hashbrown::HashMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::{fmt, result, str};
+#[cfg(feature = "std")]
+use std::{error, io, boxed::Box};
 
 use crate::endian::{Endianness, U32, U64};
 use crate::{
@@ -42,6 +43,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {}
 
 /// The result type used within the write module.
@@ -551,6 +553,7 @@ impl<'a> Object<'a> {
     ///
     /// It is advisable to use a buffered writer like [`BufWriter`](std::io::BufWriter)
     /// instead of an unbuffered writer like [`File`](std::fs::File).
+    #[cfg(feature = "std")]
     pub fn write_stream<W: io::Write>(&self, w: W) -> result::Result<(), Box<dyn error::Error>> {
         let mut stream = StreamingBuffer::new(w);
         self.emit(&mut stream)?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -1,12 +1,13 @@
 //! Interface for writing object files.
 
 use alloc::borrow::Cow;
-use hashbrown::HashMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::{fmt, result, str};
 #[cfg(feature = "std")]
-use std::{error, io, boxed::Box};
+use std::{boxed::Box, collections::HashMap, error, io};
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
 
 use crate::endian::{Endianness, U32, U64};
 use crate::{

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -4,10 +4,10 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::{fmt, result, str};
-#[cfg(feature = "std")]
-use std::{boxed::Box, collections::HashMap, error, io};
 #[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
+#[cfg(feature = "std")]
+use std::{boxed::Box, collections::HashMap, error, io};
 
 use crate::endian::{Endianness, U32, U64};
 use crate::{

--- a/src/write/pe.rs
+++ b/src/write/pe.rs
@@ -1,7 +1,7 @@
 //! Helper for writing PE files.
-use std::mem;
-use std::string::String;
-use std::vec::Vec;
+use core::mem;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 use crate::endian::{LittleEndian as LE, *};
 use crate::pe;

--- a/src/write/pe.rs
+++ b/src/write/pe.rs
@@ -1,7 +1,7 @@
 //! Helper for writing PE files.
-use core::mem;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::mem;
 
 use crate::endian::{LittleEndian as LE, *};
 use crate::pe;

--- a/src/write/string.rs
+++ b/src/write/string.rs
@@ -1,5 +1,9 @@
-use indexmap::IndexSet;
-use std::vec::Vec;
+use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+type IndexSet<K> = indexmap::IndexSet<K>;
+#[cfg(not(feature = "std"))]
+type IndexSet<K> = indexmap::IndexSet<K, hashbrown::hash_map::DefaultHashBuilder>;
 
 /// An identifer for an entry in a string table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -1,6 +1,6 @@
-use std::io;
-use std::mem;
-use std::vec::Vec;
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::{io, mem};
 
 use crate::pod::{bytes_of, bytes_of_slice, Pod};
 
@@ -86,6 +86,7 @@ impl WritableBuffer for Vec<u8> {
 ///
 /// It is advisable to use a buffered writer like [`BufWriter`](std::io::BufWriter)
 /// instead of an unbuffered writer like [`File`](std::fs::File).
+#[cfg(feature = "std")]
 #[derive(Debug)]
 pub struct StreamingBuffer<W> {
     writer: W,
@@ -93,6 +94,7 @@ pub struct StreamingBuffer<W> {
     result: Result<(), io::Error>,
 }
 
+#[cfg(feature = "std")]
 impl<W> StreamingBuffer<W> {
     /// Create a new `StreamingBuffer` backed by the given writer.
     pub fn new(writer: W) -> Self {
@@ -114,6 +116,7 @@ impl<W> StreamingBuffer<W> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {
     #[inline]
     fn len(&self) -> usize {


### PR DESCRIPTION
## Summary
This PR relaxes the requirement that `write_core` and `write` need and must enable the `std` feature.

## Motivation
To enable the ability to use this crate's awesome write functionality in no_std environments.
For example, this is needed when using various `wasmtime` subcrates in a no_std environment.

## Notes
* I have tested this with all combinations of features that I could come up with. The cargo tests also pass.
* The `write` feature could optionally enable `std`, if desired. Currently I didn't leave that feature there, but in the past, the `write_core` feature itself also enabled the `std` feature. I'm happy to make this change if requested.
    * The few write-related functions that require `std` have now been gated with a `#[cfg(feature = "std")]` attribute. Currently this only includes `StreamingBuffer`, which requires `std::io`.
* The `hashbrown` dependency is already part of the indirect dependency tree, so I used the same version that `indexmap` depends on.
* Not a big deal, but the `IndexSet` typedefs at the top of `/src/write/string.rs` can be removed once this PR lands: https://github.com/bluss/indexmap/pull/207. I can submit another PR here after that.
