### PR TITLE
Quickfix: Ignore errors when loading name subsection. (#403)

### DIFF
--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -255,21 +255,17 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                         .read_error("Couldn't read header of the name section")?
                     {
                         // TODO: Right now, ill-formed name subsections
-                        // are silently ignored in order to maintain 
-                        // compatibility with extended name sections, which 
-                        // are not yet supported by the version of 
+                        // are silently ignored in order to maintain
+                        // compatibility with extended name sections, which
+                        // are not yet supported by the version of
                         // `wasmparser` currently used.
-                        // A better fix would be to update `wasmparser` to 
+                        // A better fix would be to update `wasmparser` to
                         // the newester version, but this requires
                         // a major rewrite of this file.
-                        if let Ok(name) = name {
-                            let name = match name {
-                                wp::Name::Function(name) => name,
-                                _ => continue,
-                            };
-                            let mut name_map = name
-                                .get_map()
-                                .read_error("Couldn't read header of the function name subsection")?;
+                        if let Ok(wp::Name::Function(name)) = name {
+                            let mut name_map = name.get_map().read_error(
+                                "Couldn't read header of the function name subsection",
+                            )?;
                             for _ in 0..name_map.get_count() {
                                 let naming = name_map
                                     .read()

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -260,7 +260,7 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                         // are not yet supported by the version of
                         // `wasmparser` currently used.
                         // A better fix would be to update `wasmparser` to
-                        // the newester version, but this requires
+                        // the newest version, but this requires
                         // a major rewrite of this file.
                         if let Ok(wp::Name::Function(name)) = name {
                             let mut name_map = name.get_map().read_error(


### PR DESCRIPTION
This a work-around for (#403). 

The version of `wasmparser` currently in use does not support   [extended name sections](https://github.com/WebAssembly/extended-name-section/blob/main/proposals/extended-name-section/Overview.md) will return an error when such an unknown subsection is encountered.
This commit is a quick work-around until `wasmparser` is updated to the most recent version. This is a rather big undertaking unfortunately; it requires major changes in `wasm.rs` since the API of `wasmparser` has changed quite a bit.
If I find the time, I will attempt that and create another PR.

One downside of this work-around is that ill-formed name subsections (e.g. for function names) are silently ignored, but I think this is a manageable tradeoff until `wasmparser` is updated. In case you disagree and don't want to merge this, this PR will at least leave some clues on how to fix the issue locally if somebody runs into the same problem I did.
