### PR TITLE
Accept populated COFF symbol headers

### DIFF
--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -25,6 +25,15 @@ where
     strings: StringTable<'data, R>,
 }
 
+impl<'data, R: ReadRef<'data>> Default for SymbolTable<'data, R> {
+    fn default() -> Self {
+        Self {
+            symbols: &[],
+            strings: StringTable::default(),
+        }
+    }
+}
+
 impl<'data, R: ReadRef<'data>> SymbolTable<'data, R> {
     /// Read the symbol table.
     pub fn parse(header: &pe::ImageFileHeader, data: R) -> Result<Self> {


### PR DESCRIPTION
Some binaries (not sure what toolchain has generated them) may have pointers to COFF symbols that point to nothing.
Since COFF symbols tables are deprecated anyway, it could be better to ignore these symbols than returning an `Err` that will prevent the whole PE file from parsing.

I know you're not always happy to remove error conditions for the sake of parsing more binaries, so I'd like to have your opinion on such a "fix" :-)

Example of such binaries: git for Windows (at least some builds).
* Download [PortableGit-2.29.2.3-64-bit.7z.exe](https://github.com/git-for-windows/git/releases/download/v2.29.2.windows.3/PortableGit-2.29.2.3-64-bit.7z.exe) from [their release page](https://github.com/git-for-windows/git/releases/tag/v2.29.2.windows.3)
* Run it so that it extracts itself
* The file at `PortableGit\cmd\git.exe` has populated `pointer_to_symbol_table` and `number_of_symbols` that point after the end of file. Hence, it cannot be parsed by `object` because of "Invalid COFF symbol table offset or size"