### PR TITLE
Support ARM64 relocations when writing a Mach-O object

### DIFF
--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -584,11 +584,25 @@ impl<'a> Object<'a> {
                                 return Err(Error(format!("unimplemented relocation {:?}", reloc)));
                             }
                         },
+                        Architecture::Aarch64 => match (reloc.kind, reloc.encoding, reloc.addend) {
+                            (RelocationKind::Absolute, RelocationEncoding::Generic, 0) => {
+                                (false, macho::ARM64_RELOC_UNSIGNED)
+                            }
+                            (
+                                RelocationKind::MachO { value, relative },
+                                RelocationEncoding::Generic,
+                                0,
+                            ) => (relative, value),
+                            _ => {
+                                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                            }
+                        },
                         _ => {
-                            return Err(Error(format!(
-                                "unimplemented architecture {:?}",
-                                self.architecture
-                            )));
+                            if let RelocationKind::MachO { value, relative } = reloc.kind {
+                                (relative, value)
+                            } else {
+                                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                            }
                         }
                     };
                     let reloc_info = macho::RelocationInfo {


### PR DESCRIPTION
For now only relocations with an addend of 0 are supported. In the future we could add support for arbitrary added using `ARM64_RELOC_ADDEND`.

This PR also allows the use of arbitrary Mach-O relocations on unsupported architectures, like we already do for ELF.