### PR TITLE
Build a .drectve section in COFF objects with export directives

### DIFF
--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -17,6 +17,8 @@ use crate::{
 
 #[cfg(feature = "coff")]
 mod coff;
+#[cfg(feature = "coff")]
+pub use coff::CoffExportStyle;
 
 #[cfg(feature = "elf")]
 pub mod elf;


### PR DESCRIPTION
This is needed to export symbols with `SymbolScope::Dynamic` from a DLL.