### PR TITLE
disambiguate license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.28.3"
 edition = "2018"
 exclude = ["/.github", "/testfiles"]
 keywords = ["object", "elf", "mach-o", "pe", "coff"]
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 repository = "https://github.com/gimli-rs/object"
 description = "A unified interface for reading and writing object file formats."
 


### PR DESCRIPTION
Per <https://doc.rust-lang.org/cargo/reference/manifest.html#slash>

> Previously multiple licenses could be separated with a /, but that usage is deprecated.

I'm pretty sure that your intention is OR rather than AND: I guess this form improves by making that clear