### PR TITLE
read/pe: style changes for resource parsing

### DIFF
--- a/crates/examples/testfiles/pe/base-gnu.exe.readobj
+++ b/crates/examples/testfiles/pe/base-gnu.exe.readobj
@@ -15687,25 +15687,41 @@ ImageBaseRelocation {
     Type: IMAGE_REL_BASED_DIR64 (0xA)
     Addend: 0x140001690
 }
-ResourceDirectory {
-    Directory {
-        Number of named entries: 0
-        Number of ID entries: 1
-        Entries {
-            Name ID: 24
-            Directory {
-                Number of named entries: 0
-                Number of ID entries: 1
-                Entries {
-                    Name ID: 1
-                    Directory {
-                        Number of named entries: 0
-                        Number of ID entries: 1
-                        Entries {
-                            Name ID: 0
+ImageResourceDirectory {
+    Characteristics: 0
+    TimeDateStamp: 0
+    MajorVersion: 0
+    MinorVersion: 0
+    NumberOfNamedEntries: 0
+    NumberOfIdEntries: 1
+    ImageResourceDirectoryEntry {
+        NameOrId: RT_MANIFEST (0x18)
+        OffsetToDataOrDirectory: 0x80000018
+        ImageResourceDirectory {
+            Characteristics: 0
+            TimeDateStamp: 0
+            MajorVersion: 0
+            MinorVersion: 0
+            NumberOfNamedEntries: 0
+            NumberOfIdEntries: 1
+            ImageResourceDirectoryEntry {
+                NameOrId: 1
+                OffsetToDataOrDirectory: 0x80000030
+                ImageResourceDirectory {
+                    Characteristics: 0
+                    TimeDateStamp: 0
+                    MajorVersion: 0
+                    MinorVersion: 0
+                    NumberOfNamedEntries: 0
+                    NumberOfIdEntries: 1
+                    ImageResourceDirectoryEntry {
+                        NameOrId: 0
+                        OffsetToDataOrDirectory: 0x48
+                        ImageResourceDataEntry {
                             VirtualAddress: 0x10058
                             Size: 1167
-                            Code page: 0
+                            CodePage: 0
+                            Reserved: 0x0
                         }
                     }
                 }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -2062,11 +2062,57 @@ pub struct ImageResourceDirStringU {
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct ImageResourceDataEntry {
+    /// RVA of the data.
     pub offset_to_data: U32<LE>,
     pub size: U32<LE>,
     pub code_page: U32<LE>,
     pub reserved: U32<LE>,
 }
+
+// Resource type: https://docs.microsoft.com/en-us/windows/win32/menurc/resource-types
+
+/// ID for: Hardware-dependent cursor resource.
+pub const RT_CURSOR: u16 = 1;
+/// ID for: Bitmap resource.
+pub const RT_BITMAP: u16 = 2;
+/// ID for: Hardware-dependent icon resource.
+pub const RT_ICON: u16 = 3;
+/// ID for: Menu resource.
+pub const RT_MENU: u16 = 4;
+/// ID for: Dialog box.
+pub const RT_DIALOG: u16 = 5;
+/// ID for: String-table entry.
+pub const RT_STRING: u16 = 6;
+/// ID for: Font directory resource.
+pub const RT_FONTDIR: u16 = 7;
+/// ID for: Font resource.
+pub const RT_FONT: u16 = 8;
+/// ID for: Accelerator table.
+pub const RT_ACCELERATOR: u16 = 9;
+/// ID for: Application-defined resource (raw data).
+pub const RT_RCDATA: u16 = 10;
+/// ID for: Message-table entry.
+pub const RT_MESSAGETABLE: u16 = 11;
+/// ID for: Hardware-independent cursor resource.
+pub const RT_GROUP_CURSOR: u16 = 12;
+/// ID for: Hardware-independent icon resource.
+pub const RT_GROUP_ICON: u16 = 14;
+/// ID for: Version resource.
+pub const RT_VERSION: u16 = 16;
+/// ID for: Allows a resource editing tool to associate a string with an .rc file.
+pub const RT_DLGINCLUDE: u16 = 17;
+/// ID for: Plug and Play resource.
+pub const RT_PLUGPLAY: u16 = 19;
+/// ID for: VXD.
+pub const RT_VXD: u16 = 20;
+/// ID for: Animated cursor.
+pub const RT_ANICURSOR: u16 = 21;
+/// ID for: Animated icon.
+pub const RT_ANIICON: u16 = 22;
+/// ID for: HTML resource.
+pub const RT_HTML: u16 = 23;
+/// ID for: Side-by-Side Assembly Manifest.
+pub const RT_MANIFEST: u16 = 24;
 
 //
 // Code Integrity in loadconfig (CI)

--- a/src/read/pe/data_directory.rs
+++ b/src/read/pe/data_directory.rs
@@ -3,9 +3,7 @@ use core::slice;
 use crate::read::{Error, ReadError, ReadRef, Result};
 use crate::{pe, LittleEndian as LE};
 
-use super::{
-    ExportTable, ImportTable, RelocationBlockIterator, ResourceDirectoryTable, SectionTable,
-};
+use super::{ExportTable, ImportTable, RelocationBlockIterator, ResourceDirectory, SectionTable};
 
 /// The table of data directories in a PE file.
 #[derive(Debug, Clone, Copy)]
@@ -123,20 +121,20 @@ impl<'data> DataDirectories<'data> {
         Ok(Some(RelocationBlockIterator::new(reloc_data)))
     }
 
-    /// Returns the root resource directory table.
+    /// Returns the resource directory.
     ///
     /// `data` must be the entire file data.
-    pub fn resource_directory_table<R: ReadRef<'data>>(
+    pub fn resource_directory<R: ReadRef<'data>>(
         &self,
         data: R,
         sections: &SectionTable<'data>,
-    ) -> Result<Option<ResourceDirectoryTable<'data>>> {
+    ) -> Result<Option<ResourceDirectory<'data>>> {
         let data_dir = match self.get(pe::IMAGE_DIRECTORY_ENTRY_RESOURCE) {
             Some(data_dir) => data_dir,
             None => return Ok(None),
         };
-        let rsc_data = data_dir.data(data, sections)?;
-        ResourceDirectoryTable::parse(rsc_data).map(Some)
+        let rsrc_data = data_dir.data(data, sections)?;
+        Ok(Some(ResourceDirectory::new(rsrc_data)))
     }
 }
 

--- a/src/read/pe/resource.rs
+++ b/src/read/pe/resource.rs
@@ -1,289 +1,195 @@
-use crate::endian::{LittleEndian as LE, U16};
-use crate::pe::{ImageResourceDataEntry, ImageResourceDirectory, ImageResourceDirectoryEntry};
-use crate::read::{ReadError, ReadRef, Result};
+use alloc::string::String;
 
-/// A resource directory
-#[derive(Clone, Copy)]
-pub struct ResourceDirectoryTable<'data> {
-    directory_data: &'data [u8],
-    /// the resource directory table
-    pub table: &'data ImageResourceDirectory,
-    /// the resource directory entries
-    pub entries: &'data [ImageResourceDirectoryEntry],
+use crate::read::{ReadError, ReadRef, Result};
+use crate::{pe, LittleEndian as LE, U16};
+
+/// The `.rsrc` section of a PE file.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceDirectory<'data> {
+    data: &'data [u8],
 }
 
-impl<'data> core::fmt::Debug for ResourceDirectoryTable<'data> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Do not print self.directory_data
-        f.debug_struct("ResourceDirectoryTable")
-            .field("table", &self.table)
-            .field("entries", &self.entries)
-            .finish()
+impl<'data> ResourceDirectory<'data> {
+    /// Construct from the data of the `.rsrc` section.
+    pub fn new(data: &'data [u8]) -> Self {
+        ResourceDirectory { data }
     }
+
+    /// Parses the root resource directory.
+    pub fn root(&self) -> Result<ResourceDirectoryTable<'data>> {
+        ResourceDirectoryTable::parse(&self.data, 0)
+    }
+}
+
+/// A table of resource entries.
+#[derive(Debug, Clone)]
+pub struct ResourceDirectoryTable<'data> {
+    /// The table header.
+    pub header: &'data pe::ImageResourceDirectory,
+    /// The table entries.
+    pub entries: &'data [pe::ImageResourceDirectoryEntry],
 }
 
 impl<'data> ResourceDirectoryTable<'data> {
-    /// Parses the root resource directory.
-    ///
-    /// `data` must be the entire resource section
-    pub fn parse(data: &'data [u8]) -> Result<Self> {
-        Self::read(data, 0)
-    }
-
-    fn read(data: &'data [u8], mut offset: u64) -> Result<Self> {
-        let table = data
-            .read::<ImageResourceDirectory>(&mut offset)
-            .read_error("Invalid resource directory table")?;
-        let entries_count = table.number_of_id_entries.get(LE) as usize
-            + table.number_of_named_entries.get(LE) as usize;
+    fn parse(data: &'data [u8], offset: u32) -> Result<Self> {
+        let mut offset = u64::from(offset);
+        let header = data
+            .read::<pe::ImageResourceDirectory>(&mut offset)
+            .read_error("Invalid resource table header")?;
+        let entries_count = header.number_of_id_entries.get(LE) as usize
+            + header.number_of_named_entries.get(LE) as usize;
         let entries = data
-            .read_slice_at::<ImageResourceDirectoryEntry>(offset, entries_count)
-            .read_error("Invalid resource directory entries")?;
-        Ok(Self {
-            directory_data: data,
-            table,
-            entries,
-        })
-    }
-
-    /// Returns an iterator over the directory entries
-    pub fn iter(&self) -> ResourceDirectoryIter<'data> {
-        ResourceDirectoryIter {
-            directory_data: self.directory_data,
-            inner: self.entries.iter(),
-        }
+            .read_slice::<pe::ImageResourceDirectoryEntry>(&mut offset, entries_count)
+            .read_error("Invalid resource table entries")?;
+        Ok(Self { header, entries })
     }
 }
 
-/// An iterator over a resource directory entries
-#[allow(missing_debug_implementations)]
-pub struct ResourceDirectoryIter<'data> {
-    directory_data: &'data [u8],
-    inner: core::slice::Iter<'data, ImageResourceDirectoryEntry>,
-}
-
-impl<'data> Iterator for ResourceDirectoryIter<'data> {
-    type Item = ResourceDirectoryEntry<'data>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|entry| ResourceDirectoryEntry {
-            directory_data: self.directory_data,
-            entry,
-        })
-    }
-}
-
-/// A resource directory entry
-#[derive(Clone, Copy)]
-pub struct ResourceDirectoryEntry<'data> {
-    directory_data: &'data [u8],
-    entry: &'data ImageResourceDirectoryEntry,
-}
-
-impl<'data> core::fmt::Debug for ResourceDirectoryEntry<'data> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Do not print self.directory_data
-        f.debug_struct("ResourceDirectoryEntry")
-            .field("entry", &self.entry)
-            .finish()
-    }
-}
-
-impl<'data> ResourceDirectoryEntry<'data> {
-    /// Returns true if the entry is a sub-directory
-    pub fn is_directory(&self) -> bool {
-        (self.entry.offset_to_data_or_directory.get(LE)
-            & crate::pe::IMAGE_RESOURCE_DATA_IS_DIRECTORY)
-            > 0
+impl pe::ImageResourceDirectoryEntry {
+    /// Returns true if the entry has a name, rather than an ID.
+    pub fn has_name(&self) -> bool {
+        self.name_or_id.get(LE) & pe::IMAGE_RESOURCE_NAME_IS_STRING != 0
     }
 
-    /// Returns the offset to the associated directory or data struct
-    pub fn data_offset(&self) -> u32 {
-        self.entry.offset_to_data_or_directory.get(LE) & 0x7FFF_FFFF
-    }
-
-    /// Returns true if the name is an custom string
-    pub fn has_string_name(&self) -> bool {
-        (self.entry.name_or_id.get(LE) & crate::pe::IMAGE_RESOURCE_NAME_IS_STRING) > 0
-    }
-
-    /// Returns the name string offset
+    /// Returns the section offset of the name.
     ///
-    /// Valid if `has_string_name()` returns true
-    fn name_offset(&self) -> u32 {
-        self.entry.name_or_id.get(LE) & 0x7FFF_FFFF
+    /// Valid if `has_name()` returns true.
+    fn name(&self) -> ResourceName {
+        let offset = self.name_or_id.get(LE) & !pe::IMAGE_RESOURCE_NAME_IS_STRING;
+        ResourceName { offset }
     }
 
-    /// Returns the name id
+    /// Returns the ID.
     ///
-    /// Valid if `has_string_name()` returns false
-    fn name_id(&self) -> u16 {
-        (self.entry.name_or_id.get(LE) & 0x0000_FFFF) as u16
+    /// Valid if `has_string_name()` returns false.
+    fn id(&self) -> u16 {
+        (self.name_or_id.get(LE) & 0x0000_FFFF) as u16
     }
 
     /// Returns the entry name
-    pub fn name(&self) -> ResourceNameOrId<'data> {
-        if self.has_string_name() {
-            ResourceNameOrId::Name(ResourceName {
-                directory_data: self.directory_data,
-                offset: self.name_offset(),
-            })
+    pub fn name_or_id(&self) -> ResourceNameOrId {
+        if self.has_name() {
+            ResourceNameOrId::Name(self.name())
         } else {
-            ResourceNameOrId::Id(self.name_id())
+            ResourceNameOrId::Id(self.id())
         }
     }
 
-    /// Returns the entry language code
-    ///
-    /// This is only valid a the level 2 of a standard resource directory structure.
-    ///
-    /// In a standard resource directory structure:
-    /// - level 0: entry.name_or_id is the resource type
-    /// - level 1: entry.name_or_id is the resource name
-    /// - level 2: entry.name_or_id is the language code
-    pub fn language_code(&self) -> Option<u16> {
-        if !self.has_string_name() {
-            Some(self.name_id())
-        } else {
-            None
-        }
+    /// Returns true if the entry is a subtable.
+    pub fn is_table(&self) -> bool {
+        self.offset_to_data_or_directory.get(LE) & pe::IMAGE_RESOURCE_DATA_IS_DIRECTORY != 0
     }
 
-    /// Returns the data associated to this directory entry
-    pub fn data(&self) -> Result<ResourceDirectoryEntryData<'data>> {
-        if self.is_directory() {
-            ResourceDirectoryTable::read(self.directory_data, self.data_offset() as _)
-                .map(|t| ResourceDirectoryEntryData::Directory(t))
+    /// Returns the section offset of the associated table or data.
+    pub fn data_offset(&self) -> u32 {
+        self.offset_to_data_or_directory.get(LE) & !pe::IMAGE_RESOURCE_DATA_IS_DIRECTORY
+    }
+
+    /// Returns the data associated to this directory entry.
+    pub fn data<'data>(
+        &self,
+        section: ResourceDirectory<'data>,
+    ) -> Result<ResourceDirectoryEntryData<'data>> {
+        if self.is_table() {
+            ResourceDirectoryTable::parse(section.data, self.data_offset())
+                .map(|t| ResourceDirectoryEntryData::Table(t))
         } else {
-            self.directory_data
-                .read_at::<ImageResourceDataEntry>(self.data_offset() as _)
+            section
+                .data
+                .read_at::<pe::ImageResourceDataEntry>(self.data_offset().into())
                 .read_error("Invalid resource entry")
-                .map(|d| ResourceDirectoryEntryData::Entry(d))
+                .map(|d| ResourceDirectoryEntryData::Data(d))
         }
     }
 }
 
-/// A resource directory entry data
-#[derive(Debug, Clone, Copy)]
+/// Data associated with a resource directory entry.
+#[derive(Debug, Clone)]
 pub enum ResourceDirectoryEntryData<'data> {
-    /// A sub directory entry
-    Directory(ResourceDirectoryTable<'data>),
-    /// A resource entry
-    Entry(&'data ImageResourceDataEntry),
+    /// A subtable entry.
+    Table(ResourceDirectoryTable<'data>),
+    /// A resource data entry.
+    Data(&'data pe::ImageResourceDataEntry),
 }
 
 impl<'data> ResourceDirectoryEntryData<'data> {
-    /// Converts to an option of directory
+    /// Converts to an option of table.
     ///
-    /// Helper for iterator filtering
-    pub fn directory(self) -> Option<ResourceDirectoryTable<'data>> {
+    /// Helper for iterator filtering.
+    pub fn table(self) -> Option<ResourceDirectoryTable<'data>> {
         match self {
-            Self::Directory(dir) => Some(dir),
+            Self::Table(dir) => Some(dir),
             _ => None,
         }
     }
 
-    /// Converts to an option of entry
+    /// Converts to an option of data entry.
     ///
-    /// Helper for iterator filtering
-    pub fn resource(self) -> Option<&'data ImageResourceDataEntry> {
+    /// Helper for iterator filtering.
+    pub fn data(self) -> Option<&'data pe::ImageResourceDataEntry> {
         match self {
-            Self::Entry(rsc) => Some(rsc),
+            Self::Data(rsc) => Some(rsc),
             _ => None,
         }
     }
 }
 
-/// A resource name
-pub struct ResourceName<'data> {
-    directory_data: &'data [u8],
+/// A resource name.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceName {
     offset: u32,
 }
 
-impl<'data> ResourceName<'data> {
-    /// Converts to a `String`
-    pub fn to_string_lossy(&self) -> Result<alloc::string::String> {
-        let d = self.data()?;
-        Ok(alloc::string::String::from_utf16_lossy(d))
+impl ResourceName {
+    /// Converts to a `String`.
+    pub fn to_string_lossy(&self, directory: ResourceDirectory) -> Result<String> {
+        let d = self.data(directory)?;
+        Ok(String::from_utf16_lossy(d))
     }
 
-    /// Returns the string unicode buffer
-    pub fn data(&self) -> Result<&'data [u16]> {
-        let len = self
-            .directory_data
-            .read_at::<U16<LE>>(self.offset as _)
-            .read_error("Invalid name length")?;
-        let offset = self
-            .offset
-            .checked_add(2)
-            .read_error("Invalid name offset")?;
-        self.directory_data
-            .read_slice_at::<u16>(offset as _, len.get(LE) as _)
-            .read_error("Invalid name buffer")
+    /// Returns the string unicode buffer.
+    pub fn data<'data>(&self, directory: ResourceDirectory<'data>) -> Result<&'data [u16]> {
+        let mut offset = u64::from(self.offset);
+        let len = directory
+            .data
+            .read::<U16<LE>>(&mut offset)
+            .read_error("Invalid resource name offset")?;
+        directory
+            .data
+            .read_slice::<u16>(&mut offset, len.get(LE).into())
+            .read_error("Invalid resource name length")
     }
 }
 
-impl<'data> core::fmt::Debug for ResourceName<'data> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Do not print self.directory_data
-        f.debug_struct("ResourceName")
-            .field("offset", &self.offset)
-            .field("data", &self.data())
-            .finish()
-    }
-}
-
-/// A resource name
+/// A resource name or ID.
 ///
-/// Can be either a string or an id
+/// Can be either a string or a numeric ID.
 #[derive(Debug)]
-pub enum ResourceNameOrId<'data> {
-    /// A resource string name
-    Name(ResourceName<'data>),
-    /// A resource name id
+pub enum ResourceNameOrId {
+    /// A resource name.
+    Name(ResourceName),
+    /// A resource ID.
     Id(u16),
 }
 
-// Resource type: https://docs.microsoft.com/en-us/windows/win32/menurc/resource-types
+impl ResourceNameOrId {
+    /// Converts to an option of name.
+    ///
+    /// Helper for iterator filtering.
+    pub fn name(self) -> Option<ResourceName> {
+        match self {
+            Self::Name(name) => Some(name),
+            _ => None,
+        }
+    }
 
-/// ID for: Hardware-dependent cursor resource.
-pub const RESOURCE_TYPE_ID_RT_CURSOR: u16 = 1;
-/// ID for: Bitmap resource.
-pub const RESOURCE_TYPE_ID_RT_BITMAP: u16 = 2;
-/// ID for: Hardware-dependent icon resource.
-pub const RESOURCE_TYPE_ID_RT_ICON: u16 = 3;
-/// ID for: Menu resource.
-pub const RESOURCE_TYPE_ID_RT_MENU: u16 = 4;
-/// ID for: Dialog box.
-pub const RESOURCE_TYPE_ID_RT_DIALOG: u16 = 5;
-/// ID for: String-table entry.
-pub const RESOURCE_TYPE_ID_RT_STRING: u16 = 6;
-/// ID for: Font directory resource.
-pub const RESOURCE_TYPE_ID_RT_FONTDIR: u16 = 7;
-/// ID for: Font resource.
-pub const RESOURCE_TYPE_ID_RT_FONT: u16 = 8;
-/// ID for: Accelerator table.
-pub const RESOURCE_TYPE_ID_RT_ACCELERATOR: u16 = 9;
-/// ID for: Application-defined resource (raw data).
-pub const RESOURCE_TYPE_ID_RT_RCDATA: u16 = 10;
-/// ID for: Message-table entry.
-pub const RESOURCE_TYPE_ID_RT_MESSAGETABLE: u16 = 11;
-/// ID for: Hardware-independent cursor resource.
-pub const RESOURCE_TYPE_ID_RT_GROUP_CURSOR: u16 = 12;
-/// ID for: Hardware-independent icon resource.
-pub const RESOURCE_TYPE_ID_RT_GROUP_ICON: u16 = 14;
-/// ID for: Version resource.
-pub const RESOURCE_TYPE_ID_RT_VERSION: u16 = 16;
-/// ID for: Allows a resource editing tool to associate a string with an .rc file.
-pub const RESOURCE_TYPE_ID_RT_DLGINCLUDE: u16 = 17;
-/// ID for: Plug and Play resource.
-pub const RESOURCE_TYPE_ID_RT_PLUGPLAY: u16 = 19;
-/// ID for: VXD.
-pub const RESOURCE_TYPE_ID_RT_VXD: u16 = 20;
-/// ID for: Animated cursor.
-pub const RESOURCE_TYPE_ID_RT_ANICURSOR: u16 = 21;
-/// ID for: Animated icon.
-pub const RESOURCE_TYPE_ID_RT_ANIICON: u16 = 22;
-/// ID for: HTML resource.
-pub const RESOURCE_TYPE_ID_RT_HTML: u16 = 23;
-/// ID for: Side-by-Side Assembly Manifest.
-pub const RESOURCE_TYPE_ID_RT_MANIFEST: u16 = 24;
+    /// Converts to an option of ID.
+    ///
+    /// Helper for iterator filtering.
+    pub fn id(self) -> Option<u16> {
+        match self {
+            Self::Id(id) => Some(id),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
No major changes here, mostly just reorganizing or renaming for consistency and to fit my mental model: the resource section is a directory that contains a tree of tables and data entries.

I removed `language_code` because it's the same as `name_or_id().id()`, but let me know if you still want it.

cc @Guiguiprim 