### PR TITLE
read/coff, write/coff: support some ARM relocations

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1277,6 +1277,8 @@ pub const IMAGE_REL_ARM_GPREL12: u16 = 0x0006;
 pub const IMAGE_REL_ARM_GPREL7: u16 = 0x0007;
 pub const IMAGE_REL_ARM_BLX24: u16 = 0x0008;
 pub const IMAGE_REL_ARM_BLX11: u16 = 0x0009;
+/// 32-bit relative address from byte following reloc
+pub const IMAGE_REL_ARM_REL32: u16 = 0x000A;
 /// Section table index
 pub const IMAGE_REL_ARM_SECTION: u16 = 0x000E;
 /// Offset within section
@@ -1348,6 +1350,10 @@ pub const IMAGE_REL_ARM64_SECTION: u16 = 0x000D;
 pub const IMAGE_REL_ARM64_ADDR64: u16 = 0x000E;
 /// 19 bit offset << 2 & sign ext. for conditional B
 pub const IMAGE_REL_ARM64_BRANCH19: u16 = 0x000F;
+/// TBZ/TBNZ
+pub const IMAGE_REL_ARM64_BRANCH14: u16 = 0x0010;
+/// 32-bit relative address from byte following reloc
+pub const IMAGE_REL_ARM64_REL32: u16 = 0x0011;
 
 //
 // x64 relocations

--- a/src/read/coff/relocation.rs
+++ b/src/read/coff/relocation.rs
@@ -23,13 +23,19 @@ impl<'data, 'file, R: ReadRef<'data>> Iterator for CoffRelocationIterator<'data,
             let (kind, size, addend) = match self.file.header.machine.get(LE) {
                 pe::IMAGE_FILE_MACHINE_ARMNT => match relocation.typ.get(LE) {
                     pe::IMAGE_REL_ARM_ADDR32 => (RelocationKind::Absolute, 32, 0),
+                    pe::IMAGE_REL_ARM_ADDR32NB => (RelocationKind::ImageOffset, 32, 0),
+                    pe::IMAGE_REL_ARM_REL32 => (RelocationKind::Relative, 32, -4),
+                    pe::IMAGE_REL_ARM_SECTION => (RelocationKind::SectionIndex, 16, 0),
                     pe::IMAGE_REL_ARM_SECREL => (RelocationKind::SectionOffset, 32, 0),
                     typ => (RelocationKind::Coff(typ), 0, 0),
                 },
                 pe::IMAGE_FILE_MACHINE_ARM64 => match relocation.typ.get(LE) {
                     pe::IMAGE_REL_ARM64_ADDR32 => (RelocationKind::Absolute, 32, 0),
+                    pe::IMAGE_REL_ARM64_ADDR32NB => (RelocationKind::ImageOffset, 32, 0),
                     pe::IMAGE_REL_ARM64_SECREL => (RelocationKind::SectionOffset, 32, 0),
+                    pe::IMAGE_REL_ARM64_SECTION => (RelocationKind::SectionIndex, 16, 0),
                     pe::IMAGE_REL_ARM64_ADDR64 => (RelocationKind::Absolute, 64, 0),
+                    pe::IMAGE_REL_ARM64_REL32 => (RelocationKind::Relative, 32, -4),
                     typ => (RelocationKind::Coff(typ), 0, 0),
                 },
                 pe::IMAGE_FILE_MACHINE_I386 => match relocation.typ.get(LE) {


### PR DESCRIPTION
This change adds support for reading and writing some COFF relocations for ARM and ARM64, based on their descriptions at https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#coff-relocations-object-only.

I've implemented this mainly to help me work with resources in ARM64 cross-compilation builds, which use `IMAGE_REL_ARM64_ADDR32NB`. I've tested this manually by comparing against the output of `llvm-windres` and `cvtres`.