### PR TITLE
elf: add EF_MIPS_ABI_* e_flags constants

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -52,6 +52,10 @@ fn print_file_header<Elf: FileHeader>(p: &mut Printer<'_>, endian: Elf::Endian, 
             EM_MIPS => {
                 p.flags(flags, 0, &FLAGS_EF_MIPS);
                 p.flags(flags, EF_MIPS_ARCH, &FLAGS_EF_MIPS_ARCH);
+                // Some ABIs may have all these bits zeroed out
+                if flags & EF_MIPS_ABI != 0 {
+                    p.flags(flags, EF_MIPS_ABI, &FLAGS_EF_MIPS_ABI);
+                }
             }
             EM_PARISC => {
                 p.flags(flags, 0, &FLAGS_EF_PARISC);
@@ -1021,6 +1025,12 @@ static FLAGS_EF_MIPS_ARCH: &[Flag<u32>] = &flags!(
     EF_MIPS_ARCH_64,
     EF_MIPS_ARCH_32R2,
     EF_MIPS_ARCH_64R2,
+);
+static FLAGS_EF_MIPS_ABI: &[Flag<u32>] = &flags!(
+    EF_MIPS_ABI_O32,
+    EF_MIPS_ABI_O64,
+    EF_MIPS_ABI_EABI32,
+    EF_MIPS_ABI_EABI64,
 );
 static FLAGS_EF_PARISC: &[Flag<u32>] = &flags!(
     EF_PARISC_TRAPNIL,

--- a/crates/examples/testfiles/elf/nostd-mipsel.o.readobj
+++ b/crates/examples/testfiles/elf/nostd-mipsel.o.readobj
@@ -1,0 +1,258 @@
+Format: ELF 32-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS32 (0x1)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_REL (0x1)
+    Machine: EM_MIPS (0x8)
+    Version: EV_CURRENT (0x1)
+    Type: ET_REL (0x1)
+    Entry: 0x0
+    ProgramHeaderOffset: 0x0
+    SectionHeaderOffset: 0x1A0
+    Flags: 0x70001005
+        EF_MIPS_NOREORDER (0x1)
+        EF_MIPS_CPIC (0x4)
+        EF_MIPS_ARCH_32R2 (0x70000000)
+        EF_MIPS_ABI_O32 (0x1000)
+    HeaderSize: 0x34
+    ProgramHeaderEntrySize: 0x0
+    ProgramHeaderCount: 0
+    SectionHeaderEntrySize: 0x28
+    SectionHeaderCount: 14
+    SectionHeaderStringTableIndex: 1
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".strtab" (0x61)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x118
+    Size: 0x85
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".text" (0x1)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x0
+    Offset: 0x40
+    Size: 0x30
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 3
+    Name: ".mdebug.abi32" (0x77)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x70
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 4
+    Name: ".pdr" (0x28)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x70
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 5
+    Name: ".rel.pdr" (0x24)
+    Type: SHT_REL (0x9)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x110
+    Size: 0x8
+    Link: 13
+    Info: 4
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Relocation {
+        Offset: 0x0
+        Type: R_MIPS_32 (0x2)
+        Symbol: "main" (0x2)
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".comment" (0x7)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x90
+    Size: 0x16
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 7
+    Name: ".note.GNU-stack" (0x3B)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0xA6
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 8
+    Name: ".data" (0x71)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x0
+    Offset: 0xB0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 9
+    Name: ".bss" (0x10)
+    Type: SHT_NOBITS (0x8)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x0
+    Offset: 0xB0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 10
+    Name: ".reginfo" (0x2D)
+    Type: SHT_MIPS_REGINFO (0x70000006)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x0
+    Offset: 0xB0
+    Size: 0x18
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x18
+}
+SectionHeader {
+    Index: 11
+    Name: ".MIPS.abiflags" (0x15)
+    Type: 0x7000002A
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x0
+    Offset: 0xC8
+    Size: 0x18
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x18
+}
+SectionHeader {
+    Index: 12
+    Name: ".llvm_addrsig" (0x4B)
+    Type: 0x6FFF4C03
+    Flags: 0x80000000
+        SHF_MIPS_STRINGS (0x80000000)
+    Address: 0x0
+    Offset: 0x118
+    Size: 0x0
+    Link: 13
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 13
+    Name: ".symtab" (0x69)
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0xE0
+    Size: 0x30
+    Link: 1
+    Info: 2
+    AddressAlign: 0x4
+    EntrySize: 0x10
+    Symbol {
+        Index: 0
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "nostd.c" (0x59)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 2
+        Name: "main" (0x36)
+        Value: 0x0
+        Size: 0x30
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 2
+    }
+}

--- a/crates/examples/testfiles/elf/nostd-mipsel.readobj
+++ b/crates/examples/testfiles/elf/nostd-mipsel.readobj
@@ -1,0 +1,382 @@
+Format: ELF 32-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS32 (0x1)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x1
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_EXEC (0x2)
+    Machine: EM_MIPS (0x8)
+    Version: EV_CURRENT (0x1)
+    Type: ET_EXEC (0x2)
+    Entry: 0x0
+    ProgramHeaderOffset: 0x34
+    SectionHeaderOffset: 0x123C
+    Flags: 0x70001005
+        EF_MIPS_NOREORDER (0x1)
+        EF_MIPS_CPIC (0x4)
+        EF_MIPS_ARCH_32R2 (0x70000000)
+        EF_MIPS_ABI_O32 (0x1000)
+    HeaderSize: 0x34
+    ProgramHeaderEntrySize: 0x20
+    ProgramHeaderCount: 4
+    SectionHeaderEntrySize: 0x28
+    SectionHeaderCount: 10
+    SectionHeaderStringTableIndex: 9
+}
+ProgramHeader {
+    Type: PT_MIPS_ABIFLAGS (0x70000003)
+    Offset: 0x1000
+    VirtualAddress: 0x400000
+    PhysicalAddress: 0x400000
+    FileSize: 0x18
+    MemorySize: 0x18
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+}
+ProgramHeader {
+    Type: PT_MIPS_REGINFO (0x70000000)
+    Offset: 0x1018
+    VirtualAddress: 0x400018
+    PhysicalAddress: 0x400018
+    FileSize: 0x18
+    MemorySize: 0x18
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x1000
+    VirtualAddress: 0x400000
+    PhysicalAddress: 0x400000
+    FileSize: 0x60
+    MemorySize: 0x60
+    Flags: 0x5
+        PF_X (0x1)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_GNU_STACK (0x6474E551)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x0
+    MemorySize: 0x0
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x10
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".MIPS.abiflags" (0x1B)
+    Type: 0x7000002A
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x400000
+    Offset: 0x1000
+    Size: 0x18
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x18
+}
+SectionHeader {
+    Index: 2
+    Name: ".reginfo" (0x2A)
+    Type: SHT_MIPS_REGINFO (0x70000006)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x400018
+    Offset: 0x1018
+    Size: 0x18
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 3
+    Name: ".text" (0x33)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x400030
+    Offset: 0x1030
+    Size: 0x30
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 4
+    Name: ".comment" (0x39)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x1060
+    Size: 0x15
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 5
+    Name: ".pdr" (0x42)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x1078
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 6
+    Name: ".mdebug.abi32" (0x47)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x1098
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 7
+    Name: ".symtab" (0x1)
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x1098
+    Size: 0x110
+    Link: 8
+    Info: 7
+    AddressAlign: 0x4
+    EntrySize: 0x10
+    Symbol {
+        Index: 0
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "" (0x0)
+        Value: 0x400000
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 1
+    }
+    Symbol {
+        Index: 2
+        Name: "" (0x0)
+        Value: 0x400018
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 2
+    }
+    Symbol {
+        Index: 3
+        Name: "" (0x0)
+        Value: 0x400030
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 4
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 4
+    }
+    Symbol {
+        Index: 5
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 5
+    }
+    Symbol {
+        Index: 6
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 6
+    }
+    Symbol {
+        Index: 7
+        Name: "nostd.c" (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 8
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 9
+        Name: "_gp" (0x9)
+        Value: 0x409050
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 10
+        Name: "_fdata" (0xD)
+        Value: 0x401060
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 11
+        Name: "_ftext" (0x14)
+        Value: 0x400030
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 12
+        Name: "__bss_start" (0x1B)
+        Value: 0x401060
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 13
+        Name: "main" (0x27)
+        Value: 0x400030
+        Size: 0x30
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 14
+        Name: "_edata" (0x2C)
+        Value: 0x401060
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 15
+        Name: "_end" (0x33)
+        Value: 0x401060
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 16
+        Name: "_fbss" (0x38)
+        Value: 0x401060
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+}
+SectionHeader {
+    Index: 8
+    Name: ".strtab" (0x9)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x11A8
+    Size: 0x3E
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 9
+    Name: ".shstrtab" (0x11)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x11E6
+    Size: 0x55
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2373,6 +2373,17 @@ pub const EF_MIPS_NAN2008: u32 = 1024;
 /// MIPS architecture level.
 pub const EF_MIPS_ARCH: u32 = 0xf000_0000;
 
+/// The first MIPS 32 bit ABI
+pub const EF_MIPS_ABI_O32: u32 = 0x0000_1000;
+/// O32 ABI extended for 64-bit architectures
+pub const EF_MIPS_ABI_O64: u32 = 0x0000_2000;
+/// EABI in 32-bit mode
+pub const EF_MIPS_ABI_EABI32: u32 = 0x0000_3000;
+/// EABI in 64-bit mode
+pub const EF_MIPS_ABI_EABI64: u32 = 0x0000_4000;
+/// Mask for selecting EF_MIPS_ABI_ variant
+pub const EF_MIPS_ABI: u32 = 0x0000_f000;
+
 // Legal values for MIPS architecture level.
 
 /// -mips1 code.


### PR DESCRIPTION
This adds a few constants that are needed to fix some targets that are broken on nightly rustc. Values were taken from the [LLVM source](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/BinaryFormat/ELF.h#L518-L521).