### PR TITLE
FileFlags::Elf: Add os_abi

### DIFF
--- a/crates/examples/testfiles/elf/base-strip.objdump
+++ b/crates/examples/testfiles/elf/base-strip.objdump
@@ -1,7 +1,7 @@
 Format: Elf Little-endian 64-bit
 Kind: Dynamic
 Architecture: X86_64
-Flags: Elf { e_flags: 0 }
+Flags: Elf { os_abi: 0, e_flags: 0 }
 Relative Address Base: 0
 Entry Address: 570
 Build ID: [d4, 46, a0, 61, bb, 9a, c2, 7a, b4, 3b, 11, 71, 8f, de, df, 5b, 7f, 3a, f6, f4]

--- a/crates/examples/testfiles/elf/base.o.objdump
+++ b/crates/examples/testfiles/elf/base.o.objdump
@@ -1,7 +1,7 @@
 Format: Elf Little-endian 64-bit
 Kind: Relocatable
 Architecture: X86_64
-Flags: Elf { e_flags: 0 }
+Flags: Elf { os_abi: 0, e_flags: 0 }
 Relative Address Base: 0
 Entry Address: 0
 0: Section { name: "", address: 0, size: 0, align: 0, kind: Metadata, flags: Elf { sh_flags: 0 } }

--- a/crates/examples/testfiles/elf/base.objdump
+++ b/crates/examples/testfiles/elf/base.objdump
@@ -1,7 +1,7 @@
 Format: Elf Little-endian 64-bit
 Kind: Dynamic
 Architecture: X86_64
-Flags: Elf { e_flags: 0 }
+Flags: Elf { os_abi: 0, e_flags: 0 }
 Relative Address Base: 0
 Entry Address: 570
 Build ID: [d4, 46, a0, 61, bb, 9a, c2, 7a, b4, 3b, 11, 71, 8f, de, df, 5b, 7f, 3a, f6, f4]

--- a/src/common.rs
+++ b/src/common.rs
@@ -353,6 +353,8 @@ pub enum FileFlags {
     None,
     /// ELF file flags.
     Elf {
+        /// `os_abi` field in the ELF file header.
+        os_abi: u8,
         /// `e_flags` field in the ELF file header.
         e_flags: u32,
     },

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -419,6 +419,7 @@ where
 
     fn flags(&self) -> FileFlags {
         FileFlags::Elf {
+            os_abi: self.header.e_ident().os_abi,
             e_flags: self.header.e_flags(self.endian),
         }
     }

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -288,13 +288,13 @@ impl<'a> Object<'a> {
                 )));
             }
         };
-        let e_flags = if let FileFlags::Elf { e_flags } = self.flags {
-            e_flags
+        let (os_abi, e_flags) = if let FileFlags::Elf { os_abi, e_flags } = self.flags {
+            (os_abi, e_flags)
         } else {
-            0
+            (elf::ELFOSABI_NONE, 0)
         };
         writer.write_file_header(&FileHeader {
-            os_abi: elf::ELFOSABI_NONE,
+            os_abi,
             abi_version: 0,
             e_type,
             e_machine,


### PR DESCRIPTION
We need to be able to set the OS/ABI of ELF objects in rustc: https://github.com/rust-lang/rust/issues/97535#issuecomment-1141198653

Is this approach okay for you?