### PR TITLE
read/elf: handle empty symbol tables

### DIFF
--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -264,6 +264,9 @@ where
     }
 
     fn symbol_table(&'file self) -> Option<ElfSymbolTable<'data, 'file, Elf, R>> {
+        if self.symbols.is_empty() {
+            return None;
+        }
         Some(ElfSymbolTable {
             endian: self.endian,
             symbols: &self.symbols,
@@ -279,6 +282,9 @@ where
     }
 
     fn dynamic_symbol_table(&'file self) -> Option<ElfSymbolTable<'data, 'file, Elf, R>> {
+        if self.dynamic_symbols.is_empty() {
+            return None;
+        }
         Some(ElfSymbolTable {
             endian: self.endian,
             symbols: &self.dynamic_symbols,


### PR DESCRIPTION
Return `None` from `ElfFile::symbol_table` and `ElfFile::dynamic_symbol_table` if the tables are empty.

Fixes https://github.com/gimli-rs/addr2line/issues/250