### PR TITLE
Limit symbol_map to only nonzero-sized symbols

### DIFF
--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -473,7 +473,10 @@ pub trait Sym: Debug + Pod {
     /// Return true if the symbol is a definition of a function or data object.
     fn is_definition(&self, endian: Self::Endian) -> bool {
         let st_type = self.st_type();
-        (st_type == elf::STT_NOTYPE || st_type == elf::STT_FUNC || st_type == elf::STT_OBJECT)
+        self.st_size(endian).into() != 0
+            && (st_type == elf::STT_NOTYPE
+                || st_type == elf::STT_FUNC
+                || st_type == elf::STT_OBJECT)
             && self.st_shndx(endian) != elf::SHN_UNDEF
     }
 }

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -154,9 +154,7 @@ pub trait Object<'data: 'file, 'file>: read::private::Sealed {
         let mut symbols = Vec::new();
         if let Some(table) = self.symbol_table().or_else(|| self.dynamic_symbol_table()) {
             for symbol in table.symbols() {
-                if !symbol.is_definition()
-                    || !matches!(symbol.kind(), SymbolKind::Text | SymbolKind::Data)
-                {
+                if !symbol.is_definition() {
                     continue;
                 }
                 if let Ok(name) = symbol.name() {

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -154,7 +154,9 @@ pub trait Object<'data: 'file, 'file>: read::private::Sealed {
         let mut symbols = Vec::new();
         if let Some(table) = self.symbol_table().or_else(|| self.dynamic_symbol_table()) {
             for symbol in table.symbols() {
-                if !symbol.is_definition() {
+                if !symbol.is_definition()
+                    || !matches!(symbol.kind(), SymbolKind::Text | SymbolKind::Data)
+                {
                     continue;
                 }
                 if let Ok(name) = symbol.name() {


### PR DESCRIPTION
The documentation for symbol_map claims that this filtering should be happening, but it doesn't appear that it was. In particular, I'm seeing that code produced by rustc has symbols with the `Unknown` kind named like `$x.224` defined at the same address as many functions, and depending on the ordering can be returned by `SymbolMap::get` rather than the "real" function name.