### PR TITLE
Add pe module delay load imports

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1977,6 +1977,21 @@ pub struct ImageDelayloadDescriptor {
     pub time_date_stamp: U32<LE>,
 }
 
+impl ImageDelayloadDescriptor {
+    /// Tell whether this delay-load import descriptor is the null descriptor
+    /// (used to mark the end of the iterator array in a PE)
+    pub fn is_null(&self) -> bool {
+        self.attributes.get(LE) == 0
+            && self.dll_name_rva.get(LE) == 0
+            && self.module_handle_rva.get(LE) == 0
+            && self.import_address_table_rva.get(LE) == 0
+            && self.import_name_table_rva.get(LE) == 0
+            && self.bound_import_address_table_rva.get(LE) == 0
+            && self.unload_information_table_rva.get(LE) == 0
+            && self.time_date_stamp.get(LE) == 0
+    }
+}
+
 /// Delay load version 2 flag for `ImageDelayloadDescriptor::attributes`.
 pub const IMAGE_DELAYLOAD_RVA_BASED: u32 = 0x8000_0000;
 

--- a/src/read/pe/import.rs
+++ b/src/read/pe/import.rs
@@ -216,3 +216,117 @@ impl ImageThunkData for pe::ImageThunkData32 {
         self.0.get(LE) & 0x7fff_ffff
     }
 }
+
+/// Information for parsing a PE delay-load import table.
+#[derive(Debug, Clone)]
+pub struct DelayLoadImportTable<'data> {
+    section_data: Bytes<'data>,
+    section_address: u32,
+    import_address: u32,
+}
+
+impl<'data> DelayLoadImportTable<'data> {
+    /// Create a new delay load import table parser.
+    ///
+    /// The import descriptors start at `import_address`.
+    /// This table works in the same way the import table does: descriptors will be
+    /// parsed until a null entry.
+    ///
+    /// `section_data` should be from the section containing `import_address`, and
+    /// `section_address` should be the address of that section. Pointers within the
+    /// descriptors and thunks may point to anywhere within the section data.
+    pub fn new(section_data: &'data [u8], section_address: u32, import_address: u32) -> Self {
+        DelayLoadImportTable {
+            section_data: Bytes(section_data),
+            section_address,
+            import_address,
+        }
+    }
+
+    /// Return an iterator for the import descriptors.
+    pub fn descriptors(&self) -> Result<DelayLoadDescriptorIterator<'data>> {
+        let offset = self.import_address.wrapping_sub(self.section_address);
+        let mut data = self.section_data;
+        data.skip(offset as usize)
+            .read_error("Invalid PE delay-load import descriptor address")?;
+        Ok(DelayLoadDescriptorIterator { data })
+    }
+
+    /// Return a library name given its address.
+    ///
+    /// This address may be from [`pe::ImageDelayloadDescriptor::dll_name_rva`].
+    pub fn name(&self, address: u32) -> Result<&'data [u8]> {
+        self.section_data
+            .read_string_at(address.wrapping_sub(self.section_address) as usize)
+            .read_error("Invalid PE import descriptor name")
+    }
+
+    /// Return a list of thunks given its address.
+    ///
+    /// This address may be from the INT, i.e. from
+    /// [`pe::ImageDelayloadDescriptor::import_name_table_rva`].
+    ///
+    /// Please note that others RVA values from [`pe::ImageDelayloadDescriptor`] are used
+    /// by the delay loader at runtime to store values, and thus do not point inside the same
+    /// section as the INT. Calling this function on those addresses will fail.
+    pub fn thunks(&self, address: u32) -> Result<ImportThunkList<'data>> {
+        let offset = address.wrapping_sub(self.section_address);
+        let mut data = self.section_data;
+        data.skip(offset as usize)
+            .read_error("Invalid PE delay load import thunk table address")?;
+        Ok(ImportThunkList { data })
+    }
+
+    /// Parse a thunk.
+    pub fn import<Pe: ImageNtHeaders>(&self, thunk: Pe::ImageThunkData) -> Result<Import<'data>> {
+        if thunk.is_ordinal() {
+            Ok(Import::Ordinal(thunk.ordinal()))
+        } else {
+            let (hint, name) = self.hint_name(thunk.address())?;
+            Ok(Import::Name(hint, name))
+        }
+    }
+
+    /// Return the hint and name at the given address.
+    ///
+    /// This address may be from [`pe::ImageThunkData32`] or [`pe::ImageThunkData64`].
+    ///
+    /// The hint is an index into the export name pointer table in the target library.
+    pub fn hint_name(&self, address: u32) -> Result<(u16, &'data [u8])> {
+        let offset = address.wrapping_sub(self.section_address);
+        let mut data = self.section_data;
+        data.skip(offset as usize)
+            .read_error("Invalid PE delay load import thunk address")?;
+        let hint = data
+            .read::<U16Bytes<LE>>()
+            .read_error("Missing PE delay load import thunk hint")?
+            .get(LE);
+        let name = data
+            .read_string()
+            .read_error("Missing PE delay load import thunk name")?;
+        Ok((hint, name))
+    }
+}
+
+/// A fallible iterator for the descriptors in the delay-load data directory.
+#[derive(Debug, Clone)]
+pub struct DelayLoadDescriptorIterator<'data> {
+    data: Bytes<'data>,
+}
+
+impl<'data> DelayLoadDescriptorIterator<'data> {
+    /// Return the next descriptor.
+    ///
+    /// Returns `Ok(None)` when a null descriptor is found.
+    pub fn next(&mut self) -> Result<Option<&'data pe::ImageDelayloadDescriptor>> {
+        let import_desc = self
+            .data
+            .read::<pe::ImageDelayloadDescriptor>()
+            .read_error("Missing PE null delay-load import descriptor")?;
+        if import_desc.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(import_desc))
+        }
+    }
+}


### PR DESCRIPTION
This PR add support for the delay load import table: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#delay-load-import-tables-image-only

This is mostly copied from the import table implementation, and re-uses the thunks implem from it.

I'm not certain about the naming, between "delay load" & "delay load import".