### PR TITLE
Allow access to LoadCommandData's internal data

### DIFF
--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -77,6 +77,11 @@ impl<'data, E: Endian> LoadCommandData<'data, E> {
             .read_error("Invalid Mach-O command size")
     }
 
+    /// Raw bytes of this LoadCommand structure.
+    pub fn raw_data(&self) -> &'data [u8] {
+        self.data.0
+    }
+
     /// Parse a load command string value.
     ///
     /// Strings used by load commands are specified by offsets that are


### PR DESCRIPTION
This makes it easier to access some of the loadcommand structures. For instance, [`DylibCommand`](https://docs.rs/object/latest/object/macho/struct.DylibCommand.html) contains an [`LcStr`](https://docs.rs/object/latest/object/macho/struct.LcStr.html), which is defined as an offset from the start of the loadcommand, and is contained within the loadcommand data.

With the `raw_data()` function, we could trivially access it from a `LoadCommandData` by doing

```rust
let cmd: LoadCommandData = todo!();
let dylib = cmd.dylib().unwrap();
let dylib_name = cmd.raw_data.get(dylib.dylib.name.offset.get(endian)..);
```