### PR TITLE
e_lfanew correction

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -62,7 +62,7 @@ pub struct ImageDosHeader {
     /// Reserved words
     pub e_res2: [U16<LE>; 10],
     /// File address of new exe header
-    pub e_lfanew: U32<LE>,
+    pub e_lfanew: I32<LE>,
 }
 
 /// OS/2 .EXE header


### PR DESCRIPTION
e_lfanew in object::pe::ImageDosHeader was U32<LE> should be I32<LE>. This can resulted in invalid parse