### PR TITLE
read: fix endianness problems

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,27 @@ jobs:
       - run: cargo build --no-default-features --features read_core,wasm
       - run: cargo build --no-default-features --features doc
 
+  cross:
+    strategy:
+      matrix:
+        target:
+          # A 32-bit target.
+          - "i686-unknown-linux-gnu"
+          # A big-endian target
+          - "mips64-unknown-linux-gnuabi64"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install rust
+        run: |
+          rustup install stable
+          rustup default stable
+      - run: cargo install cross
+      - run: rustup target add ${{matrix.target}}
+      - run: cross test --target ${{matrix.target}} --features all
+
   msrv-read:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           submodules: true
       - name: Install rust
-        run: rustup update 1.42.0 && rustup default 1.42.0
+        run: rustup update 1.52.0 && rustup default 1.52.0
       - name: Test
         run: cargo test --verbose --no-default-features --features read,std
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [`crates/examples`](crates/examples) for more examples.
 Changes to MSRV are considered breaking changes. We are conservative about changing the MSRV,
 but sometimes are required to due to dependencies. The MSRV is:
 
-  * 1.42.0 for the `read` feature and its dependencies.
+  * 1.52.0 for the `read` feature and its dependencies.
   * 1.56.1 for the `write` feature and its dependencies.
 
 ## License

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -361,7 +361,7 @@ fn print_section_symbols<Elf: FileHeader>(
                 } else {
                     p.field("SectionIndex", shndx);
                 }
-                if let Some(shndx) = symbols.shndx(index) {
+                if let Some(shndx) = symbols.shndx(endian, index) {
                     p.field("ExtendedSectionIndex", shndx);
                 }
             });

--- a/crates/examples/testfiles/pe/resource.exe.readobj.0
+++ b/crates/examples/testfiles/pe/resource.exe.readobj.0
@@ -1,0 +1,42 @@
+ImageResourceDirectory {
+    Characteristics: 0
+    TimeDateStamp: 0
+    MajorVersion: 0
+    MinorVersion: 0
+    NumberOfNamedEntries: 0
+    NumberOfIdEntries: 1
+    ImageResourceDirectoryEntry {
+        NameOrId: RT_VERSION (0x10)
+        OffsetToDataOrDirectory: 0x80000018
+        ImageResourceDirectory {
+            Characteristics: 0
+            TimeDateStamp: 0
+            MajorVersion: 0
+            MinorVersion: 0
+            NumberOfNamedEntries: 1
+            NumberOfIdEntries: 0
+            ImageResourceDirectoryEntry {
+                NameOrId: "MY VERSION" (0x80000048)
+                OffsetToDataOrDirectory: 0x80000030
+                ImageResourceDirectory {
+                    Characteristics: 0
+                    TimeDateStamp: 0
+                    MajorVersion: 0
+                    MinorVersion: 0
+                    NumberOfNamedEntries: 0
+                    NumberOfIdEntries: 1
+                    ImageResourceDirectoryEntry {
+                        NameOrId: 1033
+                        OffsetToDataOrDirectory: 0x60
+                        ImageResourceDataEntry {
+                            VirtualAddress: 0x10070
+                            Size: 92
+                            CodePage: 0
+                            Reserved: 0x0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We were reading the ELF extended section indices and the PE resource names using native endian.

These fixes are breaking changes, and also update the required rust version to 1.52.0 (for UTF-16 parsing).

Also add 32-bit and big endian targets to CI.

Fixes #456 