### PR TITLE
Support reading AIX big archive format

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -61,5 +61,25 @@ pub struct AixHeader {
     pub namlen: [u8; 4],
 }
 
+/// The AIX big archive's fixed length header at file beginning.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct AIXFileHeader {
+    /// Offset of member table
+    pub memoff: [u8; 20],
+    /// Offset of global symbol table
+    pub gstoff: [u8; 20],
+    /// ffset of global symbol table for 64-bit objects
+    pub gst64off: [u8; 20],
+    /// Offset of first member
+    pub fstmoff: [u8; 20],
+    /// Offset of last member
+    pub lstmoff: [u8; 20],
+    /// Offset of first member on free list
+    pub freeoff: [u8; 20],
+}
+
+
 unsafe_impl_pod!(Header);
 unsafe_impl_pod!(AixHeader);
+unsafe_impl_pod!(AIXFileHeader);

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -61,14 +61,5 @@ pub struct AixHeader {
     pub namlen: [u8; 4],
 }
 
-/// Discriminated union for multiple type headers
-#[derive(Debug, Clone, Copy)]
-pub enum MemberHeader {
-    /// GNU or BSD style header
-    SystemV(Header),
-    /// AIX style big archive header
-    AixBig(AixHeader),
-}
-
 unsafe_impl_pod!(Header);
 unsafe_impl_pod!(AixHeader);

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -43,22 +43,22 @@ pub struct Header {
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct AixHeader {
-    /// Member size in decimal.
+    /// File member size in decimal.
     pub size: [u8; 20],
-    /// Offset of next member in decimal.
-    pub next_member: [u8; 20],
-    /// Offset of previous member in decimal.
-    pub prev_member: [u8; 20],
-    /// File modification timestamp in decimal.
+    /// Next member offset in decimal.
+    pub nxtmem: [u8; 20],
+    /// Previous member offset in decimal.
+    pub prvmem: [u8; 20],
+    /// File member date in decimal.
     pub date: [u8; 12],
-    /// User ID in decimal.
+    /// File member user id in decimal.
     pub uid: [u8; 12],
-    /// Group ID in decimal.
+    /// File member group id in decimal.
     pub gid: [u8; 12],
-    /// File mode in octal.
+    /// File member mode in octal.
     pub mode: [u8; 12],
-    /// Name length in decimal.
-    pub name_length: [u8; 4],
+    /// File member name length in decimal.
+    pub namlen: [u8; 4],
 }
 
 /// Discriminated union for multiple type headers

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -72,24 +72,3 @@ pub enum MemberHeader {
 
 unsafe_impl_pod!(Header);
 unsafe_impl_pod!(AixHeader);
-
-/// The AIX big archive fixed len header.
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-pub struct AIXBigFixedHeader {
-    /// We read the magic number in advance , so don't put this in struct.
-    /// Offset to member table
-    pub memoffset: [u8; 20],
-    /// Offset to Global offset
-    pub globsymoffset: [u8; 20],
-    /// Offset to 64 bit Sym
-    pub globsym64offset: [u8; 20],
-    /// Offset to first Child
-    pub firstchildoffset: [u8; 20],
-    /// Offset to last child
-    pub lastchildoffset: [u8; 20],
-    /// Offset to free list
-    pub freeoffset: [u8; 20],
-}
-
-unsafe_impl_pod!(AIXBigFixedHeader);

--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -229,7 +229,7 @@ impl<'data> ArchiveMember<'data> {
         let header = data
             .read::<archive::AixHeader>(offset)
             .read_error("Invalid AIX big archive member header")?;
-        let name_length = parse_u64_digits(&header.name_length, 10)
+        let name_length = parse_u64_digits(&header.namlen, 10)
             .read_error("Invalid archive member name length")?;
         let name = data
             .read_bytes(offset, name_length)
@@ -241,6 +241,7 @@ impl<'data> ArchiveMember<'data> {
         if *offset & 1 != 0 {
             *offset = offset.saturating_add(1);
         }
+        // Because of the even-byte boundary, we have to read and check terminator after header.
         let terminator = data
             .read_bytes(offset, 2)
             .read_error("Invalid archive head terminator")?;
@@ -249,7 +250,7 @@ impl<'data> ArchiveMember<'data> {
         }
         let file_offset = *offset;
         let nextmbroff =
-            parse_u64_digits(&header.next_member, 10).read_error("Invalid next member offset")?;
+            parse_u64_digits(&header.nxtmem, 10).read_error("Invalid next member offset")?;
 
         // Move the offset to next member offset
         *offset = nextmbroff;


### PR DESCRIPTION
The archive format on AIX is called 'big archive' (see definition at https://www.ibm.com/docs/en/aix/7.3?topic=formats-ar-file-format-big), which is quite different from BSD and GNU variants.

This PR will add support for reading it, as part of the efforts porting Rust toolchain onto AIX. (Writing facility was done by wrapping LLVM upstream code in https://github.com/rust-lang/ar_archive_writer/pull/2)

Also thanks to contribution from @jsji.