### PR TITLE
Support Aarch64Call relocations for Mach-O

### DIFF
--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -526,14 +526,6 @@ impl<'a> Object<'a> {
         match relocation.size {
             32 => data.write_at(offset, &U32::new(self.endian, addend as u32)),
             64 => data.write_at(offset, &U64::new(self.endian, addend as u64)),
-
-            // For aarch64 call relocations in Mach-O, the addend is
-            // encoded in a separate relocation, so don't write it here
-            26 if relocation.encoding == RelocationEncoding::AArch64Call
-                && self.format == BinaryFormat::MachO =>
-            {
-                Ok(())
-            }
             _ => {
                 return Err(Error(format!(
                     "unimplemented relocation addend {:?}",

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -526,6 +526,14 @@ impl<'a> Object<'a> {
         match relocation.size {
             32 => data.write_at(offset, &U32::new(self.endian, addend as u32)),
             64 => data.write_at(offset, &U64::new(self.endian, addend as u64)),
+
+            // For aarch64 call relocations in Mach-O, the addend is
+            // encoded in a separate relocation, so don't write it here
+            26 if relocation.encoding == RelocationEncoding::AArch64Call
+                && self.format == BinaryFormat::MachO =>
+            {
+                Ok(())
+            }
             _ => {
                 return Err(Error(format!(
                     "unimplemented relocation addend {:?}",


### PR DESCRIPTION
This PR adds support for relocations with  `RelocationEncoding::Aarch64Call`  on Mach-O. Before this PR we would error out, as the relocation has a size of 26 which was unhandled, and we weren't setting the appropriate `r_type`. After this PR we support relocations with `RelocationEncoding::Aarch64Call` and an arbitrary addend.

This PR also handles a few extra cases of the relocation size (21 and 12) in order to support the usage of Mach-O specific relocations like `ARM64_RELOC_PAGE21` and `ARM64_RELOC_PAGEOFF12`, respectively.