### PR TITLE
examples/dyldcachedump: fix finding dyld subcaches on macOS 13

### DIFF
--- a/crates/examples/src/bin/dyldcachedump.rs
+++ b/crates/examples/src/bin/dyldcachedump.rs
@@ -71,7 +71,8 @@ fn main() {
 
 // If the file is a dyld shared cache, and we're on macOS 12 or later,
 // then there will be one or more "subcache" files next to this file,
-// with the names filename.1, filename.2, ..., filename.symbols.
+// with the names filename.1, filename.2, ..., filename.symbols
+// or filename.01, filename.02 on macOS 13
 fn open_subcaches_if_exist(path: &str) -> Vec<fs::File> {
     let mut files = Vec::new();
     for i in 1.. {
@@ -80,6 +81,15 @@ fn open_subcaches_if_exist(path: &str) -> Vec<fs::File> {
             Ok(subcache_file) => files.push(subcache_file),
             Err(_) => break,
         };
+    }
+    if files.is_empty() {
+        for i in 1.. {
+            let subcache_path = format!("{}.{:02}", path, i);
+            match fs::File::open(&subcache_path) {
+                Ok(subcache_file) => files.push(subcache_file),
+                Err(_) => break,
+            };
+        }
     }
     let symbols_subcache_path = format!("{}.symbols", path);
     if let Ok(subcache_file) = fs::File::open(&symbols_subcache_path) {


### PR DESCRIPTION
```bash
$ ls -l /System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/
total 7706920
-rwxr-xr-x  1 root  admin   802367771 Sep 24 00:00 aot_shared_cache.0
-rwxr-xr-x  1 root  admin   956507291 Sep 24 00:00 aot_shared_cache.1
-rwxr-xr-x  1 root  admin   910736027 Sep 24 00:00 aot_shared_cache.2
-rwxr-xr-x  1 root  admin   890360219 Sep 24 00:00 aot_shared_cache.3
-rwxr-xr-x  1 root  admin   129487259 Sep 24 00:00 aot_shared_cache.4
-rwxr-xr-x  1 root  admin  1600995328 Sep 24 00:00 dyld_shared_cache_arm64e
-rwxr-xr-x  1 root  admin  1671282688 Sep 24 00:00 dyld_shared_cache_arm64e.01
-rwxr-xr-x  1 root  admin      933245 Sep 24 00:00 dyld_shared_cache_arm64e.map
-rwxr-xr-x  1 root  admin   811483136 Sep 24 00:00 dyld_shared_cache_x86_64
-rwxr-xr-x  1 root  admin   800620544 Sep 24 00:00 dyld_shared_cache_x86_64.01
-rwxr-xr-x  1 root  admin   757383168 Sep 24 00:00 dyld_shared_cache_x86_64.02
-rwxr-xr-x  1 root  admin   782106624 Sep 24 00:00 dyld_shared_cache_x86_64.03
-rwxr-xr-x  1 root  admin   235241472 Sep 24 00:00 dyld_shared_cache_x86_64.04
-rwxr-xr-x  1 root  admin      701282 Sep 24 00:00 dyld_shared_cache_x86_64.map
```