### PR TITLE
read/archive: AIX big archive enhancements

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -64,21 +64,28 @@ pub struct AixHeader {
 /// The AIX big archive's fixed length header at file beginning.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct AIXFileHeader {
-    /// Offset of member table
+pub struct AixFileHeader {
+    /// Archive magic string.
+    pub magic: [u8; 8],
+    /// Offset of member table.
     pub memoff: [u8; 20],
-    /// Offset of global symbol table
+    /// Offset of global symbol table.
     pub gstoff: [u8; 20],
-    /// ffset of global symbol table for 64-bit objects
+    /// Offset of global symbol table for 64-bit objects.
     pub gst64off: [u8; 20],
-    /// Offset of first member
+    /// Offset of first member.
     pub fstmoff: [u8; 20],
-    /// Offset of last member
+    /// Offset of last member.
     pub lstmoff: [u8; 20],
-    /// Offset of first member on free list
+    /// Offset of first member on free list.
     pub freeoff: [u8; 20],
 }
 
-unsafe_impl_pod!(Header);
-unsafe_impl_pod!(AixHeader);
-unsafe_impl_pod!(AIXFileHeader);
+/// Offset of a member in an AIX big archive.
+///
+/// This is used in the member index.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct AixMemberOffset(pub [u8; 20]);
+
+unsafe_impl_pod!(Header, AixHeader, AixFileHeader, AixMemberOffset,);


### PR DESCRIPTION
- Include magic in `AixFileHeader`.
- Move AIX file header parsing into separate function.
- Use `ArchiveMember::parse_aixbig` to parse the members for the symbol tables and member index.
- Add `Members` enum for `ArchiveFile::members` instead of overloading the meaning of fields.
- Fix length of member index count (20 instead of 30).
- Add `AixMemberOffset` to simplify member index parsing.
- Read the entire member index array at once. This avoids some overflow checking.
- Don't set `ArchiveFile::names` since it isn't used.

Followup to #467. @ecnelises Can you test and review please?