### PR TITLE
elf: Update LoongArch eflags

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -76,7 +76,14 @@ fn print_file_header<Elf: FileHeader>(p: &mut Printer<'_>, endian: Elf::Endian, 
                 p.flags(flags, 0, &FLAGS_EF_RISCV);
                 p.flags(flags, EF_RISCV_FLOAT_ABI, &FLAGS_EF_RISCV_FLOAT_ABI);
             }
-            EM_LOONGARCH => p.flags(flags, 0, &FLAGS_EF_LOONGARCH),
+            EM_LOONGARCH => {
+                p.flags(flags, 0, &FLAGS_EF_LARCH_OBJABI);
+                p.flags(
+                    flags,
+                    EF_LARCH_ABI_MODIFIER_MASK,
+                    &FLAGS_EF_LARCH_ABI_MODIFIER,
+                );
+            }
             _ => {}
         };
         p.field_hex("HeaderSize", elf.e_ehsize(endian));
@@ -1107,14 +1114,12 @@ static FLAGS_EF_RISCV_FLOAT_ABI: &[Flag<u32>] = &flags!(
     EF_RISCV_FLOAT_ABI_DOUBLE,
     EF_RISCV_FLOAT_ABI_QUAD,
 );
-static FLAGS_EF_LOONGARCH: &[Flag<u32>] = &flags!(
-    EF_LARCH_ABI_LP64S,
-    EF_LARCH_ABI_LP64F,
-    EF_LARCH_ABI_LP64D,
-    EF_LARCH_ABI_ILP32S,
-    EF_LARCH_ABI_ILP32F,
-    EF_LARCH_ABI_ILP32D,
+static FLAGS_EF_LARCH_ABI_MODIFIER: &[Flag<u32>] = &flags!(
+    EF_LARCH_ABI_SOFT_FLOAT,
+    EF_LARCH_ABI_SINGLE_FLOAT,
+    EF_LARCH_ABI_DOUBLE_FLOAT,
 );
+static FLAGS_EF_LARCH_OBJABI: &[Flag<u32>] = &flags!(EF_LARCH_OBJABI_V1,);
 static FLAGS_PT: &[Flag<u32>] = &flags!(
     PT_NULL,
     PT_LOAD,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6251,18 +6251,17 @@ pub const R_NDS32_TLS_TPOFF: u32 = 102;
 pub const R_NDS32_TLS_DESC: u32 = 119;
 
 // LoongArch values `FileHeader*::e_flags`.
-/// Uses 64-bit GPRs and the stack for parameter passing
-pub const EF_LARCH_ABI_LP64S: u32 = 0x1;
-/// Uses 64-bit GPRs, 32-bit FPRs and the stack for parameter passing
-pub const EF_LARCH_ABI_LP64F: u32 = 0x2;
-/// Uses 64-bit GPRs, 64-bit FPRs and the stack for parameter passing
-pub const EF_LARCH_ABI_LP64D: u32 = 0x3;
-/// Uses 32-bit GPRs and the stack for parameter passing
-pub const EF_LARCH_ABI_ILP32S: u32 = 0x5;
-/// Uses 32-bit GPRs, 32-bit FPRs and the stack for parameter passing
-pub const EF_LARCH_ABI_ILP32F: u32 = 0x6;
-/// Uses 32-bit GPRs, 64-bit FPRs and the stack for parameter passing
-pub const EF_LARCH_ABI_ILP32D: u32 = 0x7;
+/// Additional properties of the base ABI type, including the FP calling
+/// convention.
+pub const EF_LARCH_ABI_MODIFIER_MASK: u32 = 0x7;
+/// Uses GPRs and the stack for parameter passing
+pub const EF_LARCH_ABI_SOFT_FLOAT: u32 = 0x1;
+/// Uses GPRs, 32-bit FPRs and the stack for parameter passing
+pub const EF_LARCH_ABI_SINGLE_FLOAT: u32 = 0x2;
+/// Uses GPRs, 64-bit FPRs and the stack for parameter passing
+pub const EF_LARCH_ABI_DOUBLE_FLOAT: u32 = 0x3;
+/// Uses relocation types directly writing to immediate slots
+pub const EF_LARCH_OBJABI_V1: u32 = 0x40;
 
 // LoongArch values `Rel*::r_type`.
 /// No reloc


### PR DESCRIPTION
In a revision of LoongArch ELF ABI [1], it was decided that ILP32 objects must use ELFCLASS32.  Now both LP64D and ILP32D will use the same number (0x1) for "double float", so EF_LARCH_ABI_LP64{S,F,D} are renamed and EF_LARCH_ABI_ILP32{S,F,D} are removed.

The change is ABI-compatible for LP64, but not API-compatible.  ILP32 is not supported by GCC and Glibc yet so it's not really used anyway.

And, a seperate bit is allocated to indicate if the ELF object file uses any relocation type directly writing to immediate slots [2].

Update the code to match these changes.

[1]:https://github.com/loongson/LoongArch-Documentation/pull/47/files#diff-711b3e7b6a005b492898ac6d93f2d8d37c00e0831e210993a6f9dbb26c043717 [2]:https://github.com/loongson/LoongArch-Documentation/pull/61/files#diff-711b3e7b6a005b492898ac6d93f2d8d37c00e0831e210993a6f9dbb26c043717