### PR TITLE
Change xcoff to be an unstable feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,9 @@ jobs:
         rustup install ${{matrix.rust_channel}}
         rustup default ${{matrix.rust_channel}}
     - name: Test debug
-      run: cargo test --verbose --features all
+      run: |
+        cargo test --verbose --features all
+        cargo test --verbose --features unstable-all
     - name: Test release
       run: cargo test --verbose --features all --release
 
@@ -42,7 +44,7 @@ jobs:
       - run: cargo build --no-default-features --features read_core,write_core,macho
       - run: cargo build --no-default-features --features read_core,pe
       - run: cargo build --no-default-features --features read_core,wasm
-      - run: cargo build --no-default-features --features read_core,xcoff
+      - run: cargo build --no-default-features --features read_core,xcoff,unstable
       - run: cargo build --no-default-features --features doc
 
   cross:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object"
-# Note: disable resolver in workspace setting before releases.
 version = "0.29.0"
 edition = "2018"
 exclude = ["/.github", "/testfiles"]
@@ -32,8 +31,8 @@ alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-all
 
 # Core read support. You will need to enable some file formats too.
 read_core = []
-# Read support for all file formats (including unaligned files).
-read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned", "xcoff"]
+# Read support for most file formats (including unaligned files).
+read = ["read_core", "archive", "coff", "elf", "macho", "pe", "unaligned"]
 # Core write support. You will need to enable some file formats too.
 write_core = ["crc32fast", "indexmap", "hashbrown"]
 # Core write support with libstd features. You will need to enable some file formats too.
@@ -65,7 +64,6 @@ elf = []
 macho = []
 pe = ["coff"]
 wasm = ["wasmparser"]
-xcoff = []
 
 #=======================================
 # By default, support all read features.
@@ -85,8 +83,14 @@ cargo-all = []
 doc = [
   "read_core", "write_std",
   "std", "compression",
-  "archive", "coff", "elf", "macho", "pe", "wasm", "xcoff"
+  "archive", "coff", "elf", "macho", "pe", "wasm",
 ]
+
+#=======================================
+# Unstable features. Breaking changes in these features will not affect versioning.
+unstable = []
+xcoff = []
+unstable-all = ["all", "unstable", "xcoff"]
 
 #=======================================
 # Internal feature, only used when building as part of libstd, not part of the
@@ -96,4 +100,4 @@ rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc', 'memchr/rustc-dep-of-s
 [workspace]
 members = ["crates/examples"]
 default-members = [".", "crates/examples"]
-#resolver = "2"
+resolver = "2"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -12,6 +12,10 @@ glob = "0.3"
 
 [features]
 read = ["object/read"]
+wasm = ["object/wasm"]
+xcoff = ["object/xcoff"]
+all = ["read", "wasm"]
+unstable-all = ["all", "xcoff"]
 default = ["read"]
 
 [[bin]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@
 #[cfg(feature = "cargo-all")]
 compile_error!("'--all-features' is not supported; use '--features all' instead");
 
+#[cfg(all(feature = "xcoff", not(feature = "unstable")))]
+compile_error!("'xcoff` is an unstable feature; enable 'unstable' as well");
+
 #[cfg(any(feature = "read_core", feature = "write_core"))]
 #[allow(unused_imports)]
 #[macro_use]


### PR DESCRIPTION
The xcoff feature needs further work before being ready for release.

Also, the default resolver can be changed to "2" now that the MSRV is at least 1.51. This works better with features in workspaces.

cc @EsmeYi 