### PR TITLE
feat: add ResourceName::raw_data method

### DIFF
--- a/src/read/pe/resource.rs
+++ b/src/read/pe/resource.rs
@@ -166,6 +166,11 @@ impl ResourceName {
             .read_slice::<U16Bytes<LE>>(&mut offset, len.get(LE).into())
             .read_error("Invalid resource name length")
     }
+
+    /// Returns the string buffer as raw bytes.
+    pub fn raw_data<'data>(&self, directory: ResourceDirectory<'data>) -> Result<&'data [u8]> {
+        self.data(directory).map(crate::pod::bytes_of_slice)
+    }
 }
 
 /// A resource name or ID.


### PR DESCRIPTION
In my program, I want to give access to the bytes of a resource name. Since this is a unicode string, there is already a method to get a slice of u16. I can use it to get back the raw bytes, but that requires unsafe code that can be avoided by getting the raw bytes.

So this PR adds a new method to ResourceName to get the name as a slice of bytes instead of a slice of u16.