### PR TITLE
Add support for AArch64 ILP32 for ELF

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -5,6 +5,8 @@
 pub enum Architecture {
     Unknown,
     Aarch64,
+    #[allow(non_camel_case_types)]
+    Aarch64_Ilp32,
     Arm,
     Avr,
     Bpf,
@@ -36,6 +38,7 @@ impl Architecture {
         match self {
             Architecture::Unknown => None,
             Architecture::Aarch64 => Some(AddressSize::U64),
+            Architecture::Aarch64_Ilp32 => Some(AddressSize::U32),
             Architecture::Arm => Some(AddressSize::U32),
             Architecture::Avr => Some(AddressSize::U8),
             Architecture::Bpf => Some(AddressSize::U64),

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -156,7 +156,8 @@ where
             self.header.e_machine(self.endian),
             self.header.is_class_64(),
         ) {
-            (elf::EM_AARCH64, _) => Architecture::Aarch64,
+            (elf::EM_AARCH64, true) => Architecture::Aarch64,
+            (elf::EM_AARCH64, false) => Architecture::Aarch64_Ilp32,
             (elf::EM_ARM, _) => Architecture::Arm,
             (elf::EM_AVR, _) => Architecture::Avr,
             (elf::EM_BPF, _) => Architecture::Bpf,

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -231,6 +231,7 @@ fn elf_x86_64() {
 fn elf_any() {
     for (arch, endian) in [
         (Architecture::Aarch64, Endianness::Little),
+        (Architecture::Aarch64_Ilp32, Endianness::Little),
         (Architecture::Arm, Endianness::Little),
         (Architecture::Avr, Endianness::Little),
         (Architecture::Bpf, Endianness::Little),


### PR DESCRIPTION
This is needed for the `aarch64-unknown-linux-gnu_ilp32` target in rustc.

I've only implemented minimal support for ILP32 relocations since rustc doesn't use these (it only generates object files to wrap metadata or to force the linker to import symbols).