### PR TITLE
write: Create symbols for sections

### DIFF
--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -193,6 +193,9 @@ impl<'a> Object<'a> {
             flags: SectionFlags::None,
         });
 
+        // Create a symbol for the section
+        self.section_symbol(id);
+
         // Add to self.standard_sections if required. This may match multiple standard sections.
         let section = &self.sections[id.0];
         for standard_section in StandardSection::all() {


### PR DESCRIPTION
👋 Hey,

It looks like we don't automatically create a symbol when adding a section, this PR changes that.

See https://github.com/bjorn3/rustc_codegen_cranelift/issues/1249#issuecomment-1382724051 for some context.