### PR TITLE
write: Add `SectionKind::ReadOnlyDataWithRel`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -122,6 +122,11 @@ pub enum SectionKind {
     ///
     /// Example Mach-O sections: `__TEXT/__const`, `__DATA/__const`, `__TEXT/__literal4`
     ReadOnlyData,
+    /// A read only data section with relocations.
+    ///
+    /// This is the same as either `Data` or `ReadOnlyData`, depending on the file format.
+    /// This value is only used in the API for writing files. It is never returned when reading files.
+    ReadOnlyDataWithRel,
     /// A loadable string section.
     ///
     /// Example ELF sections: `.rodata.str`

--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -355,7 +355,9 @@ impl<'a> Object<'a> {
                             | coff::IMAGE_SCN_MEM_READ
                             | coff::IMAGE_SCN_MEM_WRITE
                     }
-                    SectionKind::ReadOnlyData | SectionKind::ReadOnlyString => {
+                    SectionKind::ReadOnlyData
+                    | SectionKind::ReadOnlyDataWithRel
+                    | SectionKind::ReadOnlyString => {
                         coff::IMAGE_SCN_CNT_INITIALIZED_DATA | coff::IMAGE_SCN_MEM_READ
                     }
                     SectionKind::Debug | SectionKind::Other | SectionKind::OtherString => {

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -38,7 +38,9 @@ impl<'a> Object<'a> {
             StandardSection::ReadOnlyData | StandardSection::ReadOnlyString => {
                 (&[], &b".rodata"[..], SectionKind::ReadOnlyData)
             }
-            StandardSection::ReadOnlyDataWithRel => (&[], b".data.rel.ro", SectionKind::Data),
+            StandardSection::ReadOnlyDataWithRel => {
+                (&[], b".data.rel.ro", SectionKind::ReadOnlyDataWithRel)
+            }
             StandardSection::UninitializedData => {
                 (&[], &b".bss"[..], SectionKind::UninitializedData)
             }
@@ -767,7 +769,9 @@ impl<'a> Object<'a> {
             } else {
                 match section.kind {
                     SectionKind::Text => elf::SHF_ALLOC | elf::SHF_EXECINSTR,
-                    SectionKind::Data => elf::SHF_ALLOC | elf::SHF_WRITE,
+                    SectionKind::Data | SectionKind::ReadOnlyDataWithRel => {
+                        elf::SHF_ALLOC | elf::SHF_WRITE
+                    }
                     SectionKind::Tls => elf::SHF_ALLOC | elf::SHF_WRITE | elf::SHF_TLS,
                     SectionKind::UninitializedData => elf::SHF_ALLOC | elf::SHF_WRITE,
                     SectionKind::UninitializedTls => elf::SHF_ALLOC | elf::SHF_WRITE | elf::SHF_TLS,

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -51,9 +51,11 @@ impl<'a> Object<'a> {
             StandardSection::ReadOnlyData => {
                 (&b"__TEXT"[..], &b"__const"[..], SectionKind::ReadOnlyData)
             }
-            StandardSection::ReadOnlyDataWithRel => {
-                (&b"__DATA"[..], &b"__const"[..], SectionKind::ReadOnlyData)
-            }
+            StandardSection::ReadOnlyDataWithRel => (
+                &b"__DATA"[..],
+                &b"__const"[..],
+                SectionKind::ReadOnlyDataWithRel,
+            ),
             StandardSection::ReadOnlyString => (
                 &b"__TEXT"[..],
                 &b"__cstring"[..],
@@ -406,7 +408,7 @@ impl<'a> Object<'a> {
                         macho::S_ATTR_PURE_INSTRUCTIONS | macho::S_ATTR_SOME_INSTRUCTIONS
                     }
                     SectionKind::Data => 0,
-                    SectionKind::ReadOnlyData => 0,
+                    SectionKind::ReadOnlyData | SectionKind::ReadOnlyDataWithRel => 0,
                     SectionKind::ReadOnlyString => macho::S_CSTRING_LITERALS,
                     SectionKind::UninitializedData | SectionKind::Common => macho::S_ZEROFILL,
                     SectionKind::Tls => macho::S_THREAD_LOCAL_REGULAR,

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -615,9 +615,8 @@ impl StandardSection {
         match self {
             StandardSection::Text => SectionKind::Text,
             StandardSection::Data => SectionKind::Data,
-            StandardSection::ReadOnlyData | StandardSection::ReadOnlyDataWithRel => {
-                SectionKind::ReadOnlyData
-            }
+            StandardSection::ReadOnlyData => SectionKind::ReadOnlyData,
+            StandardSection::ReadOnlyDataWithRel => SectionKind::ReadOnlyDataWithRel,
             StandardSection::ReadOnlyString => SectionKind::ReadOnlyString,
             StandardSection::UninitializedData => SectionKind::UninitializedData,
             StandardSection::Tls => SectionKind::Tls,


### PR DESCRIPTION
👋 Hey,

This PR adds a `SectionKind::ReadOnlyDataWithRel`. For MachO and COFF it is essentially the same as ReadOnlyData.