### PR TITLE
Add ELF RISCV_RVE for E ABI

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -1109,7 +1109,7 @@ static FLAGS_EF_SH_MACH: &[Flag<u32>] = &flags!(
     EF_SH2A_SH3E,
 );
 static FLAGS_EF_S390: &[Flag<u32>] = &flags!(EF_S390_HIGH_GPRS);
-static FLAGS_EF_RISCV: &[Flag<u32>] = &flags!(EF_RISCV_RVC);
+static FLAGS_EF_RISCV: &[Flag<u32>] = &flags!(EF_RISCV_RVC, EF_RISCV_RVE, EF_RISCV_TSO);
 static FLAGS_EF_RISCV_FLOAT_ABI: &[Flag<u32>] = &flags!(
     EF_RISCV_FLOAT_ABI_SOFT,
     EF_RISCV_FLOAT_ABI_SINGLE,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6121,6 +6121,8 @@ pub const EF_RISCV_FLOAT_ABI_SINGLE: u32 = 0x0002;
 pub const EF_RISCV_FLOAT_ABI_DOUBLE: u32 = 0x0004;
 #[allow(missing_docs)]
 pub const EF_RISCV_FLOAT_ABI_QUAD: u32 = 0x0006;
+#[allow(missing_docs)]
+pub const EF_RISCV_RVE: u32 = 0x0008;
 
 // RISC-V values `Rel*::r_type`.
 #[allow(missing_docs)]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6123,6 +6123,8 @@ pub const EF_RISCV_FLOAT_ABI_DOUBLE: u32 = 0x0004;
 pub const EF_RISCV_FLOAT_ABI_QUAD: u32 = 0x0006;
 #[allow(missing_docs)]
 pub const EF_RISCV_RVE: u32 = 0x0008;
+#[allow(missing_docs)]
+pub const EF_RISCV_TSO: u32 = 0x0010;
 
 // RISC-V values `Rel*::r_type`.
 #[allow(missing_docs)]


### PR DESCRIPTION
For targeting the RV32E base ISA. From
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/079772828bd10933d34121117a222b4cc0ee2200/riscv-elf.adoc