### PR TITLE
elfcopy: Add --redefine-syms <file> arguments

### DIFF
--- a/crates/examples/src/bin/elfcopy.rs
+++ b/crates/examples/src/bin/elfcopy.rs
@@ -6,14 +6,35 @@ use object::elf;
 use object::read::elf::{Dyn, FileHeader, ProgramHeader, Rel, Rela, SectionHeader, Sym};
 use object::Endianness;
 
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::fs::File;
+use std::io::{self, BufRead};
+
 fn main() {
     let mut args = env::args();
-    if args.len() != 3 {
-        eprintln!("Usage: {} <infile> <outfile>", args.next().unwrap());
+    if !(args.len() == 3 || args.len() == 5) {
+        eprintln!(
+            "Usage: {} [--redefine-syms <file>] <infile> <outfile>",
+            args.next().unwrap()
+        );
         process::exit(1);
     }
 
     args.next();
+
+    let redefine_file = match args.len() {
+        // 4 tokens remaining means we have specified --redefine-syms <file>
+        4 => {
+            if args.next() != Some("--redefine-syms".to_string()) {
+                eprintln!("Usage: [--redefine-syms <file>] <infile> <outfile>");
+                process::exit(1);
+            }
+            Some(args.next().unwrap())
+        }
+        _ => None,
+    };
+
     let in_file_path = args.next().unwrap();
     let out_file_path = args.next().unwrap();
 
@@ -41,8 +62,12 @@ fn main() {
         }
     };
     let out_data = match kind {
-        object::FileKind::Elf32 => copy_file::<elf::FileHeader32<Endianness>>(in_data).unwrap(),
-        object::FileKind::Elf64 => copy_file::<elf::FileHeader64<Endianness>>(in_data).unwrap(),
+        object::FileKind::Elf32 => {
+            copy_file::<elf::FileHeader32<Endianness>>(in_data, redefine_file).unwrap()
+        }
+        object::FileKind::Elf64 => {
+            copy_file::<elf::FileHeader64<Endianness>>(in_data, redefine_file).unwrap()
+        }
         _ => {
             eprintln!("Not an ELF file");
             process::exit(1);
@@ -80,8 +105,63 @@ struct DynamicSymbol {
     gnu_hash: Option<u32>,
 }
 
+/// Table that holds a map of the symbols we should rename while copying
+///
+/// This will be loaded by passing a file with lines of the form:
+/// ```
+/// <original_sym> <new_sym>
+/// ```
+/// A symbol name can then be passed to query the corresponding new
+/// name that we should provide the `out_*` variables in `copy_file`.
+struct RedefineSymTable {
+    map: Option<HashMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl RedefineSymTable {
+    fn new(filename: Option<String>) -> Result<Self, Box<dyn Error>> {
+        match filename {
+            Some(filename) => {
+                let file = File::open(filename)?;
+
+                let mut map = HashMap::new();
+
+                for res in io::BufReader::new(file).lines() {
+                    let line = res?;
+                    let names: Vec<&str> = line.split(' ').take(2).collect();
+
+                    // check that there are two symbol names on each line
+                    if names.len() != 2 {
+                        return Err(
+                            "Error: invalid redefine file. --redefine-syms expects lines \
+                    of the form: <original_sym> <new_sym>"
+                                .into(),
+                        );
+                    }
+
+                    map.insert(names[0].into(), names[1].into());
+                }
+
+                Ok(Self { map: Some(map) })
+            }
+            None => Ok(Self { map: None }),
+        }
+    }
+
+    fn get_redefined_name<'a>(&'a self, original: &'a [u8]) -> &'a [u8] {
+        // check if we have a rename for this symbol
+        if let Some(map) = self.map.as_ref() {
+            if let Some(new_string) = map.get(original.into()) {
+                return new_string.as_slice();
+            }
+        }
+
+        return original;
+    }
+}
+
 fn copy_file<Elf: FileHeader<Endian = Endianness>>(
     in_data: &[u8],
+    redefine_file: Option<String>,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
     let in_elf = Elf::parse(in_data)?;
     let endian = in_elf.endian()?;
@@ -90,6 +170,8 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(
     let in_sections = in_elf.sections(endian, in_data)?;
     let in_syms = in_sections.symbols(endian, in_data, elf::SHT_SYMTAB)?;
     let in_dynsyms = in_sections.symbols(endian, in_data, elf::SHT_DYNSYM)?;
+
+    let redefine_table = RedefineSymTable::new(redefine_file)?;
 
     let mut out_data = Vec::new();
     let mut writer = object::write::elf::Writer::new(endian, in_elf.is_class_64(), &mut out_data);
@@ -234,11 +316,12 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(
         let mut gnu_hash = None;
         if in_dynsym.st_name(endian) != 0 {
             let in_name = in_dynsyms.symbol_name(endian, in_dynsym)?;
-            name = Some(writer.add_dynamic_string(in_name));
-            if !in_name.is_empty() {
-                hash = Some(elf::hash(in_name));
+            let redefined_name = redefine_table.get_redefined_name(in_name);
+            name = Some(writer.add_dynamic_string(redefined_name));
+            if !redefined_name.is_empty() {
+                hash = Some(elf::hash(redefined_name));
                 if !in_dynsym.is_undefined(endian) {
-                    gnu_hash = Some(elf::gnu_hash(in_name));
+                    gnu_hash = Some(elf::gnu_hash(redefined_name));
                 }
             }
         };
@@ -301,7 +384,9 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(
         };
         out_syms_index.push(writer.reserve_symbol_index(section));
         let name = if in_sym.st_name(endian) != 0 {
-            Some(writer.add_string(in_syms.symbol_name(endian, in_sym)?))
+            Some(writer.add_string(
+                redefine_table.get_redefined_name(in_syms.symbol_name(endian, in_sym)?),
+            ))
         } else {
             None
         };


### PR DESCRIPTION
I know that elfcopy is supposed to be a reader/writer example for ELF files, but I found it was the only tool that would let me redefine symbols in shared libraries. I think there is some serious value in having a tool that does this, especially since the way other objcopy implementations work makes it basically impossible to implement something like this easily.

If you'd like elfcopy to remain a basic copy example without command line arguments I'll understand. I originally made this a [standalone](https://github.com/amshafer/elfcopy) repo, but I'd like to contribute it back as I personally found it pretty lifesaving. Thanks and love the toolkit!

---

This commit makes elfcopy the only tool I'm aware of that will let you rename symbols in dynamic libraries. Other tools like objcopy will only perform renaming on the symbol table, but will not rename dynamic strings or recalculate the hashes/offsets that change as a result.

This works by creating a redefinition table, and handing symbol (dynamic and otherwise) to the table's get_redefined_name function before adding that string to the out_* variables. The elf binary is then regenerated from the output data (containing the renamed strings) and a valid DSO is generated.
