### PR TITLE
write: fix reserving empty section error

### DIFF
--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -216,9 +216,6 @@ impl<'a> Writer<'a> {
     ///
     /// Returns the aligned offset of the start of the range.
     pub fn reserve(&mut self, len: usize, align_start: usize) -> usize {
-        if len == 0 {
-            return self.len;
-        }
         self.len = util::align(self.len, align_start);
         let offset = self.len;
         self.len += len;


### PR DESCRIPTION
if we copy a elf with a empty section, it will return a unaligned offset.