### PR TITLE
Accept `SymbolKind::Unknown` for macho when writing an object.

### DIFF
--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -273,16 +273,8 @@ impl<'a> Object<'a> {
             //
             // Since we don't actually emit the symbol kind, we validate it here too.
             match symbol.kind {
-                SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {}
+                SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls | SymbolKind::Unknown => {}
                 SymbolKind::File | SymbolKind::Section => continue,
-                SymbolKind::Unknown => {
-                    if symbol.section != SymbolSection::Undefined {
-                        return Err(Error(format!(
-                            "defined symbol `{}` with unknown kind",
-                            symbol.name().unwrap_or(""),
-                        )));
-                    }
-                }
                 SymbolKind::Null | SymbolKind::Label => {
                     return Err(Error(format!(
                         "unimplemented symbol `{}` kind {:?}",


### PR DESCRIPTION
Apple defines a bunch of segments:sections, it is tedious to deal with all of them. Symbols from unknown sections are flagged as unknown, leading to the inability to write it using the `writer` module.

This commit removes the check that requires symbol to be known for macho.

(See https://github.com/gimli-rs/object/pull/517 for more information).