### PR TITLE
Migrate to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object"
 version = "0.30.3"
-edition = "2018"
+edition = "2021"
 exclude = ["/.github", "/testfiles"]
 keywords = ["object", "elf", "mach-o", "pe", "coff"]
 license = "Apache-2.0 OR MIT"

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -701,7 +701,6 @@ impl<'data> CompressedData<'data> {
             CompressionFormat::None => Ok(Cow::Borrowed(self.data)),
             #[cfg(feature = "compression")]
             CompressionFormat::Zlib => {
-                use core::convert::TryInto;
                 let size = self
                     .uncompressed_size
                     .try_into()


### PR DESCRIPTION
This pull request upgrades crate's Rust edition to 2021.

Note: `use core::convert::TryInto;` is removed for Rust 2021 prelude already include this trait for all code. This line of code would emit warning on Rust 2021 compiler, where `rustc` development (`rustc-codegen-ssa` depends on `object`) would not allow as it applies `-D warnings`.

Code here still emit clippy warnings after this pull request; those clippy warnings will be fixed on following pull requests.

r? @philipc