### PR TITLE
Support COFF format on RISCV RV32 and RV64

### DIFF
--- a/src/write/coff.rs
+++ b/src/write/coff.rs
@@ -311,6 +311,8 @@ impl<'a> Object<'a> {
                     Architecture::Aarch64 => coff::IMAGE_FILE_MACHINE_ARM64,
                     Architecture::I386 => coff::IMAGE_FILE_MACHINE_I386,
                     Architecture::X86_64 => coff::IMAGE_FILE_MACHINE_AMD64,
+                    Architecture::Riscv32 => coff::IMAGE_FILE_MACHINE_RISCV32,
+                    Architecture::Riscv64 => coff::IMAGE_FILE_MACHINE_RISCV64,
                     _ => {
                         return Err(Error(format!(
                             "unimplemented architecture {:?}",


### PR DESCRIPTION
This pull request adds COFF image header support for Riscv32 and Riscv64. It's useful to develop RISC-V UEFI applications and drivers where UEFI applications uses COFF image format. Future Windows on RISC-V would also benefit from this pull request.

This commit only adds architecture header support, because Microsoft does not provide architecture specific COFF relocation type definitions for RISC-V architecture. We leave it unsupported and RISC-V Windows/UEFI applications should not use relocations by now. After Microsoft provide relocation types, we can have it supported in `object` crate at that time.

Note: COFF has RISCV128 machine support, but current `object` crate does not have `Architecture::Riscv128` yet. Riscv128 support should be added after enum Architecture has a Riscv128 field.