### PR TITLE
elf: improve attributes section support

### DIFF
--- a/crates/examples/testfiles/elf/base-mips64el.o.readobj
+++ b/crates/examples/testfiles/elf/base-mips64el.o.readobj
@@ -245,6 +245,15 @@ SectionHeader {
     Info: 0
     AddressAlign: 0x1
     EntrySize: 0x0
+    Attributes {
+        Version: 65
+        Subsection {
+            Vendor: "gnu"
+            Subsubsection {
+                Tag: Tag_File (0x1)
+            }
+        }
+    }
 }
 SectionHeader {
     Index: 13

--- a/crates/examples/testfiles/elf/base-mips64el.readobj
+++ b/crates/examples/testfiles/elf/base-mips64el.readobj
@@ -959,6 +959,15 @@ SectionHeader {
     Info: 0
     AddressAlign: 0x1
     EntrySize: 0x0
+    Attributes {
+        Version: 65
+        Subsection {
+            Vendor: "gnu"
+            Subsubsection {
+                Tag: Tag_File (0x1)
+            }
+        }
+    }
 }
 SectionHeader {
     Index: 28

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6724,6 +6724,13 @@ pub const R_XTENSA_NDIFF16: u32 = 61;
 #[allow(missing_docs)]
 pub const R_XTENSA_NDIFF32: u32 = 62;
 
+#[allow(missing_docs, non_upper_case_globals)]
+pub const Tag_File: u8 = 1;
+#[allow(missing_docs, non_upper_case_globals)]
+pub const Tag_Section: u8 = 2;
+#[allow(missing_docs, non_upper_case_globals)]
+pub const Tag_Symbol: u8 = 3;
+
 unsafe_impl_endian_pod!(
     FileHeader32,
     FileHeader64,

--- a/src/read/elf/attributes.rs
+++ b/src/read/elf/attributes.rs
@@ -1,109 +1,303 @@
+use core::convert::TryInto;
+
+use crate::elf;
 use crate::endian;
-use crate::read::{Bytes, ReadError, Result};
+use crate::read::{Bytes, Error, ReadError, Result};
 
 use super::FileHeader;
 
-/// An iterator over the section entries in an ELF `SHT_GNU_attributes` section.
+/// An ELF attributes section.
+///
+/// This may be a GNU attributes section, or an architecture specific attributes section.
+///
+/// An attributes section contains a series of subsections.
 #[derive(Debug, Clone)]
-pub struct AttribSubsectionIterator<'data, Elf: FileHeader> {
+pub struct AttributesSection<'data, Elf: FileHeader> {
+    endian: Elf::Endian,
+    version: u8,
+    data: Bytes<'data>,
+}
+
+impl<'data, Elf: FileHeader> AttributesSection<'data, Elf> {
+    /// Parse an ELF attributes section given the section data.
+    pub fn new(endian: Elf::Endian, data: &'data [u8]) -> Result<Self> {
+        let mut data = Bytes(data);
+
+        // Skip the version field that is one byte long.
+        let version = *data
+            .read::<u8>()
+            .read_error("Invalid ELF attributes section offset or size")?;
+
+        Ok(AttributesSection {
+            endian,
+            version,
+            data,
+        })
+    }
+
+    /// Return the version of the attributes section.
+    pub fn version(&self) -> u8 {
+        self.version
+    }
+
+    /// Return an iterator over the subsections.
+    pub fn subsections(&self) -> Result<AttributesSubsectionIterator<'data, Elf>> {
+        // There is currently only one format version.
+        if self.version != b'A' {
+            return Err(Error("Unsupported ELF attributes section version"));
+        }
+
+        Ok(AttributesSubsectionIterator {
+            endian: self.endian,
+            data: self.data,
+        })
+    }
+}
+
+/// An iterator over the subsections in an ELF attributes section.
+#[derive(Debug, Clone)]
+pub struct AttributesSubsectionIterator<'data, Elf: FileHeader> {
     endian: Elf::Endian,
     data: Bytes<'data>,
 }
 
-impl<'data, Elf: FileHeader> AttribSubsectionIterator<'data, Elf> {
-    pub(super) fn new(endian: Elf::Endian, data: Bytes<'data>) -> Self {
-        AttribSubsectionIterator { endian, data: data }
-    }
-
-    /// Return the next Vendor attribute section
-    pub fn next(
-        &mut self,
-    ) -> Result<Option<(&'data [u8], AttribSubSubsectionIterator<'data, Elf>)>> {
+impl<'data, Elf: FileHeader> AttributesSubsectionIterator<'data, Elf> {
+    /// Return the next subsection.
+    pub fn next(&mut self) -> Result<Option<AttributesSubsection<'data, Elf>>> {
         if self.data.is_empty() {
             return Ok(None);
         }
 
-        // First read the section length
+        let result = self.parse();
+        if result.is_err() {
+            self.data = Bytes(&[]);
+        }
+        result
+    }
+
+    fn parse(&mut self) -> Result<Option<AttributesSubsection<'data, Elf>>> {
+        // First read the subsection length.
         let mut data = self.data;
-        let section_length = data
+        let length = data
             .read::<endian::U32Bytes<Elf::Endian>>()
-            .read_error("ELF GNU attributes vendor section is too short")?
+            .read_error("ELF attributes section is too short")?
             .get(self.endian);
 
-        // Now read the entire section
-        let mut section = self
+        // Now read the entire subsection, updating self.data.
+        let mut data = self
             .data
-            .read_bytes(section_length as usize)
-            .read_error("ELF GNU attributes section incorrectly sized")?;
-        // Skip the section length field
-        section
-            .skip(core::mem::size_of::<endian::U32<Elf::Endian>>())
-            .read_error("ELF GNU attributes vendor section is too short")?;
+            .read_bytes(length as usize)
+            .read_error("Invalid ELF attributes subsection length")?;
+        // Skip the subsection length field.
+        data.skip(4)
+            .read_error("Invalid ELF attributes subsection length")?;
 
-        let vendor_name = section
+        let vendor = data
             .read_string()
-            .read_error("ELF GNU attributes vendor section is too short")?;
+            .read_error("Invalid ELF attributes vendor")?;
 
-        // Pass the remainder of this section to the tag iterator
-        let tags = AttribSubSubsectionIterator::new(self.endian, section);
-
-        Ok(Some((vendor_name, tags)))
+        Ok(Some(AttributesSubsection {
+            endian: self.endian,
+            length,
+            vendor,
+            data,
+        }))
     }
 }
 
-/// An iterator over the attribute tags in a GNU attributes section
+/// A subsection in an ELF attributes section.
+///
+/// A subsection is identified by a vendor name.  It contains a series of sub-subsections.
 #[derive(Debug, Clone)]
-pub struct AttribSubSubsectionIterator<'data, Elf: FileHeader> {
+pub struct AttributesSubsection<'data, Elf: FileHeader> {
+    endian: Elf::Endian,
+    length: u32,
+    vendor: &'data [u8],
+    data: Bytes<'data>,
+}
+
+impl<'data, Elf: FileHeader> AttributesSubsection<'data, Elf> {
+    /// Return the length of the attributes subsection.
+    pub fn length(&self) -> u32 {
+        self.length
+    }
+
+    /// Return the vendor name of the attributes subsection.
+    pub fn vendor(&self) -> &'data [u8] {
+        self.vendor
+    }
+
+    /// Return an iterator over the sub-subsections.
+    pub fn subsubsections(&self) -> AttributesSubsubsectionIterator<'data, Elf> {
+        AttributesSubsubsectionIterator {
+            endian: self.endian,
+            data: self.data,
+        }
+    }
+}
+
+/// An iterator over the sub-subsections in an ELF attributes section.
+#[derive(Debug, Clone)]
+pub struct AttributesSubsubsectionIterator<'data, Elf: FileHeader> {
     endian: Elf::Endian,
     data: Bytes<'data>,
 }
 
-impl<'data, Elf: FileHeader> AttribSubSubsectionIterator<'data, Elf> {
-    pub(super) fn new(endian: Elf::Endian, data: Bytes<'data>) -> Self {
-        AttribSubSubsectionIterator { endian, data: data }
-    }
-
-    /// Return the next tag.
-    ///
-    /// The format of attributes looks like this:
-    /// ```text
-    /// [ <file-tag> <size> <attribute>*
-    /// | <section-tag> <size> <section-number>* 0 <attribute>*
-    /// | <symbol-tag> <size> <symbol-number>* 0 <attribute>*
-    /// ]+
-    /// ```
-    /// This iterator returns the (tag, data) pair, allowing the user to access the raw data for
-    /// the tags. The data is an array of attributes, each of which is an attribute tag folowed by
-    /// either a uleb128 encoded integer or a NULL terminated string
-    pub fn next(&mut self) -> Result<Option<(u8, &'data [u8])>> {
+impl<'data, Elf: FileHeader> AttributesSubsubsectionIterator<'data, Elf> {
+    /// Return the next sub-subsection.
+    pub fn next(&mut self) -> Result<Option<AttributesSubsubsection<'data>>> {
         if self.data.is_empty() {
             return Ok(None);
         }
 
-        let tag = self
-            .data
+        let result = self.parse();
+        if result.is_err() {
+            self.data = Bytes(&[]);
+        }
+        result
+    }
+
+    fn parse(&mut self) -> Result<Option<AttributesSubsubsection<'data>>> {
+        // The format of a sub-section looks like this:
+        //
+        // <file-tag> <size> <attribute>*
+        // | <section-tag> <size> <section-number>* 0 <attribute>*
+        // | <symbol-tag> <size> <symbol-number>* 0 <attribute>*
+        let mut data = self.data;
+        let tag = *data
             .read::<u8>()
-            .read_error("GNU Attributes tag not correctly sized")?;
-
-        let tag_length = self
-            .data
+            .read_error("ELF attributes subsection is too short")?;
+        let length = data
             .read::<endian::U32Bytes<Elf::Endian>>()
-            .read_error("ELF GNU attributes vendor section is too short")?
-            .get(self.endian) as usize;
+            .read_error("ELF attributes subsection is too short")?
+            .get(self.endian);
 
-        // Subtract the size of our tag and length fields here
-        let tag_size = tag_length
-            .checked_sub(core::mem::size_of::<endian::U32<Elf::Endian>>())
-            .ok_or(())
-            .read_error("GNU attriutes tag size is too short")?
-            .checked_sub(1)
-            .ok_or(())
-            .read_error("GNU attriutes tag size is too short")?;
-
-        let tag_data = self
+        // Now read the entire sub-subsection, updating self.data.
+        let mut data = self
             .data
-            .read_slice(tag_size)
-            .read_error("GNU attributes tag data does not match size requested")?;
-        return Ok(Some((*tag, tag_data)));
+            .read_bytes(length as usize)
+            .read_error("Invalid ELF attributes sub-subsection length")?;
+        // Skip the tag and sub-subsection size field.
+        data.skip(1 + 4)
+            .read_error("Invalid ELF attributes sub-subsection length")?;
+
+        let indices = if tag == elf::Tag_Section || tag == elf::Tag_Symbol {
+            data.read_string()
+                .map(Bytes)
+                .read_error("Missing ELF attributes sub-subsection indices")?
+        } else if tag == elf::Tag_File {
+            Bytes(&[])
+        } else {
+            return Err(Error("Unimplemented ELF attributes sub-subsection tag"));
+        };
+
+        Ok(Some(AttributesSubsubsection {
+            tag,
+            length,
+            indices,
+            data,
+        }))
+    }
+}
+
+/// A sub-subsection in an ELF attributes section.
+///
+/// A sub-subsection is identified by a tag.  It contains an optional series of indices,
+/// followed by a series of attributes.
+#[derive(Debug, Clone)]
+pub struct AttributesSubsubsection<'data> {
+    tag: u8,
+    length: u32,
+    indices: Bytes<'data>,
+    data: Bytes<'data>,
+}
+
+impl<'data> AttributesSubsubsection<'data> {
+    /// Return the tag of the attributes sub-subsection.
+    pub fn tag(&self) -> u8 {
+        self.tag
+    }
+
+    /// Return the length of the attributes sub-subsection.
+    pub fn length(&self) -> u32 {
+        self.length
+    }
+
+    /// Return the data containing the indices.
+    pub fn indices_data(&self) -> &'data [u8] {
+        self.indices.0
+    }
+
+    /// Return the indices.
+    ///
+    /// This will be section indices if the tag is `Tag_Section`,
+    /// or symbol indices if the tag is `Tag_Symbol`,
+    /// and otherwise it will be empty.
+    pub fn indices(&self) -> AttributeIndexIterator<'data> {
+        AttributeIndexIterator { data: self.indices }
+    }
+
+    /// Return the data containing the attributes.
+    pub fn attributes_data(&self) -> &'data [u8] {
+        self.data.0
+    }
+
+    /// Return a parser for the data containing the attributes.
+    pub fn attributes(&self) -> AttributeReader<'data> {
+        AttributeReader { data: self.data }
+    }
+}
+
+/// An iterator over the indices in a sub-subsection in an ELF attributes section.
+#[derive(Debug, Clone)]
+pub struct AttributeIndexIterator<'data> {
+    data: Bytes<'data>,
+}
+
+impl<'data> AttributeIndexIterator<'data> {
+    /// Parse the next index.
+    pub fn next(&mut self) -> Result<Option<u32>> {
+        if self.data.is_empty() {
+            return Ok(None);
+        }
+        let err = "Invalid ELF attribute index";
+        self.data
+            .read_uleb128()
+            .read_error(err)?
+            .try_into()
+            .map_err(|_| ())
+            .read_error(err)
+            .map(Some)
+    }
+}
+
+/// A parser for the attributes in a sub-subsection in an ELF attributes section.
+///
+/// The parser relies on the caller to know the format of the data for each attribute tag.
+#[derive(Debug, Clone)]
+pub struct AttributeReader<'data> {
+    data: Bytes<'data>,
+}
+
+impl<'data> AttributeReader<'data> {
+    /// Parse a tag.
+    pub fn read_tag(&mut self) -> Result<Option<u64>> {
+        if self.data.is_empty() {
+            return Ok(None);
+        }
+        let err = "Invalid ELF attribute tag";
+        self.data.read_uleb128().read_error(err).map(Some)
+    }
+
+    /// Parse an integer value.
+    pub fn read_integer(&mut self) -> Result<u64> {
+        let err = "Invalid ELF attribute integer value";
+        self.data.read_uleb128().read_error(err)
+    }
+
+    /// Parse a string value.
+    pub fn read_string(&mut self) -> Result<&'data [u8]> {
+        let err = "Invalid ELF attribute string value";
+        self.data.read_string().read_error(err)
     }
 }


### PR DESCRIPTION
- read: add iterator for section and symbol indices
- read: add AttributeReader for parsing attribute data
- write: add AttributesWriter for building the attributes section
- elfcopy: convert section and symbol indices
- elfcopy: handle attributes sections in object files
- readobj: print some contents of attributes sections