### PR TITLE
Update crate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # `object`
 
 The `object` crate provides a unified interface to working with object files
-across platforms. It supports reading object files and executable files,
-and writing COFF/ELF/Mach-O object files and ELF/PE executable files.
+across platforms. It supports reading relocatable object files and executable files,
+and writing COFF/ELF/Mach-O/XCOFF relocatable object files and ELF/PE executable files.
 
 For reading files, it provides multiple levels of support:
 
@@ -11,7 +11,7 @@ For reading files, it provides multiple levels of support:
 * a higher level unified API for accessing common features of object files, such
   as sections and symbols ([example](crates/examples/src/objdump.rs))
 
-Supported file formats: ELF, Mach-O, Windows PE/COFF, Wasm, and Unix archive.
+Supported file formats: ELF, Mach-O, Windows PE/COFF, Wasm, XCOFF, and Unix archive.
 
 ## Example for unified read API
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 //! # `object`
 //!
 //! The `object` crate provides a unified interface to working with object files
-//! across platforms. It supports reading object files and executable files,
-//! and writing object files and some executable files.
+//! across platforms. It supports reading relocatable object files and executable files,
+//! and writing relocatable object files and some executable files.
 //!
 //! ## Raw struct definitions
 //!
-//! Raw structs are defined for: [ELF](elf), [Mach-O](macho), [PE/COFF](pe), [archive].
+//! Raw structs are defined for: [ELF](elf), [Mach-O](macho), [PE/COFF](pe),
+//! [XCOFF](xcoff), [archive].
 //! Types and traits for zerocopy support are defined in [pod] and [endian].
 //!
 //! ## Unified read API
@@ -14,7 +15,8 @@
 //! The [read::Object] trait defines the unified interface. This trait is implemented
 //! by [read::File], which allows reading any file format, as well as implementations
 //! for each file format: [ELF](read::elf::ElfFile), [Mach-O](read::macho::MachOFile),
-//! [COFF](read::coff::CoffFile), [PE](read::pe::PeFile), [Wasm](read::wasm::WasmFile).
+//! [COFF](read::coff::CoffFile), [PE](read::pe::PeFile), [Wasm](read::wasm::WasmFile),
+//! [XCOFF](read::xcoff::XcoffFile).
 //!
 //! ## Low level read API
 //!
@@ -24,7 +26,8 @@
 //!
 //! ## Unified write API
 //!
-//! [write::Object] allows building a COFF/ELF/Mach-O object and then writing it out.
+//! [write::Object] allows building a COFF/ELF/Mach-O/XCOFF relocatable object file and
+//! then writing it out.
 //!
 //! ## Low level executable writers
 //!

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -57,7 +57,7 @@ impl error::Error for Error {}
 /// The result type used within the write module.
 pub type Result<T> = result::Result<T, Error>;
 
-/// A writable object file.
+/// A writable relocatable object file.
 #[derive(Debug)]
 pub struct Object<'a> {
     format: BinaryFormat,


### PR DESCRIPTION
Clarify that write::Object is only for relocatable object files.

Add XCOFF where appropriate.

Closes #478 