### PR TITLE
Support reading PE data directly from memory (sections are page aligned)

### DIFF
--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -253,9 +253,9 @@ impl<'data, R: ReadRef<'data>> File<'data, R> {
             #[cfg(feature = "wasm")]
             FileKind::Wasm => FileInternal::Wasm(wasm::WasmFile::parse(data)?),
             #[cfg(feature = "pe")]
-            FileKind::Pe32 => FileInternal::Pe32(pe::PeFile32::parse(data)?),
+            FileKind::Pe32 => FileInternal::Pe32(pe::PeFile32::parse(data, false)?),
             #[cfg(feature = "pe")]
-            FileKind::Pe64 => FileInternal::Pe64(pe::PeFile64::parse(data)?),
+            FileKind::Pe64 => FileInternal::Pe64(pe::PeFile64::parse(data, false)?),
             #[cfg(feature = "coff")]
             FileKind::Coff => FileInternal::Coff(coff::CoffFile::parse(data)?),
             #[cfg(feature = "coff")]

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -259,7 +259,7 @@ pub trait CoffHeader: Debug + Pod {
         data: R,
         offset: u64,
     ) -> read::Result<SectionTable<'data>> {
-        SectionTable::parse(self, data, offset)
+        SectionTable::parse(self, data, offset, false)
     }
 
     /// Read the symbol table and string table.

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -15,6 +15,7 @@ use super::{CoffFile, CoffHeader, CoffRelocationIterator};
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SectionTable<'data> {
     sections: &'data [pe::ImageSectionHeader],
+    pub(crate) va_space: bool,
 }
 
 impl<'data> SectionTable<'data> {
@@ -26,11 +27,12 @@ impl<'data> SectionTable<'data> {
         header: &Coff,
         data: R,
         offset: u64,
+        va_space: bool,
     ) -> Result<Self> {
         let sections = data
             .read_slice_at(offset, header.number_of_sections() as usize)
             .read_error("Invalid COFF/PE section headers")?;
-        Ok(SectionTable { sections })
+        Ok(SectionTable { sections, va_space })
     }
 
     /// Iterate over the section headers.

--- a/src/read/pe/data_directory.rs
+++ b/src/read/pe/data_directory.rs
@@ -170,7 +170,7 @@ impl pe::ImageDataDirectory {
         (self.virtual_address.get(LE), self.size.get(LE))
     }
 
-    /// Return the file offset and size of this directory entry.
+    /// Return the offset and size of this directory entry.
     ///
     /// This function has some limitations:
     /// - It requires that the data is contained in a single section.
@@ -178,9 +178,9 @@ impl pe::ImageDataDirectory {
     /// not desirable for all data directories.
     /// - It uses the `virtual_address` of the directory entry as an address,
     /// which is not valid for `IMAGE_DIRECTORY_ENTRY_SECURITY`.
-    pub fn file_range(&self, sections: &SectionTable<'_>) -> Result<(u32, u32)> {
+    pub fn range(&self, sections: &SectionTable<'_>) -> Result<(u32, u32)> {
         let (offset, section_size) = sections
-            .pe_file_range_at(self.virtual_address.get(LE))
+            .pe_range_at(self.virtual_address.get(LE))
             .read_error("Invalid data dir virtual address")?;
         let size = self.size.get(LE);
         if size > section_size {

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -40,12 +40,12 @@ where
     Pe: ImageNtHeaders,
     R: ReadRef<'data>,
 {
-    /// Parse the raw PE file data.
-    pub fn parse(data: R) -> Result<Self> {
+    /// Parse the raw PE data.
+    pub fn parse(data: R, va_space: bool) -> Result<Self> {
         let dos_header = pe::ImageDosHeader::parse(data)?;
         let mut offset = dos_header.nt_headers_offset().into();
         let (nt_headers, data_directories) = Pe::parse(data, &mut offset)?;
-        let sections = nt_headers.sections(data, offset)?;
+        let sections = nt_headers.sections(data, offset, va_space)?;
         let coff_symbols = nt_headers.symbols(data);
         let image_base = nt_headers.optional_header().image_base();
 
@@ -613,8 +613,9 @@ pub trait ImageNtHeaders: Debug + Pod {
         &self,
         data: R,
         offset: u64,
+        va_space: bool,
     ) -> read::Result<SectionTable<'data>> {
-        SectionTable::parse(self.file_header(), data, offset)
+        SectionTable::parse(self.file_header(), data, offset, va_space)
     }
 
     /// Read the COFF symbol table and string table.


### PR DESCRIPTION
At the moment its not possible to load PE data from memory, because sections are located at the virtual_address, not pointer_to_raw_data because of page alignment.

This pr unifies file "address space" and virtual address space, by adding a bool to SectionTable which specifies the location to use.