### PR TITLE
Remove Pod bounds on traits

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -21,6 +21,7 @@ pub(super) fn print_elf64(p: &mut Printer<'_>, data: &[u8]) {
 fn print_elf<Elf: FileHeader<Endian = Endianness>>(p: &mut Printer<'_>, elf: &Elf, data: &[u8])
 where
     Elf::CompressionHeader: Pod,
+    Elf::Dyn: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);
@@ -115,7 +116,9 @@ fn print_program_headers<Elf: FileHeader>(
     data: &[u8],
     elf: &Elf,
     segments: &[Elf::ProgramHeader],
-) {
+) where
+    Elf::Dyn: Pod,
+{
     for segment in segments {
         p.group("ProgramHeader", |p| {
             let proc = match elf.e_machine(endian) {
@@ -191,7 +194,9 @@ fn print_segment_dynamic<Elf: FileHeader>(
     elf: &Elf,
     segments: &[Elf::ProgramHeader],
     segment: &Elf::ProgramHeader,
-) {
+) where
+    Elf::Dyn: Pod,
+{
     if let Some(Some(dynamic)) = segment.dynamic(endian, data).print_err(p) {
         // TODO: add a helper API for this and the other mandatory tags?
         let mut strtab = 0;
@@ -225,6 +230,7 @@ fn print_section_headers<Elf: FileHeader>(
     sections: &SectionTable<Elf>,
 ) where
     Elf::CompressionHeader: Pod,
+    Elf::Dyn: Pod,
 {
     for (index, section) in sections.iter().enumerate() {
         let index = SectionIndex(index);
@@ -518,7 +524,9 @@ fn print_section_dynamic<Elf: FileHeader>(
     elf: &Elf,
     sections: &SectionTable<Elf>,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::Dyn: Pod,
+{
     if let Some(Some((dynamic, index))) = section.dynamic(endian, data).print_err(p) {
         let strings = sections.strings(endian, data, index).unwrap_or_default();
         print_dynamic(p, endian, elf, dynamic, strings);

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -22,6 +22,7 @@ fn print_elf<Elf: FileHeader<Endian = Endianness>>(p: &mut Printer<'_>, elf: &El
 where
     Elf::CompressionHeader: Pod,
     Elf::Dyn: Pod,
+    Elf::NoteHeader: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);
@@ -118,6 +119,7 @@ fn print_program_headers<Elf: FileHeader>(
     segments: &[Elf::ProgramHeader],
 ) where
     Elf::Dyn: Pod,
+    Elf::NoteHeader: Pod,
 {
     for segment in segments {
         p.group("ProgramHeader", |p| {
@@ -181,7 +183,9 @@ fn print_segment_notes<Elf: FileHeader>(
     data: &[u8],
     elf: &Elf,
     segment: &Elf::ProgramHeader,
-) {
+) where
+    Elf::NoteHeader: Pod,
+{
     if let Some(Some(notes)) = segment.notes(endian, data).print_err(p) {
         print_notes(p, endian, elf, notes);
     }
@@ -231,6 +235,7 @@ fn print_section_headers<Elf: FileHeader>(
 ) where
     Elf::CompressionHeader: Pod,
     Elf::Dyn: Pod,
+    Elf::NoteHeader: Pod,
 {
     for (index, section) in sections.iter().enumerate() {
         let index = SectionIndex(index);
@@ -511,7 +516,9 @@ fn print_section_notes<Elf: FileHeader>(
     data: &[u8],
     elf: &Elf,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::NoteHeader: Pod,
+{
     if let Some(Some(notes)) = section.notes(endian, data).print_err(p) {
         print_notes(p, endian, elf, notes);
     }
@@ -569,7 +576,9 @@ fn print_notes<Elf: FileHeader>(
     endian: Elf::Endian,
     elf: &Elf,
     mut notes: NoteIterator<Elf>,
-) {
+) where
+    Elf::NoteHeader: Pod,
+{
     while let Some(Some(note)) = notes.next().print_err(p) {
         p.group("Note", |p| {
             let name = note.name();

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -1,5 +1,6 @@
 use super::*;
 use object::elf::*;
+use object::pod::Pod;
 use object::read::elf::*;
 use object::read::{SectionIndex, StringTable};
 
@@ -17,7 +18,10 @@ pub(super) fn print_elf64(p: &mut Printer<'_>, data: &[u8]) {
     }
 }
 
-fn print_elf<Elf: FileHeader<Endian = Endianness>>(p: &mut Printer<'_>, elf: &Elf, data: &[u8]) {
+fn print_elf<Elf: FileHeader<Endian = Endianness>>(p: &mut Printer<'_>, elf: &Elf, data: &[u8])
+where
+    Elf::CompressionHeader: Pod,
+{
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);
         if let Some(segments) = elf.program_headers(endian, data).print_err(p) {
@@ -219,7 +223,9 @@ fn print_section_headers<Elf: FileHeader>(
     data: &[u8],
     elf: &Elf,
     sections: &SectionTable<Elf>,
-) {
+) where
+    Elf::CompressionHeader: Pod,
+{
     for (index, section) in sections.iter().enumerate() {
         let index = SectionIndex(index);
         p.group("SectionHeader", |p| {
@@ -526,7 +532,9 @@ fn print_section_group<Elf: FileHeader>(
     _elf: &Elf,
     sections: &SectionTable<Elf>,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::CompressionHeader: Pod,
+{
     if let Some(Some((flag, members))) = section.group(endian, data).print_err(p) {
         p.field_enum("GroupFlag", flag, FLAGS_GRP);
         p.group("GroupSections", |p| {

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -24,6 +24,7 @@ where
     Elf::Dyn: Pod,
     Elf::NoteHeader: Pod,
     Elf::Rel: Pod,
+    Elf::Rela: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);
@@ -238,6 +239,7 @@ fn print_section_headers<Elf: FileHeader>(
     Elf::Dyn: Pod,
     Elf::NoteHeader: Pod,
     Elf::Rel: Pod,
+    Elf::Rela: Pod,
 {
     for (index, section) in sections.iter().enumerate() {
         let index = SectionIndex(index);
@@ -440,7 +442,9 @@ fn print_section_rela<Elf: FileHeader>(
     elf: &Elf,
     sections: &SectionTable<Elf>,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::Rela: Pod,
+{
     if let Some(Some((relocations, link))) = section.rela(endian, data).print_err(p) {
         let symbols = sections
             .symbol_table_by_index(endian, data, link)

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -27,6 +27,7 @@ where
     Elf::Rela: Pod,
     Elf::SectionHeader: Pod,
     Elf::ProgramHeader: Pod,
+    Elf::Sym: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);
@@ -242,6 +243,7 @@ fn print_section_headers<Elf: FileHeader>(
     Elf::NoteHeader: Pod,
     Elf::Rel: Pod,
     Elf::Rela: Pod,
+    Elf::Sym: Pod,
 {
     for (index, section) in sections.iter().enumerate() {
         let index = SectionIndex(index);
@@ -329,7 +331,9 @@ fn print_section_symbols<Elf: FileHeader>(
     sections: &SectionTable<Elf>,
     section_index: SectionIndex,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::Sym: Pod,
+{
     if let Some(Some(symbols)) = section
         .symbols(endian, data, sections, section_index)
         .print_err(p)
@@ -420,6 +424,7 @@ fn print_section_rel<Elf: FileHeader>(
     section: &Elf::SectionHeader,
 ) where
     Elf::Rel: Pod,
+    Elf::Sym: Pod,
 {
     if let Some(Some((relocations, link))) = section.rel(endian, data).print_err(p) {
         let symbols = sections
@@ -446,6 +451,7 @@ fn print_section_rela<Elf: FileHeader>(
     section: &Elf::SectionHeader,
 ) where
     Elf::Rela: Pod,
+    Elf::Sym: Pod,
 {
     if let Some(Some((relocations, link))) = section.rela(endian, data).print_err(p) {
         let symbols = sections
@@ -865,7 +871,9 @@ fn print_gnu_versym<Elf: FileHeader>(
     _elf: &Elf,
     sections: &SectionTable<Elf>,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::Sym: Pod,
+{
     if let Some(Some((syms, _link))) = section.gnu_versym(endian, data).print_err(p) {
         let versions = sections.versions(endian, data).print_err(p).flatten();
         for (index, sym) in syms.iter().enumerate() {

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -25,6 +25,7 @@ where
     Elf::NoteHeader: Pod,
     Elf::Rel: Pod,
     Elf::Rela: Pod,
+    Elf::SectionHeader: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -23,6 +23,7 @@ where
     Elf::CompressionHeader: Pod,
     Elf::Dyn: Pod,
     Elf::NoteHeader: Pod,
+    Elf::Rel: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);
@@ -236,6 +237,7 @@ fn print_section_headers<Elf: FileHeader>(
     Elf::CompressionHeader: Pod,
     Elf::Dyn: Pod,
     Elf::NoteHeader: Pod,
+    Elf::Rel: Pod,
 {
     for (index, section) in sections.iter().enumerate() {
         let index = SectionIndex(index);
@@ -412,7 +414,9 @@ fn print_section_rel<Elf: FileHeader>(
     elf: &Elf,
     sections: &SectionTable<Elf>,
     section: &Elf::SectionHeader,
-) {
+) where
+    Elf::Rel: Pod,
+{
     if let Some(Some((relocations, link))) = section.rel(endian, data).print_err(p) {
         let symbols = sections
             .symbol_table_by_index(endian, data, link)

--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -26,6 +26,7 @@ where
     Elf::Rel: Pod,
     Elf::Rela: Pod,
     Elf::SectionHeader: Pod,
+    Elf::ProgramHeader: Pod,
 {
     if let Some(endian) = elf.endian().print_err(p) {
         print_file_header(p, endian, elf);

--- a/crates/examples/src/readobj/macho.rs
+++ b/crates/examples/src/readobj/macho.rs
@@ -155,7 +155,9 @@ fn print_macho<Mach: MachHeader<Endian = Endianness>>(
     header: &Mach,
     data: &[u8],
     offset: u64,
-) {
+) where
+    Mach::Nlist: Pod,
+{
     if let Some(endian) = header.endian().print_err(p) {
         let mut state = MachState::default();
         print_mach_header(p, endian, header);
@@ -185,7 +187,9 @@ fn print_load_command<Mach: MachHeader>(
     header: &Mach,
     command: LoadCommandData<Mach::Endian>,
     state: &mut MachState,
-) {
+) where
+    Mach::Nlist: Pod,
+{
     if let Some(variant) = command.variant().print_err(p) {
         match variant {
             LoadCommandVariant::Segment32(segment, section_data) => {
@@ -628,7 +632,9 @@ fn print_symtab<Mach: MachHeader>(
     endian: Mach::Endian,
     data: &[u8],
     symtab: &SymtabCommand<Mach::Endian>,
-) {
+) where
+    Mach::Nlist: Pod,
+{
     p.group("SymtabCommand", |p| {
         p.field_enum("Cmd", symtab.cmd.get(endian), FLAGS_LC);
         p.field_hex("CmdSize", symtab.cmdsize.get(endian));

--- a/crates/examples/src/readobj/macho.rs
+++ b/crates/examples/src/readobj/macho.rs
@@ -1,5 +1,6 @@
 use super::*;
 use object::macho::*;
+use object::pod::Pod;
 use object::read::macho::*;
 use object::BigEndian;
 
@@ -529,7 +530,9 @@ fn print_segment<S: Segment>(
     segment: &S,
     section_data: &[u8],
     state: &mut MachState,
-) {
+) where
+    S::Section: Pod,
+{
     p.group("SegmentCommand", |p| {
         p.field_enum("Cmd", segment.cmd(endian), FLAGS_LC);
         p.field_hex("CmdSize", segment.cmdsize(endian));

--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -1,5 +1,6 @@
 use super::*;
 use object::pe::*;
+use object::pod::Pod;
 use object::read::coff::ImageSymbol as _;
 use object::read::coff::*;
 use object::read::pe::*;
@@ -504,7 +505,9 @@ fn print_sections<'data, Coff: CoffHeader>(
     machine: u16,
     symbols: Option<&SymbolTable<'data, &'data [u8], Coff>>,
     sections: &SectionTable,
-) {
+) where
+    Coff::ImageSymbol: Pod,
+{
     for (index, section) in sections.iter().enumerate() {
         p.group("ImageSectionHeader", |p| {
             p.field("Index", index + 1);
@@ -602,7 +605,9 @@ fn print_symbols<'data, Coff: CoffHeader>(
     p: &mut Printer<'_>,
     sections: Option<&SectionTable>,
     symbols: &SymbolTable<'data, &'data [u8], Coff>,
-) {
+) where
+    Coff::ImageSymbol: Pod,
+{
     for (index, symbol) in symbols.iter() {
         p.group("ImageSymbol", |p| {
             p.field("Index", index);

--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -49,7 +49,7 @@ pub(super) fn print_pe64(p: &mut Printer<'_>, data: &[u8]) {
     print_pe::<ImageNtHeaders64>(p, data);
 }
 
-fn print_pe<Pe: ImageNtHeaders>(p: &mut Printer<'_>, data: &[u8]) {
+fn print_pe<Pe: ImageNtHeaders + Pod>(p: &mut Printer<'_>, data: &[u8]) {
     if let Some(dos_header) = ImageDosHeader::parse(data).print_err(p) {
         p.group("ImageDosHeader", |p| {
             p.field_hex("Magic", dos_header.e_magic.get(LE));

--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -49,7 +49,10 @@ pub(super) fn print_pe64(p: &mut Printer<'_>, data: &[u8]) {
     print_pe::<ImageNtHeaders64>(p, data);
 }
 
-fn print_pe<Pe: ImageNtHeaders + Pod>(p: &mut Printer<'_>, data: &[u8]) {
+fn print_pe<Pe: ImageNtHeaders + Pod>(p: &mut Printer<'_>, data: &[u8])
+where
+    Pe::ImageThunkData: Pod,
+{
     if let Some(dos_header) = ImageDosHeader::parse(data).print_err(p) {
         p.group("ImageDosHeader", |p| {
             p.field_hex("Magic", dos_header.e_magic.get(LE));
@@ -303,7 +306,10 @@ fn print_import_dir<Pe: ImageNtHeaders>(
     data: &[u8],
     sections: &SectionTable,
     data_directories: &DataDirectories,
-) -> Option<()> {
+) -> Option<()>
+where
+    Pe::ImageThunkData: Pod,
+{
     let import_table = data_directories
         .import_table(data, sections)
         .print_err(p)??;
@@ -371,7 +377,10 @@ fn print_delay_load_dir<Pe: ImageNtHeaders>(
     data: &[u8],
     sections: &SectionTable,
     data_directories: &DataDirectories,
-) -> Option<()> {
+) -> Option<()>
+where
+    Pe::ImageThunkData: Pod,
+{
     let import_table = data_directories
         .delay_load_import_table(data, sections)
         .print_err(p)??;

--- a/src/read/coff/comdat.rs
+++ b/src/read/coff/comdat.rs
@@ -2,6 +2,7 @@ use core::str;
 
 use crate::endian::LittleEndian as LE;
 use crate::pe;
+use crate::pod::Pod;
 use crate::read::{
     self, ComdatKind, ObjectComdat, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
 };
@@ -26,6 +27,8 @@ pub struct CoffComdatIterator<
 
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> Iterator
     for CoffComdatIterator<'data, 'file, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
 {
     type Item = CoffComdat<'data, 'file, R, Coff>;
 
@@ -59,7 +62,10 @@ pub struct CoffComdat<
     selection: u8,
 }
 
-impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> CoffComdat<'data, 'file, R, Coff> {
+impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> CoffComdat<'data, 'file, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
+{
     fn parse(
         file: &'file CoffFile<'data, R, Coff>,
         section_symbol: &'data Coff::ImageSymbol,
@@ -105,6 +111,8 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> read::private::Sealed
 
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> ObjectComdat<'data>
     for CoffComdat<'data, 'file, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
 {
     type SectionIterator = CoffComdatSectionIterator<'data, 'file, R, Coff>;
 
@@ -169,6 +177,8 @@ pub struct CoffComdatSectionIterator<
 
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> Iterator
     for CoffComdatSectionIterator<'data, 'file, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
 {
     type Item = SectionIndex;
 

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -227,7 +227,7 @@ pub fn anon_object_class_id<'data, R: ReadRef<'data>>(data: R) -> Result<pe::Cls
 
 /// A trait for generic access to `ImageFileHeader` and `AnonObjectHeaderBigobj`.
 #[allow(missing_docs)]
-pub trait CoffHeader: Debug + Pod {
+pub trait CoffHeader: Debug {
     type ImageSymbol: ImageSymbol;
     type ImageSymbolBytes: Debug + Pod;
 

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -63,6 +63,7 @@ where
     'data: 'file,
     R: 'file + ReadRef<'data>,
     Coff: CoffHeader,
+    Coff::ImageSymbol: Pod,
 {
     type Segment = CoffSegment<'data, 'file, R, Coff>;
     type SegmentIterator = CoffSegmentIterator<'data, 'file, R, Coff>;
@@ -228,7 +229,7 @@ pub fn anon_object_class_id<'data, R: ReadRef<'data>>(data: R) -> Result<pe::Cls
 /// A trait for generic access to `ImageFileHeader` and `AnonObjectHeaderBigobj`.
 #[allow(missing_docs)]
 pub trait CoffHeader: Debug {
-    type ImageSymbol: ImageSymbol;
+    type ImageSymbol: ImageSymbol + ?Sized;
     type ImageSymbolBytes: Debug + Pod;
 
     /// Return true if this type is `AnonObjectHeaderBigobj`.

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -22,7 +22,7 @@ impl<'data> SectionTable<'data> {
     ///
     /// `data` must be the entire file data.
     /// `offset` must be after the optional file header.
-    pub fn parse<Coff: CoffHeader, R: ReadRef<'data>>(
+    pub fn parse<Coff: CoffHeader + ?Sized, R: ReadRef<'data>>(
         header: &Coff,
         data: R,
         offset: u64,

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -95,7 +95,10 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader + ?Sized> SymbolTable<'data, R, 
 
     /// Return the symbol table entry at the given index.
     #[inline]
-    pub fn symbol(&self, index: usize) -> Result<&'data Coff::ImageSymbol> {
+    pub fn symbol(&self, index: usize) -> Result<&'data Coff::ImageSymbol>
+    where
+        Coff::ImageSymbol: Pod,
+    {
         self.get::<Coff::ImageSymbol>(index, 0)
     }
 
@@ -147,7 +150,10 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader + ?Sized> SymbolTable<'data, R, 
     pub fn map<Entry: SymbolMapEntry, F: Fn(&'data Coff::ImageSymbol) -> Option<Entry>>(
         &self,
         f: F,
-    ) -> SymbolMap<Entry> {
+    ) -> SymbolMap<Entry>
+    where
+        Coff::ImageSymbol: Pod,
+    {
         let mut symbols = Vec::with_capacity(self.symbols.len());
         for (_, symbol) in self.iter() {
             if !symbol.is_definition() {
@@ -176,6 +182,8 @@ where
 
 impl<'data, 'table, R: ReadRef<'data>, Coff: CoffHeader + ?Sized> Iterator
     for SymbolIterator<'data, 'table, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
 {
     type Item = (usize, &'data Coff::ImageSymbol);
 
@@ -208,6 +216,8 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> read::private::Sealed
 
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> ObjectSymbolTable<'data>
     for CoffSymbolTable<'data, 'file, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
 {
     type Symbol = CoffSymbol<'data, 'file, R, Coff>;
     type SymbolIterator = CoffSymbolIterator<'data, 'file, R, Coff>;
@@ -253,6 +263,8 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> fmt::Debug
 
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> Iterator
     for CoffSymbolIterator<'data, 'file, R, Coff>
+where
+    Coff::ImageSymbol: Pod,
 {
     type Item = CoffSymbol<'data, 'file, R, Coff>;
 
@@ -494,7 +506,7 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> ObjectSymbol<'data>
 
 /// A trait for generic access to `ImageSymbol` and `ImageSymbolEx`.
 #[allow(missing_docs)]
-pub trait ImageSymbol: Debug + Pod {
+pub trait ImageSymbol: Debug {
     fn raw_name(&self) -> &[u8; 8];
     fn value(&self) -> u32;
     fn section_number(&self) -> i32;

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -21,7 +21,7 @@ use crate::read::{
 pub struct SymbolTable<'data, R = &'data [u8], Coff = pe::ImageFileHeader>
 where
     R: ReadRef<'data>,
-    Coff: CoffHeader,
+    Coff: CoffHeader + ?Sized,
 {
     symbols: &'data [Coff::ImageSymbolBytes],
     strings: StringTable<'data, R>,
@@ -36,7 +36,7 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader> Default for SymbolTable<'data, 
     }
 }
 
-impl<'data, R: ReadRef<'data>, Coff: CoffHeader> SymbolTable<'data, R, Coff> {
+impl<'data, R: ReadRef<'data>, Coff: CoffHeader + ?Sized> SymbolTable<'data, R, Coff> {
     /// Read the symbol table.
     pub fn parse(header: &Coff, data: R) -> Result<Self> {
         // The symbol table may not be present.
@@ -168,13 +168,13 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader> SymbolTable<'data, R, Coff> {
 pub struct SymbolIterator<'data, 'table, R = &'data [u8], Coff = pe::ImageFileHeader>
 where
     R: ReadRef<'data>,
-    Coff: CoffHeader,
+    Coff: CoffHeader + ?Sized,
 {
     symbols: &'table SymbolTable<'data, R, Coff>,
     index: usize,
 }
 
-impl<'data, 'table, R: ReadRef<'data>, Coff: CoffHeader> Iterator
+impl<'data, 'table, R: ReadRef<'data>, Coff: CoffHeader + ?Sized> Iterator
     for SymbolIterator<'data, 'table, R, Coff>
 {
     type Item = (usize, &'data Coff::ImageSymbol);

--- a/src/read/elf/compression.rs
+++ b/src/read/elf/compression.rs
@@ -2,11 +2,10 @@ use core::fmt::Debug;
 
 use crate::elf;
 use crate::endian;
-use crate::pod::Pod;
 
 /// A trait for generic access to `CompressionHeader32` and `CompressionHeader64`.
 #[allow(missing_docs)]
-pub trait CompressionHeader: Debug + Pod {
+pub trait CompressionHeader: Debug {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 

--- a/src/read/elf/dynamic.rs
+++ b/src/read/elf/dynamic.rs
@@ -3,12 +3,11 @@ use core::fmt::Debug;
 
 use crate::elf;
 use crate::endian;
-use crate::pod::Pod;
 use crate::read::{ReadError, Result, StringTable};
 
 /// A trait for generic access to `Dyn32` and `Dyn64`.
 #[allow(missing_docs)]
-pub trait Dyn: Debug + Pod {
+pub trait Dyn: Debug {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -149,6 +149,7 @@ where
     Elf: FileHeader,
     Elf::CompressionHeader: Pod,
     Elf::NoteHeader: Pod,
+    Elf::Rel: Pod + Clone,
     R: 'file + ReadRef<'data>,
 {
     type Segment = ElfSegment<'data, 'file, Elf, R>;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -53,6 +53,7 @@ where
         Elf: Pod,
         Elf::SectionHeader: Pod,
         Elf::ProgramHeader: Pod,
+        Elf::Sym: Pod,
     {
         let header = Elf::parse(data)?;
         let endian = header.endian()?;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -148,6 +148,7 @@ where
     'data: 'file,
     Elf: FileHeader,
     Elf::CompressionHeader: Pod,
+    Elf::NoteHeader: Pod,
     R: 'file + ReadRef<'data>,
 {
     type Segment = ElfSegment<'data, 'file, Elf, R>;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -94,7 +94,10 @@ where
     fn raw_section_by_name<'file>(
         &'file self,
         section_name: &[u8],
-    ) -> Option<ElfSection<'data, 'file, Elf, R>> {
+    ) -> Option<ElfSection<'data, 'file, Elf, R>>
+    where
+        Elf::CompressionHeader: Pod,
+    {
         self.sections
             .section_by_name(self.endian, section_name)
             .map(|(index, section)| ElfSection {
@@ -108,7 +111,10 @@ where
     fn zdebug_section_by_name<'file>(
         &'file self,
         section_name: &[u8],
-    ) -> Option<ElfSection<'data, 'file, Elf, R>> {
+    ) -> Option<ElfSection<'data, 'file, Elf, R>>
+    where
+        Elf::CompressionHeader: Pod,
+    {
         if !section_name.starts_with(b".debug_") {
             return None;
         }
@@ -138,6 +144,7 @@ impl<'data, 'file, Elf, R> Object<'data, 'file> for ElfFile<'data, Elf, R>
 where
     'data: 'file,
     Elf: FileHeader,
+    Elf::CompressionHeader: Pod,
     R: 'file + ReadRef<'data>,
 {
     type Segment = ElfSegment<'data, 'file, Elf, R>;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -150,6 +150,7 @@ where
     Elf::CompressionHeader: Pod,
     Elf::NoteHeader: Pod,
     Elf::Rel: Pod + Clone,
+    Elf::Rela: Pod + Clone,
     R: 'file + ReadRef<'data>,
 {
     type Segment = ElfSegment<'data, 'file, Elf, R>;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -48,7 +48,10 @@ where
     R: ReadRef<'data>,
 {
     /// Parse the raw ELF file data.
-    pub fn parse(data: R) -> read::Result<Self> {
+    pub fn parse(data: R) -> read::Result<Self>
+    where
+        Elf: Pod,
+    {
         let header = Elf::parse(data)?;
         let endian = header.endian()?;
         let segments = header.program_headers(endian, data)?;
@@ -444,7 +447,7 @@ where
 
 /// A trait for generic access to `FileHeader32` and `FileHeader64`.
 #[allow(missing_docs)]
-pub trait FileHeader: Debug + Pod {
+pub trait FileHeader: Debug {
     // Ideally this would be a `u64: From<Word>`, but can't express that.
     type Word: Into<u64>;
     type Sword: Into<i64>;
@@ -492,7 +495,10 @@ pub trait FileHeader: Debug + Pod {
     /// Read the file header.
     ///
     /// Also checks that the ident field in the file header is a supported format.
-    fn parse<'data, R: ReadRef<'data>>(data: R) -> read::Result<&'data Self> {
+    fn parse<'data, R: ReadRef<'data>>(data: R) -> read::Result<&'data Self>
+    where
+        Self: Pod,
+    {
         let header = data
             .read_at::<Self>(0)
             .read_error("Invalid ELF header size or alignment")?;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -51,6 +51,7 @@ where
     pub fn parse(data: R) -> read::Result<Self>
     where
         Elf: Pod,
+        Elf::SectionHeader: Pod,
     {
         let header = Elf::parse(data)?;
         let endian = header.endian()?;
@@ -553,7 +554,10 @@ pub trait FileHeader: Debug {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<&'data Self::SectionHeader>> {
+    ) -> read::Result<Option<&'data Self::SectionHeader>>
+    where
+        Self::SectionHeader: Pod,
+    {
         let shoff: u64 = self.e_shoff(endian).into();
         if shoff == 0 {
             // No section headers is ok.
@@ -572,11 +576,10 @@ pub trait FileHeader: Debug {
     /// Return the `e_phnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn phnum<'data, R: ReadRef<'data>>(
-        &self,
-        endian: Self::Endian,
-        data: R,
-    ) -> read::Result<usize> {
+    fn phnum<'data, R: ReadRef<'data>>(&self, endian: Self::Endian, data: R) -> read::Result<usize>
+    where
+        Self::SectionHeader: Pod,
+    {
         let e_phnum = self.e_phnum(endian);
         if e_phnum < elf::PN_XNUM {
             Ok(e_phnum as usize)
@@ -591,11 +594,10 @@ pub trait FileHeader: Debug {
     /// Return the `e_shnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn shnum<'data, R: ReadRef<'data>>(
-        &self,
-        endian: Self::Endian,
-        data: R,
-    ) -> read::Result<usize> {
+    fn shnum<'data, R: ReadRef<'data>>(&self, endian: Self::Endian, data: R) -> read::Result<usize>
+    where
+        Self::SectionHeader: Pod,
+    {
         let e_shnum = self.e_shnum(endian);
         if e_shnum > 0 {
             Ok(e_shnum as usize)
@@ -615,11 +617,10 @@ pub trait FileHeader: Debug {
     /// Return the `e_shstrndx` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values (including if the index is 0).
-    fn shstrndx<'data, R: ReadRef<'data>>(
-        &self,
-        endian: Self::Endian,
-        data: R,
-    ) -> read::Result<u32> {
+    fn shstrndx<'data, R: ReadRef<'data>>(&self, endian: Self::Endian, data: R) -> read::Result<u32>
+    where
+        Self::SectionHeader: Pod,
+    {
         let e_shstrndx = self.e_shstrndx(endian);
         let index = if e_shstrndx != elf::SHN_XINDEX {
             e_shstrndx.into()
@@ -643,7 +644,10 @@ pub trait FileHeader: Debug {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<&'data [Self::ProgramHeader]> {
+    ) -> read::Result<&'data [Self::ProgramHeader]>
+    where
+        Self::SectionHeader: Pod,
+    {
         let phoff: u64 = self.e_phoff(endian).into();
         if phoff == 0 {
             // No program headers is ok.
@@ -671,7 +675,10 @@ pub trait FileHeader: Debug {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<&'data [Self::SectionHeader]> {
+    ) -> read::Result<&'data [Self::SectionHeader]>
+    where
+        Self::SectionHeader: Pod,
+    {
         let shoff: u64 = self.e_shoff(endian).into();
         if shoff == 0 {
             // No section headers is ok.
@@ -697,7 +704,10 @@ pub trait FileHeader: Debug {
         endian: Self::Endian,
         data: R,
         sections: &[Self::SectionHeader],
-    ) -> read::Result<StringTable<'data, R>> {
+    ) -> read::Result<StringTable<'data, R>>
+    where
+        Self::SectionHeader: Pod,
+    {
         if sections.is_empty() {
             return Ok(StringTable::default());
         }
@@ -719,7 +729,10 @@ pub trait FileHeader: Debug {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<SectionTable<'data, Self, R>> {
+    ) -> read::Result<SectionTable<'data, Self, R>>
+    where
+        Self::SectionHeader: Pod,
+    {
         let sections = self.section_headers(endian, data)?;
         let strings = self.section_strings(endian, data, sections)?;
         Ok(SectionTable::new(sections, strings))

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -52,6 +52,7 @@ where
     where
         Elf: Pod,
         Elf::SectionHeader: Pod,
+        Elf::ProgramHeader: Pod,
     {
         let header = Elf::parse(data)?;
         let endian = header.endian()?;
@@ -647,6 +648,7 @@ pub trait FileHeader: Debug {
     ) -> read::Result<&'data [Self::ProgramHeader]>
     where
         Self::SectionHeader: Pod,
+        Self::ProgramHeader: Pod,
     {
         let phoff: u64 = self.e_phoff(endian).into();
         if phoff == 0 {

--- a/src/read/elf/hash.rs
+++ b/src/read/elf/hash.rs
@@ -8,12 +8,12 @@ use super::{FileHeader, Sym, SymbolTable, Version, VersionTable};
 
 /// A SysV symbol hash table in an ELF file.
 #[derive(Debug)]
-pub struct HashTable<'data, Elf: FileHeader> {
+pub struct HashTable<'data, Elf: FileHeader + ?Sized> {
     buckets: &'data [U32<Elf::Endian>],
     chains: &'data [U32<Elf::Endian>],
 }
 
-impl<'data, Elf: FileHeader> HashTable<'data, Elf> {
+impl<'data, Elf: FileHeader + ?Sized> HashTable<'data, Elf> {
     /// Parse a SysV hash table.
     ///
     /// `data` should be from a `SHT_HASH` section, or from a
@@ -71,7 +71,7 @@ impl<'data, Elf: FileHeader> HashTable<'data, Elf> {
 
 /// A GNU symbol hash table in an ELF file.
 #[derive(Debug)]
-pub struct GnuHashTable<'data, Elf: FileHeader> {
+pub struct GnuHashTable<'data, Elf: FileHeader + ?Sized> {
     symbol_base: u32,
     bloom_shift: u32,
     bloom_filters: &'data [u8],

--- a/src/read/elf/note.rs
+++ b/src/read/elf/note.rs
@@ -23,6 +23,7 @@ where
 impl<'data, Elf> NoteIterator<'data, Elf>
 where
     Elf: FileHeader,
+    Elf::NoteHeader: Pod,
 {
     /// An iterator over the notes in an ELF section or segment.
     ///
@@ -159,7 +160,7 @@ impl<'data, Elf: FileHeader> Note<'data, Elf> {
 
 /// A trait for generic access to `NoteHeader32` and `NoteHeader64`.
 #[allow(missing_docs)]
-pub trait NoteHeader: Debug + Pod {
+pub trait NoteHeader: Debug {
     type Endian: endian::Endian;
 
     fn n_namesz(&self, endian: Self::Endian) -> u32;

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -23,7 +23,7 @@ impl RelocationSections {
     /// Create a new mapping using the section table.
     ///
     /// Skips relocation sections that do not use the given symbol table section.
-    pub fn parse<'data, Elf: FileHeader, R: ReadRef<'data>>(
+    pub fn parse<'data, Elf: FileHeader + ?Sized, R: ReadRef<'data>>(
         endian: Elf::Endian,
         sections: &SectionTable<'data, Elf, R>,
         symbol_section: SectionIndex,

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -80,7 +80,10 @@ impl<'data, Elf: FileHeader> ElfRelaIterator<'data, Elf> {
     }
 }
 
-impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf> {
+impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf>
+where
+    Elf::Rel: Clone,
+{
     type Item = Elf::Rela;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -113,6 +116,7 @@ where
 impl<'data, 'file, Elf, R> Iterator for ElfDynamicRelocationIterator<'data, 'file, Elf, R>
 where
     Elf: FileHeader,
+    Elf::Rel: Pod + Clone,
     R: ReadRef<'data>,
 {
     type Item = (u64, Relocation);
@@ -186,6 +190,7 @@ where
 impl<'data, 'file, Elf, R> Iterator for ElfSectionRelocationIterator<'data, 'file, Elf, R>
 where
     Elf: FileHeader,
+    Elf::Rel: Pod + Clone,
     R: ReadRef<'data>,
 {
     type Item = (u64, Relocation);
@@ -431,7 +436,7 @@ fn parse_relocation<Elf: FileHeader>(
 
 /// A trait for generic access to `Rel32` and `Rel64`.
 #[allow(missing_docs)]
-pub trait Rel: Debug + Pod + Clone {
+pub trait Rel: Debug {
     type Word: Into<u64>;
     type Sword: Into<i64>;
     type Endian: endian::Endian;

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -83,6 +83,7 @@ impl<'data, Elf: FileHeader> ElfRelaIterator<'data, Elf> {
 impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf>
 where
     Elf::Rel: Clone,
+    Elf::Rela: Clone,
 {
     type Item = Elf::Rela;
 
@@ -117,6 +118,7 @@ impl<'data, 'file, Elf, R> Iterator for ElfDynamicRelocationIterator<'data, 'fil
 where
     Elf: FileHeader,
     Elf::Rel: Pod + Clone,
+    Elf::Rela: Pod + Clone,
     R: ReadRef<'data>,
 {
     type Item = (u64, Relocation);
@@ -191,6 +193,7 @@ impl<'data, 'file, Elf, R> Iterator for ElfSectionRelocationIterator<'data, 'fil
 where
     Elf: FileHeader,
     Elf::Rel: Pod + Clone,
+    Elf::Rela: Pod + Clone,
     R: ReadRef<'data>,
 {
     type Item = (u64, Relocation);
@@ -501,7 +504,7 @@ impl<Endian: endian::Endian> Rel for elf::Rel64<Endian> {
 
 /// A trait for generic access to `Rela32` and `Rela64`.
 #[allow(missing_docs)]
-pub trait Rela: Debug + Pod + Clone {
+pub trait Rela: Debug {
     type Word: Into<u64>;
     type Sword: Into<i64>;
     type Endian: endian::Endian;

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -797,7 +797,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<NoteIterator<'data, Self::Elf>>> {
+    ) -> read::Result<Option<NoteIterator<'data, Self::Elf>>>
+    where
+        <Self::Elf as FileHeader>::NoteHeader: Pod,
+    {
         if self.sh_type(endian) != elf::SHT_NOTE {
             return Ok(None);
         }

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -614,7 +614,7 @@ where
 
 /// A trait for generic access to `SectionHeader32` and `SectionHeader64`.
 #[allow(missing_docs)]
-pub trait SectionHeader: Debug + Pod {
+pub trait SectionHeader: Debug {
     type Elf: FileHeader<SectionHeader = Self, Endian = Self::Endian, Word = Self::Word>;
     type Word: Into<u64>;
     type Endian: endian::Endian;

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -417,6 +417,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ElfSection<'data, 'file, 
     where
         Elf::CompressionHeader: Pod,
         Elf::Rel: Pod + Clone,
+        Elf::Rela: Pod + Clone,
     {
         let name = match self.name() {
             Ok(name) => name,
@@ -471,6 +472,7 @@ where
     Elf: FileHeader,
     Elf::CompressionHeader: Pod,
     Elf::Rel: Pod + Clone,
+    Elf::Rela: Pod + Clone,
     R: ReadRef<'data>,
 {
     type RelocationIterator = ElfSectionRelocationIterator<'data, 'file, Elf, R>;
@@ -759,7 +761,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<(&'data [<Self::Elf as FileHeader>::Rela], SectionIndex)>> {
+    ) -> read::Result<Option<(&'data [<Self::Elf as FileHeader>::Rela], SectionIndex)>>
+    where
+        <Self::Elf as FileHeader>::Rela: Pod,
+    {
         if self.sh_type(endian) != elf::SHT_RELA {
             return Ok(None);
         }

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -19,7 +19,7 @@ use super::{
 ///
 /// Also includes the string table used for the section names.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct SectionTable<'data, Elf: FileHeader, R = &'data [u8]>
+pub struct SectionTable<'data, Elf: FileHeader + ?Sized, R = &'data [u8]>
 where
     R: ReadRef<'data>,
 {
@@ -27,7 +27,7 @@ where
     strings: StringTable<'data, R>,
 }
 
-impl<'data, Elf: FileHeader, R: ReadRef<'data>> SectionTable<'data, Elf, R> {
+impl<'data, Elf: FileHeader + ?Sized, R: ReadRef<'data>> SectionTable<'data, Elf, R> {
     /// Create a new section table.
     #[inline]
     pub fn new(sections: &'data [Elf::SectionHeader], strings: StringTable<'data, R>) -> Self {

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -416,6 +416,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ElfSection<'data, 'file, 
     fn maybe_compressed_gnu(&self) -> read::Result<Option<CompressedFileRange>>
     where
         Elf::CompressionHeader: Pod,
+        Elf::Rel: Pod + Clone,
     {
         let name = match self.name() {
             Ok(name) => name,
@@ -469,6 +470,7 @@ impl<'data, 'file, Elf, R> ObjectSection<'data> for ElfSection<'data, 'file, Elf
 where
     Elf: FileHeader,
     Elf::CompressionHeader: Pod,
+    Elf::Rel: Pod + Clone,
     R: ReadRef<'data>,
 {
     type RelocationIterator = ElfSectionRelocationIterator<'data, 'file, Elf, R>;
@@ -733,7 +735,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<(&'data [<Self::Elf as FileHeader>::Rel], SectionIndex)>> {
+    ) -> read::Result<Option<(&'data [<Self::Elf as FileHeader>::Rel], SectionIndex)>>
+    where
+        <Self::Elf as FileHeader>::Rel: Pod,
+    {
         if self.sh_type(endian) != elf::SHT_REL {
             return Ok(None);
         }

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -112,7 +112,10 @@ impl<'data, Elf: FileHeader + ?Sized, R: ReadRef<'data>> SectionTable<'data, Elf
         endian: Elf::Endian,
         data: R,
         sh_type: u32,
-    ) -> read::Result<SymbolTable<'data, Elf, R>> {
+    ) -> read::Result<SymbolTable<'data, Elf, R>>
+    where
+        Elf::Sym: Pod,
+    {
         debug_assert!(sh_type == elf::SHT_DYNSYM || sh_type == elf::SHT_SYMTAB);
 
         let (index, section) = match self
@@ -136,7 +139,10 @@ impl<'data, Elf: FileHeader + ?Sized, R: ReadRef<'data>> SectionTable<'data, Elf
         endian: Elf::Endian,
         data: R,
         index: SectionIndex,
-    ) -> read::Result<SymbolTable<'data, Elf, R>> {
+    ) -> read::Result<SymbolTable<'data, Elf, R>>
+    where
+        Elf::Sym: Pod,
+    {
         let section = self.section(index)?;
         match section.sh_type(endian) {
             elf::SHT_DYNSYM | elf::SHT_SYMTAB => {}
@@ -314,7 +320,10 @@ impl<'data, Elf: FileHeader + ?Sized, R: ReadRef<'data>> SectionTable<'data, Elf
         &self,
         endian: Elf::Endian,
         data: R,
-    ) -> read::Result<Option<VersionTable<'data, Elf>>> {
+    ) -> read::Result<Option<VersionTable<'data, Elf>>>
+    where
+        Elf::Sym: Pod,
+    {
         let (versyms, link) = match self.gnu_versym(endian, data)? {
             Some(val) => val,
             None => return Ok(None),
@@ -719,7 +728,10 @@ pub trait SectionHeader: Debug {
         data: R,
         sections: &SectionTable<'data, Self::Elf, R>,
         section_index: SectionIndex,
-    ) -> read::Result<Option<SymbolTable<'data, Self::Elf, R>>> {
+    ) -> read::Result<Option<SymbolTable<'data, Self::Elf, R>>>
+    where
+        <Self::Elf as FileHeader>::Sym: Pod,
+    {
         let sh_type = self.sh_type(endian);
         if sh_type != elf::SHT_SYMTAB && sh_type != elf::SHT_DYNSYM {
             return Ok(None);

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -165,7 +165,10 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SectionTable<'data, Elf, R> {
         &self,
         endian: Elf::Endian,
         data: R,
-    ) -> read::Result<Option<(&'data [Elf::Dyn], SectionIndex)>> {
+    ) -> read::Result<Option<(&'data [Elf::Dyn], SectionIndex)>>
+    where
+        Elf::Dyn: Pod,
+    {
         for section in self.sections {
             if let Some(dynamic) = section.dynamic(endian, data)? {
                 return Ok(Some(dynamic));
@@ -772,7 +775,10 @@ pub trait SectionHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<(&'data [<Self::Elf as FileHeader>::Dyn], SectionIndex)>> {
+    ) -> read::Result<Option<(&'data [<Self::Elf as FileHeader>::Dyn], SectionIndex)>>
+    where
+        <Self::Elf as FileHeader>::Dyn: Pod,
+    {
         if self.sh_type(endian) != elf::SHT_DYNAMIC {
             return Ok(None);
         }

--- a/src/read/elf/segment.rs
+++ b/src/read/elf/segment.rs
@@ -230,7 +230,10 @@ pub trait ProgramHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<NoteIterator<'data, Self::Elf>>> {
+    ) -> read::Result<Option<NoteIterator<'data, Self::Elf>>>
+    where
+        <Self::Elf as FileHeader>::NoteHeader: Pod,
+    {
         if self.p_type(endian) != elf::PT_NOTE {
             return Ok(None);
         }

--- a/src/read/elf/segment.rs
+++ b/src/read/elf/segment.rs
@@ -137,7 +137,7 @@ where
 
 /// A trait for generic access to `ProgramHeader32` and `ProgramHeader64`.
 #[allow(missing_docs)]
-pub trait ProgramHeader: Debug + Pod {
+pub trait ProgramHeader: Debug {
     type Elf: FileHeader<ProgramHeader = Self, Endian = Self::Endian, Word = Self::Word>;
     type Word: Into<u64>;
     type Endian: endian::Endian;

--- a/src/read/elf/segment.rs
+++ b/src/read/elf/segment.rs
@@ -209,7 +209,10 @@ pub trait ProgramHeader: Debug + Pod {
         &self,
         endian: Self::Endian,
         data: R,
-    ) -> read::Result<Option<&'data [<Self::Elf as FileHeader>::Dyn]>> {
+    ) -> read::Result<Option<&'data [<Self::Elf as FileHeader>::Dyn]>>
+    where
+        <Self::Elf as FileHeader>::Dyn: Pod,
+    {
         if self.p_type(endian) != elf::PT_DYNAMIC {
             return Ok(None);
         }

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -77,7 +77,10 @@ impl<'data, Elf: FileHeader + ?Sized, R: ReadRef<'data>> SymbolTable<'data, Elf,
         sections: &SectionTable<'data, Elf, R>,
         section_index: SectionIndex,
         section: &Elf::SectionHeader,
-    ) -> read::Result<Self> {
+    ) -> read::Result<Self>
+    where
+        Elf::Sym: Pod,
+    {
         debug_assert!(
             section.sh_type(endian) == elf::SHT_DYNSYM
                 || section.sh_type(endian) == elf::SHT_SYMTAB
@@ -462,7 +465,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
 
 /// A trait for generic access to `Sym32` and `Sym64`.
 #[allow(missing_docs)]
-pub trait Sym: Debug + Pod {
+pub trait Sym: Debug {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 

--- a/src/read/elf/version.rs
+++ b/src/read/elf/version.rs
@@ -60,7 +60,7 @@ impl<'data> Version<'data> {
 ///
 /// This is derived from entries in the `SHT_GNU_versym`, `SHT_GNU_verdef` and `SHT_GNU_verneed` sections.
 #[derive(Debug, Clone)]
-pub struct VersionTable<'data, Elf: FileHeader> {
+pub struct VersionTable<'data, Elf: FileHeader + ?Sized> {
     symbols: &'data [elf::Versym<Elf::Endian>],
     versions: Vec<Version<'data>>,
 }
@@ -74,7 +74,7 @@ impl<'data, Elf: FileHeader> Default for VersionTable<'data, Elf> {
     }
 }
 
-impl<'data, Elf: FileHeader> VersionTable<'data, Elf> {
+impl<'data, Elf: FileHeader + ?Sized> VersionTable<'data, Elf> {
     /// Parse the version sections.
     pub fn parse<R: ReadRef<'data>>(
         endian: Elf::Endian,
@@ -211,13 +211,21 @@ impl<'data, Elf: FileHeader> VersionTable<'data, Elf> {
 }
 
 /// An iterator over the entries in an ELF `SHT_GNU_verdef` section.
-#[derive(Debug, Clone)]
-pub struct VerdefIterator<'data, Elf: FileHeader> {
+#[derive(Debug)]
+pub struct VerdefIterator<'data, Elf: FileHeader + ?Sized> {
     endian: Elf::Endian,
     data: Bytes<'data>,
 }
 
-impl<'data, Elf: FileHeader> VerdefIterator<'data, Elf> {
+// derive(Debug) incorrectly requires Elf: Sized.
+impl<Elf: FileHeader + ?Sized> Clone for VerdefIterator<'_, Elf> {
+    fn clone(&self) -> Self {
+        let &Self { endian, data } = self;
+        Self { endian, data }
+    }
+}
+
+impl<'data, Elf: FileHeader + ?Sized> VerdefIterator<'data, Elf> {
     pub(super) fn new(endian: Elf::Endian, data: &'data [u8]) -> Self {
         VerdefIterator {
             endian,
@@ -258,14 +266,30 @@ impl<'data, Elf: FileHeader> VerdefIterator<'data, Elf> {
 }
 
 /// An iterator over the auxiliary records for an entry in an ELF `SHT_GNU_verdef` section.
-#[derive(Debug, Clone)]
-pub struct VerdauxIterator<'data, Elf: FileHeader> {
+#[derive(Debug)]
+pub struct VerdauxIterator<'data, Elf: FileHeader + ?Sized> {
     endian: Elf::Endian,
     data: Bytes<'data>,
     count: u16,
 }
 
-impl<'data, Elf: FileHeader> VerdauxIterator<'data, Elf> {
+// derive(Debug) incorrectly requires Elf: Sized.
+impl<Elf: FileHeader + ?Sized> Clone for VerdauxIterator<'_, Elf> {
+    fn clone(&self) -> Self {
+        let &Self {
+            endian,
+            data,
+            count,
+        } = self;
+        Self {
+            endian,
+            data,
+            count,
+        }
+    }
+}
+
+impl<'data, Elf: FileHeader + ?Sized> VerdauxIterator<'data, Elf> {
     pub(super) fn new(endian: Elf::Endian, data: &'data [u8], count: u16) -> Self {
         VerdauxIterator {
             endian,
@@ -294,13 +318,21 @@ impl<'data, Elf: FileHeader> VerdauxIterator<'data, Elf> {
 }
 
 /// An iterator over the entries in an ELF `SHT_GNU_verneed` section.
-#[derive(Debug, Clone)]
-pub struct VerneedIterator<'data, Elf: FileHeader> {
+#[derive(Debug)]
+pub struct VerneedIterator<'data, Elf: FileHeader + ?Sized> {
     endian: Elf::Endian,
     data: Bytes<'data>,
 }
 
-impl<'data, Elf: FileHeader> VerneedIterator<'data, Elf> {
+// derive(Debug) incorrectly requires Elf: Sized.
+impl<Elf: FileHeader + ?Sized> Clone for VerneedIterator<'_, Elf> {
+    fn clone(&self) -> Self {
+        let &Self { endian, data } = self;
+        Self { endian, data }
+    }
+}
+
+impl<'data, Elf: FileHeader + ?Sized> VerneedIterator<'data, Elf> {
     pub(super) fn new(endian: Elf::Endian, data: &'data [u8]) -> Self {
         VerneedIterator {
             endian,
@@ -347,13 +379,13 @@ impl<'data, Elf: FileHeader> VerneedIterator<'data, Elf> {
 
 /// An iterator over the auxiliary records for an entry in an ELF `SHT_GNU_verneed` section.
 #[derive(Debug, Clone)]
-pub struct VernauxIterator<'data, Elf: FileHeader> {
+pub struct VernauxIterator<'data, Elf: FileHeader + ?Sized> {
     endian: Elf::Endian,
     data: Bytes<'data>,
     count: u16,
 }
 
-impl<'data, Elf: FileHeader> VernauxIterator<'data, Elf> {
+impl<'data, Elf: FileHeader + ?Sized> VernauxIterator<'data, Elf> {
     pub(super) fn new(endian: Elf::Endian, data: &'data [u8], count: u16) -> Self {
         VernauxIterator {
             endian,

--- a/src/read/macho/fat.rs
+++ b/src/read/macho/fat.rs
@@ -1,5 +1,5 @@
 use crate::read::{Architecture, Error, ReadError, ReadRef, Result};
-use crate::{macho, BigEndian, Pod};
+use crate::{macho, BigEndian};
 
 pub use macho::{FatArch32, FatArch64, FatHeader};
 
@@ -41,7 +41,7 @@ impl FatHeader {
 
 /// A trait for generic access to `FatArch32` and `FatArch64`.
 #[allow(missing_docs)]
-pub trait FatArch: Pod {
+pub trait FatArch {
     type Word: Into<u64>;
 
     fn cputype(&self) -> u32;

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -50,6 +50,7 @@ where
     where
         Mach: Pod,
         Mach::Section: Pod,
+        Mach::Nlist: Pod,
     {
         let header = Mach::parse(data, 0)?;
         let endian = header.endian()?;
@@ -92,6 +93,7 @@ where
     where
         Mach: Pod,
         Mach::Section: Pod,
+        Mach::Nlist: Pod,
     {
         let (data, header_offset) = image.image_data_and_offset()?;
         let header = Mach::parse(data, header_offset)?;

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -49,6 +49,7 @@ where
     pub fn parse(data: R) -> Result<Self>
     where
         Mach: Pod,
+        Mach::Section: Pod,
     {
         let header = Mach::parse(data, 0)?;
         let endian = header.endian()?;
@@ -90,6 +91,7 @@ where
     ) -> Result<Self>
     where
         Mach: Pod,
+        Mach::Section: Pod,
     {
         let (data, header_offset) = image.image_data_and_offset()?;
         let header = Mach::parse(data, header_offset)?;

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -340,7 +340,10 @@ impl<E: Endian> macho::SymtabCommand<E> {
         &self,
         endian: E,
         data: R,
-    ) -> Result<SymbolTable<'data, Mach, R>> {
+    ) -> Result<SymbolTable<'data, Mach, R>>
+    where
+        Mach::Nlist: Pod,
+    {
         let symbols = data
             .read_slice_at(
                 self.symoff.get(endian).into(),

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -204,13 +204,34 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub(super) struct MachOSectionInternal<'data, Mach: MachHeader> {
     pub index: SectionIndex,
     pub segment_index: usize,
     pub kind: SectionKind,
     pub section: &'data Mach::Section,
 }
+
+// derive(Clone) incorrectly requires Elf: Sized.
+impl<'data, Mach: MachHeader> Clone for MachOSectionInternal<'data, Mach> {
+    fn clone(&self) -> Self {
+        let &Self {
+            index,
+            segment_index,
+            kind,
+            section,
+        } = self;
+        Self {
+            index,
+            segment_index,
+            kind,
+            section,
+        }
+    }
+}
+
+// derive(Copy) incorrectly requires Mach: Sized.
+impl<'data, Mach: MachHeader> Copy for MachOSectionInternal<'data, Mach> {}
 
 impl<'data, Mach: MachHeader> MachOSectionInternal<'data, Mach> {
     pub(super) fn parse(

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -3,7 +3,6 @@ use core::{fmt, result, slice, str};
 
 use crate::endian::{self, Endianness};
 use crate::macho;
-use crate::pod::Pod;
 use crate::read::{
     self, CompressedData, CompressedFileRange, ObjectSection, ReadError, ReadRef, Result,
     SectionFlags, SectionIndex, SectionKind,
@@ -270,7 +269,7 @@ impl<'data, Mach: MachHeader> MachOSectionInternal<'data, Mach> {
 
 /// A trait for generic access to `Section32` and `Section64`.
 #[allow(missing_docs)]
-pub trait Section: Debug + Pod {
+pub trait Section: Debug {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 

--- a/src/read/macho/segment.rs
+++ b/src/read/macho/segment.rs
@@ -153,7 +153,7 @@ pub(super) struct MachOSegmentInternal<'data, Mach: MachHeader, R: ReadRef<'data
 
 /// A trait for generic access to `SegmentCommand32` and `SegmentCommand64`.
 #[allow(missing_docs)]
-pub trait Segment: Debug + Pod {
+pub trait Segment: Debug {
     type Word: Into<u64>;
     type Endian: endian::Endian;
     type Section: Section<Endian = Self::Endian>;

--- a/src/read/macho/segment.rs
+++ b/src/read/macho/segment.rs
@@ -205,7 +205,10 @@ pub trait Segment: Debug + Pod {
         &self,
         endian: Self::Endian,
         section_data: R,
-    ) -> Result<&'data [Self::Section]> {
+    ) -> Result<&'data [Self::Section]>
+    where
+        Self::Section: Pod,
+    {
         section_data
             .read_slice_at(0, self.nsects(endian) as usize)
             .read_error("Invalid Mach-O number of sections")

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -4,7 +4,6 @@ use core::{fmt, slice, str};
 
 use crate::endian::{self, Endianness};
 use crate::macho;
-use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
     self, ObjectMap, ObjectMapEntry, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Result,
@@ -396,7 +395,7 @@ where
 
 /// A trait for generic access to `Nlist32` and `Nlist64`.
 #[allow(missing_docs)]
-pub trait Nlist: Debug + Pod {
+pub trait Nlist: Debug {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -631,7 +631,7 @@ pub trait ImageNtHeaders: Debug {
 
 /// A trait for generic access to `ImageOptionalHeader32` and `ImageOptionalHeader64`.
 #[allow(missing_docs)]
-pub trait ImageOptionalHeader: Debug + Pod {
+pub trait ImageOptionalHeader: Debug {
     // Standard fields.
     fn magic(&self) -> u16;
     fn major_linker_version(&self) -> u8;

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -131,6 +131,7 @@ impl<'data, 'file, Pe, R> Object<'data, 'file> for PeFile<'data, Pe, R>
 where
     'data: 'file,
     Pe: ImageNtHeaders + Pod,
+    Pe::ImageThunkData: Pod,
     R: 'file + ReadRef<'data>,
 {
     type Segment = PeSegment<'data, 'file, Pe, R>;

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -37,7 +37,7 @@ where
 
 impl<'data, Pe, R> PeFile<'data, Pe, R>
 where
-    Pe: ImageNtHeaders,
+    Pe: ImageNtHeaders + Pod,
     R: ReadRef<'data>,
 {
     /// Parse the raw PE file data.
@@ -130,7 +130,7 @@ where
 impl<'data, 'file, Pe, R> Object<'data, 'file> for PeFile<'data, Pe, R>
 where
     'data: 'file,
-    Pe: ImageNtHeaders,
+    Pe: ImageNtHeaders + Pod,
     R: 'file + ReadRef<'data>,
 {
     type Segment = PeSegment<'data, 'file, Pe, R>;
@@ -542,7 +542,7 @@ pub fn optional_header_magic<'data, R: ReadRef<'data>>(data: R) -> Result<u16> {
 
 /// A trait for generic access to `ImageNtHeaders32` and `ImageNtHeaders64`.
 #[allow(missing_docs)]
-pub trait ImageNtHeaders: Debug + Pod {
+pub trait ImageNtHeaders: Debug {
     type ImageOptionalHeader: ImageOptionalHeader;
     type ImageThunkData: ImageThunkData;
 
@@ -576,7 +576,10 @@ pub trait ImageNtHeaders: Debug + Pod {
     fn parse<'data, R: ReadRef<'data>>(
         data: R,
         offset: &mut u64,
-    ) -> read::Result<(&'data Self, DataDirectories<'data>)> {
+    ) -> read::Result<(&'data Self, DataDirectories<'data>)>
+    where
+        Self: Pod,
+    {
         // Note that this does not include the data directories in the optional header.
         let nt_headers = data
             .read::<Self>(offset)

--- a/src/read/pe/import.rs
+++ b/src/read/pe/import.rs
@@ -126,7 +126,10 @@ pub struct ImportThunkList<'data> {
 
 impl<'data> ImportThunkList<'data> {
     /// Get the thunk at the given index.
-    pub fn get<Pe: ImageNtHeaders>(&self, index: usize) -> Result<Pe::ImageThunkData> {
+    pub fn get<Pe: ImageNtHeaders>(&self, index: usize) -> Result<Pe::ImageThunkData>
+    where
+        Pe::ImageThunkData: Pod,
+    {
         let thunk = self
             .data
             .read_at(index * mem::size_of::<Pe::ImageThunkData>())
@@ -137,7 +140,10 @@ impl<'data> ImportThunkList<'data> {
     /// Return the first thunk in the list, and update `self` to point after it.
     ///
     /// Returns `Ok(None)` when a null thunk is found.
-    pub fn next<Pe: ImageNtHeaders>(&mut self) -> Result<Option<Pe::ImageThunkData>> {
+    pub fn next<Pe: ImageNtHeaders>(&mut self) -> Result<Option<Pe::ImageThunkData>>
+    where
+        Pe::ImageThunkData: Pod,
+    {
         let thunk = self
             .data
             .read::<Pe::ImageThunkData>()
@@ -163,12 +169,12 @@ pub enum Import<'data> {
 
 /// A trait for generic access to [`pe::ImageThunkData32`] and [`pe::ImageThunkData64`].
 #[allow(missing_docs)]
-pub trait ImageThunkData: Debug + Pod {
+pub trait ImageThunkData: Debug {
     /// Return the raw thunk value.
     fn raw(self) -> u64;
 
     /// Returns true if the ordinal flag is set.
-    fn is_ordinal(self) -> bool;
+    fn is_ordinal(&self) -> bool;
 
     /// Return the ordinal portion of the thunk.
     ///
@@ -186,7 +192,7 @@ impl ImageThunkData for pe::ImageThunkData64 {
         self.0.get(LE)
     }
 
-    fn is_ordinal(self) -> bool {
+    fn is_ordinal(&self) -> bool {
         self.0.get(LE) & pe::IMAGE_ORDINAL_FLAG64 != 0
     }
 
@@ -204,7 +210,7 @@ impl ImageThunkData for pe::ImageThunkData32 {
         self.0.get(LE).into()
     }
 
-    fn is_ordinal(self) -> bool {
+    fn is_ordinal(&self) -> bool {
         self.0.get(LE) & pe::IMAGE_ORDINAL_FLAG32 != 0
     }
 

--- a/src/read/pe/section.rs
+++ b/src/read/pe/section.rs
@@ -4,6 +4,7 @@ use core::{cmp, iter, slice, str};
 use crate::endian::LittleEndian as LE;
 use crate::pe;
 use crate::pe::ImageSectionHeader;
+use crate::pod::Pod;
 use crate::read::{
     self, CompressedData, CompressedFileRange, ObjectSection, ObjectSegment, ReadError, ReadRef,
     Relocation, Result, SectionFlags, SectionIndex, SectionKind, SegmentFlags,
@@ -71,7 +72,7 @@ where
 
 impl<'data, 'file, Pe, R> ObjectSegment<'data> for PeSegment<'data, 'file, Pe, R>
 where
-    Pe: ImageNtHeaders,
+    Pe: ImageNtHeaders + Pod,
     R: ReadRef<'data>,
 {
     #[inline]
@@ -194,7 +195,7 @@ where
 
 impl<'data, 'file, Pe, R> ObjectSection<'data> for PeSection<'data, 'file, Pe, R>
 where
-    Pe: ImageNtHeaders,
+    Pe: ImageNtHeaders + Pod,
     R: ReadRef<'data>,
 {
     type RelocationIterator = PeRelocationIterator<'data, 'file, R>;

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -43,7 +43,10 @@ where
     R: ReadRef<'data>,
 {
     /// Parse the raw XCOFF file data.
-    pub fn parse(data: R) -> Result<Self> {
+    pub fn parse(data: R) -> Result<Self>
+    where
+        Xcoff: Pod,
+    {
         let mut offset = 0;
         let header = Xcoff::parse(data, &mut offset)?;
         let aux_header = header.aux_header(data, &mut offset)?;
@@ -243,7 +246,7 @@ where
 
 /// A trait for generic access to `FileHeader32` and `FileHeader64`.
 #[allow(missing_docs)]
-pub trait FileHeader: Debug + Pod {
+pub trait FileHeader: Debug {
     type Word: Into<u64>;
     type AuxHeader: AuxHeader<Word = Self::Word>;
     type SectionHeader: SectionHeader<Word = Self::Word>;
@@ -267,7 +270,10 @@ pub trait FileHeader: Debug + Pod {
     /// Read the file header.
     ///
     /// Also checks that the magic field in the file header is a supported format.
-    fn parse<'data, R: ReadRef<'data>>(data: R, offset: &mut u64) -> Result<&'data Self> {
+    fn parse<'data, R: ReadRef<'data>>(data: R, offset: &mut u64) -> Result<&'data Self>
+    where
+        Self: Pod,
+    {
         let header = data
             .read::<Self>(offset)
             .read_error("Invalid XCOFF header size or alignment")?;
@@ -321,7 +327,7 @@ pub trait FileHeader: Debug + Pod {
     /// Return the symbol table.
     #[inline]
     fn symbols<'data, R: ReadRef<'data>>(&self, data: R) -> Result<SymbolTable<'data, Self, R>> {
-        SymbolTable::parse(*self, data)
+        SymbolTable::parse(self, data)
     }
 }
 

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -47,6 +47,7 @@ where
     where
         Xcoff: Pod,
         Xcoff::AuxHeader: Pod,
+        Xcoff::SectionHeader: Pod,
     {
         let mut offset = 0;
         let header = Xcoff::parse(data, &mut offset)?;
@@ -324,7 +325,10 @@ pub trait FileHeader: Debug {
         &self,
         data: R,
         offset: &mut u64,
-    ) -> Result<SectionTable<'data, Self>> {
+    ) -> Result<SectionTable<'data, Self>>
+    where
+        Self::SectionHeader: Pod,
+    {
         SectionTable::parse(self, data, offset)
     }
 

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -46,6 +46,7 @@ where
     pub fn parse(data: R) -> Result<Self>
     where
         Xcoff: Pod,
+        Xcoff::AuxHeader: Pod,
     {
         let mut offset = 0;
         let header = Xcoff::parse(data, &mut offset)?;
@@ -293,7 +294,10 @@ pub trait FileHeader: Debug {
         &self,
         data: R,
         offset: &mut u64,
-    ) -> Result<Option<&'data Self::AuxHeader>> {
+    ) -> Result<Option<&'data Self::AuxHeader>>
+    where
+        Self::AuxHeader: Pod,
+    {
         let aux_header_size = self.f_opthdr();
         if self.f_flags() & xcoff::F_EXEC == 0 {
             // No auxiliary header is required for an object file that is not an executable.
@@ -414,7 +418,7 @@ impl FileHeader for xcoff::FileHeader64 {
 }
 
 #[allow(missing_docs)]
-pub trait AuxHeader: Debug + Pod {
+pub trait AuxHeader: Debug {
     type Word: Into<u64>;
 
     fn o_vstamp(&self) -> u16;

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -86,6 +86,7 @@ impl<'data, 'file, Xcoff, R> Object<'data, 'file> for XcoffFile<'data, Xcoff, R>
 where
     'data: 'file,
     Xcoff: FileHeader,
+    Xcoff::CsectAux: Pod,
     Xcoff::FileAux: Pod,
     Xcoff::Symbol: Pod,
     R: 'file + ReadRef<'data>,

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -86,6 +86,7 @@ impl<'data, 'file, Xcoff, R> Object<'data, 'file> for XcoffFile<'data, Xcoff, R>
 where
     'data: 'file,
     Xcoff: FileHeader,
+    Xcoff::Symbol: Pod,
     R: 'file + ReadRef<'data>,
 {
     type Segment = XcoffSegment<'data, 'file, Xcoff, R>;

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -86,6 +86,7 @@ impl<'data, 'file, Xcoff, R> Object<'data, 'file> for XcoffFile<'data, Xcoff, R>
 where
     'data: 'file,
     Xcoff: FileHeader,
+    Xcoff::FileAux: Pod,
     Xcoff::Symbol: Pod,
     R: 'file + ReadRef<'data>,
 {

--- a/src/read/xcoff/relocation.rs
+++ b/src/read/xcoff/relocation.rs
@@ -2,7 +2,6 @@ use alloc::fmt;
 use core::fmt::Debug;
 use core::slice;
 
-use crate::pod::Pod;
 use crate::{xcoff, BigEndian as BE, Relocation};
 
 use crate::read::{ReadRef, RelocationEncoding, RelocationKind, RelocationTarget, SymbolIndex};
@@ -78,7 +77,7 @@ where
 
 /// A trait for generic access to `Rel32` and `Rel64`.
 #[allow(missing_docs)]
-pub trait Rel: Debug + Pod {
+pub trait Rel: Debug {
     type Word: Into<u64>;
     fn r_vaddr(&self) -> Self::Word;
     fn r_symndx(&self) -> u32;

--- a/src/read/xcoff/section.rs
+++ b/src/read/xcoff/section.rs
@@ -200,13 +200,13 @@ where
 
 /// The table of section headers in an XCOFF file.
 #[derive(Debug, Clone, Copy)]
-pub struct SectionTable<'data, Xcoff: FileHeader> {
+pub struct SectionTable<'data, Xcoff: FileHeader + ?Sized> {
     sections: &'data [Xcoff::SectionHeader],
 }
 
 impl<'data, Xcoff> Default for SectionTable<'data, Xcoff>
 where
-    Xcoff: FileHeader,
+    Xcoff: FileHeader + ?Sized,
 {
     fn default() -> Self {
         Self { sections: &[] }
@@ -215,7 +215,7 @@ where
 
 impl<'data, Xcoff> SectionTable<'data, Xcoff>
 where
-    Xcoff: FileHeader,
+    Xcoff: FileHeader + ?Sized,
 {
     /// Parse the section table.
     ///

--- a/src/read/xcoff/section.rs
+++ b/src/read/xcoff/section.rs
@@ -221,7 +221,10 @@ where
     ///
     /// `data` must be the entire file data.
     /// `offset` must be after the optional file header.
-    pub fn parse<R: ReadRef<'data>>(header: &Xcoff, data: R, offset: &mut u64) -> Result<Self> {
+    pub fn parse<R: ReadRef<'data>>(header: &Xcoff, data: R, offset: &mut u64) -> Result<Self>
+    where
+        Xcoff::SectionHeader: Pod,
+    {
         let section_num = header.f_nscns();
         if section_num == 0 {
             return Ok(SectionTable::default());
@@ -262,7 +265,7 @@ where
 
 /// A trait for generic access to `SectionHeader32` and `SectionHeader64`.
 #[allow(missing_docs)]
-pub trait SectionHeader: Debug + Pod {
+pub trait SectionHeader: Debug {
     type Word: Into<u64>;
     type HalfWord: Into<u32>;
     type Xcoff: FileHeader<SectionHeader = Self, Word = Self::Word>;

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -91,12 +91,18 @@ where
     }
 
     /// Return the symbol at the given index.
-    pub fn symbol(&self, index: usize) -> Result<&'data Xcoff::Symbol> {
+    pub fn symbol(&self, index: usize) -> Result<&'data Xcoff::Symbol>
+    where
+        Xcoff::Symbol: Pod,
+    {
         self.get::<Xcoff::Symbol>(index, 0)
     }
 
     /// Return a file auxiliary symbol.
-    pub fn aux_file(&self, index: usize, offset: usize) -> Result<&'data Xcoff::FileAux> {
+    pub fn aux_file(&self, index: usize, offset: usize) -> Result<&'data Xcoff::FileAux>
+    where
+        Xcoff::Symbol: Pod,
+    {
         debug_assert!(self.symbol(index)?.has_aux_file());
         let aux_file = self.get::<Xcoff::FileAux>(index, offset)?;
         if let Some(aux_type) = aux_file.x_auxtype() {
@@ -108,7 +114,10 @@ where
     }
 
     /// Return the csect auxiliary symbol.
-    pub fn aux_csect(&self, index: usize, offset: usize) -> Result<&'data Xcoff::CsectAux> {
+    pub fn aux_csect(&self, index: usize, offset: usize) -> Result<&'data Xcoff::CsectAux>
+    where
+        Xcoff::Symbol: Pod,
+    {
         debug_assert!(self.symbol(index)?.has_aux_csect());
         let aux_csect = self.get::<Xcoff::CsectAux>(index, offset)?;
         if let Some(aux_type) = aux_csect.x_auxtype() {
@@ -159,6 +168,8 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> read::private::Sealed
 
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbolTable<'data>
     for XcoffSymbolTable<'data, 'file, Xcoff, R>
+where
+    Xcoff::Symbol: Pod,
 {
     type Symbol = XcoffSymbol<'data, 'file, Xcoff, R>;
     type SymbolIterator = XcoffSymbolIterator<'data, 'file, Xcoff, R>;
@@ -210,6 +221,8 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> fmt::Debug
 
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> Iterator
     for XcoffSymbolIterator<'data, 'file, Xcoff, R>
+where
+    Xcoff::Symbol: Pod,
 {
     type Item = XcoffSymbol<'data, 'file, Xcoff, R>;
 
@@ -254,6 +267,8 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> read::private::Sealed
 
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
     for XcoffSymbol<'data, 'file, Xcoff, R>
+where
+    Xcoff::Symbol: Pod,
 {
     #[inline]
     fn index(&self) -> SymbolIndex {
@@ -454,7 +469,7 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
 
 /// A trait for generic access to `Symbol32` and `Symbol64`.
 #[allow(missing_docs)]
-pub trait Symbol: Debug + Pod {
+pub trait Symbol: Debug {
     type Word: Into<u64>;
 
     fn n_value(&self) -> Self::Word;

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -101,6 +101,7 @@ where
     /// Return a file auxiliary symbol.
     pub fn aux_file(&self, index: usize, offset: usize) -> Result<&'data Xcoff::FileAux>
     where
+        Xcoff::FileAux: Pod,
         Xcoff::Symbol: Pod,
     {
         debug_assert!(self.symbol(index)?.has_aux_file());
@@ -169,6 +170,7 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> read::private::Sealed
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbolTable<'data>
     for XcoffSymbolTable<'data, 'file, Xcoff, R>
 where
+    Xcoff::FileAux: Pod,
     Xcoff::Symbol: Pod,
 {
     type Symbol = XcoffSymbol<'data, 'file, Xcoff, R>;
@@ -268,6 +270,7 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> read::private::Sealed
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
     for XcoffSymbol<'data, 'file, Xcoff, R>
 where
+    Xcoff::FileAux: Pod,
     Xcoff::Symbol: Pod,
 {
     #[inline]
@@ -587,7 +590,7 @@ impl Symbol for xcoff::Symbol32 {
 
 /// A trait for generic access to `FileAux32` and `FileAux64`.
 #[allow(missing_docs)]
-pub trait FileAux: Debug + Pod {
+pub trait FileAux: Debug {
     fn x_fname(&self) -> &[u8; 8];
     fn x_ftype(&self) -> u8;
     fn x_auxtype(&self) -> Option<u8>;

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -22,7 +22,7 @@ use super::{FileHeader, XcoffFile};
 #[derive(Debug)]
 pub struct SymbolTable<'data, Xcoff, R = &'data [u8]>
 where
-    Xcoff: FileHeader,
+    Xcoff: FileHeader + ?Sized,
     R: ReadRef<'data>,
 {
     symbols: &'data [xcoff::SymbolBytes],
@@ -46,11 +46,11 @@ where
 
 impl<'data, Xcoff, R> SymbolTable<'data, Xcoff, R>
 where
-    Xcoff: FileHeader,
+    Xcoff: FileHeader + ?Sized,
     R: ReadRef<'data>,
 {
     /// Parse the symbol table.
-    pub fn parse(header: Xcoff, data: R) -> Result<Self> {
+    pub fn parse(header: &Xcoff, data: R) -> Result<Self> {
         let mut offset = header.f_symptr().into();
         let (symbols, strings) = if offset != 0 {
             let symbols = data

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -117,6 +117,7 @@ where
     /// Return the csect auxiliary symbol.
     pub fn aux_csect(&self, index: usize, offset: usize) -> Result<&'data Xcoff::CsectAux>
     where
+        Xcoff::CsectAux: Pod,
         Xcoff::Symbol: Pod,
     {
         debug_assert!(self.symbol(index)?.has_aux_csect());
@@ -170,6 +171,7 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> read::private::Sealed
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbolTable<'data>
     for XcoffSymbolTable<'data, 'file, Xcoff, R>
 where
+    Xcoff::CsectAux: Pod,
     Xcoff::FileAux: Pod,
     Xcoff::Symbol: Pod,
 {
@@ -270,6 +272,7 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> read::private::Sealed
 impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
     for XcoffSymbol<'data, 'file, Xcoff, R>
 where
+    Xcoff::CsectAux: Pod,
     Xcoff::FileAux: Pod,
     Xcoff::Symbol: Pod,
 {
@@ -647,7 +650,7 @@ impl FileAux for xcoff::FileAux32 {
 
 /// A trait for generic access to `CsectAux32` and `CsectAux64`.
 #[allow(missing_docs)]
-pub trait CsectAux: Debug + Pod {
+pub trait CsectAux: Debug {
     fn x_scnlen(&self) -> u64;
     fn x_parmhash(&self) -> u32;
     fn x_snhash(&self) -> u16;


### PR DESCRIPTION
Because Pod has a 'static bound, its present on many traits means it is
impossible to implement those traits on any type that has a non-static
lifetime. Removing the Pod bounds requires granular bounds elsewhere, which are
added here.
