### PR TITLE
read/coff: lower level parsing support for ImportObjectHeader

### DIFF
--- a/crates/examples/src/objdump.rs
+++ b/crates/examples/src/objdump.rs
@@ -22,7 +22,7 @@ pub fn print<W: Write, E: Write>(
                         writeln!(w)?;
                         writeln!(w, "{}:", String::from_utf8_lossy(member.name()))?;
                         if let Ok(data) = member.data(file) {
-                            if FileKind::parse(data) == Ok(FileKind::CoffImportFile) {
+                            if FileKind::parse(data) == Ok(FileKind::CoffImport) {
                                 dump_import(w, e, data)?;
                             } else {
                                 dump_object(w, e, data)?;
@@ -252,7 +252,7 @@ fn dump_parsed_object<W: Write, E: Write>(w: &mut W, e: &mut E, file: &object::F
 }
 
 fn dump_import<W: Write, E: Write>(w: &mut W, e: &mut E, data: &[u8]) -> Result<()> {
-    let file = match coff::CoffImportFile::parse(data) {
+    let file = match coff::ImportFile::parse(data) {
         Ok(import) => import,
         Err(err) => {
             writeln!(e, "Failed to parse short import: {}", err)?;

--- a/crates/examples/src/readobj/mod.rs
+++ b/crates/examples/src/readobj/mod.rs
@@ -193,6 +193,7 @@ fn print_object(p: &mut Printer<'_>, data: &[u8]) {
         object::FileKind::Archive => print_archive(p, data),
         object::FileKind::Coff => pe::print_coff(p, data),
         object::FileKind::CoffBig => pe::print_coff_big(p, data),
+        object::FileKind::CoffImport => pe::print_coff_import(p, data),
         object::FileKind::DyldCache => macho::print_dyld_cache(p, data),
         object::FileKind::Elf32 => elf::print_elf32(p, data),
         object::FileKind::Elf64 => elf::print_elf64(p, data),

--- a/crates/examples/testfiles/coff/import_msvc.lib.readobj
+++ b/crates/examples/testfiles/coff/import_msvc.lib.readobj
@@ -1,0 +1,1058 @@
+Format: Archive (Coff)
+
+Member: test_x64.dll
+Format: COFF import
+ImportObjectHeader {
+    Signature1: 0x0
+    Signature2: 0xFFFF
+    Version: 0
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    TimeDateStamp: 1687268223
+    SizeOfData: 0x15
+    OrdinalOrHint: 2
+    ImportType: IMPORT_OBJECT_CODE (0x0)
+    NameType: IMPORT_OBJECT_NAME (0x1)
+    Symbol: "foo_x64"
+    Dll: "test_x64.dll"
+}
+
+Member: test_x64.dll
+Format: COFF import
+ImportObjectHeader {
+    Signature1: 0x0
+    Signature2: 0xFFFF
+    Version: 0
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    TimeDateStamp: 1687268223
+    SizeOfData: 0x15
+    OrdinalOrHint: 1
+    ImportType: IMPORT_OBJECT_CODE (0x0)
+    NameType: IMPORT_OBJECT_ORDINAL (0x0)
+    Symbol: "bar_x64"
+    Dll: "test_x64.dll"
+}
+
+Member: test_x64.dll
+Format: COFF import
+ImportObjectHeader {
+    Signature1: 0x0
+    Signature2: 0xFFFF
+    Version: 0
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    TimeDateStamp: 1687268223
+    SizeOfData: 0x15
+    OrdinalOrHint: 1
+    ImportType: IMPORT_OBJECT_DATA (0x1)
+    NameType: IMPORT_OBJECT_NAME (0x1)
+    Symbol: "FOO_x64"
+    Dll: "test_x64.dll"
+}
+
+Member: test_x64.dll
+Format: COFF import
+ImportObjectHeader {
+    Signature1: 0x0
+    Signature2: 0xFFFF
+    Version: 0
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    TimeDateStamp: 1687268223
+    SizeOfData: 0x15
+    OrdinalOrHint: 0
+    ImportType: IMPORT_OBJECT_CONST (0x2)
+    NameType: IMPORT_OBJECT_NAME (0x1)
+    Symbol: "BAR_x64"
+    Dll: "test_x64.dll"
+}
+
+Member: test_x64.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    NumberOfSections: 3
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0xDE
+    NumberOfSymbols: 2
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x0
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x42
+    PointerToRawData: 0x8C
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$5"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x8
+    PointerToRawData: 0xCE
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0400040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_8BYTES (0x400000)
+}
+ImageSectionHeader {
+    Index: 3
+    Name: ".idata$4"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x8
+    PointerToRawData: 0xD6
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0400040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_8BYTES (0x400000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "test_x64_NULL_THUNK_DATA"
+    Value: 0x0
+    Section: ".idata$5" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_x64.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    NumberOfSections: 2
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0xBA
+    NumberOfSymbols: 2
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x0
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x42
+    PointerToRawData: 0x64
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$3"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x14
+    PointerToRawData: 0xA6
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "__NULL_IMPORT_DESCRIPTOR"
+    Value: 0x0
+    Section: ".idata$3" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_x64.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_AMD64 (0x8664)
+    NumberOfSections: 3
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0x10E
+    NumberOfSymbols: 8
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x0
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x42
+    PointerToRawData: 0x8C
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$2"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x14
+    PointerToRawData: 0xCE
+    PointerToRelocations: 0xE2
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 3
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+    ImageRelocation {
+        VirtualAddress: 0xC
+        Symbol: ".idata$6" (0x3)
+        Type: IMAGE_REL_AMD64_ADDR32NB (0x3)
+    }
+    ImageRelocation {
+        VirtualAddress: 0x0
+        Symbol: ".idata$4" (0x4)
+        Type: IMAGE_REL_AMD64_ADDR32NB (0x3)
+    }
+    ImageRelocation {
+        VirtualAddress: 0x10
+        Symbol: ".idata$5" (0x5)
+        Type: IMAGE_REL_AMD64_ADDR32NB (0x3)
+    }
+}
+ImageSectionHeader {
+    Index: 3
+    Name: ".idata$6"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0xE
+    PointerToRawData: 0x100
+    PointerToRelocations: 0xE2
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0200040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_2BYTES (0x200000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "__IMPORT_DESCRIPTOR_test_x64"
+    Value: 0x0
+    Section: ".idata$2" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 2
+    Name: ".idata$2"
+    Value: 0xC0000040
+    Section: ".idata$2" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 3
+    Name: ".idata$6"
+    Value: 0x0
+    Section: ".idata$6" (0x3)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 4
+    Name: ".idata$4"
+    Value: 0xC0000040
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 5
+    Name: ".idata$5"
+    Value: 0xC0000040
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 6
+    Name: "__NULL_IMPORT_DESCRIPTOR"
+    Value: 0x0
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 7
+    Name: "test_x64_NULL_THUNK_DATA"
+    Value: 0x0
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_x86.dll
+Format: COFF import
+ImportObjectHeader {
+    Signature1: 0x0
+    Signature2: 0xFFFF
+    Version: 0
+    Machine: IMAGE_FILE_MACHINE_I386 (0x14C)
+    TimeDateStamp: 1687268223
+    SizeOfData: 0x16
+    OrdinalOrHint: 0
+    ImportType: IMPORT_OBJECT_CODE (0x0)
+    NameType: IMPORT_OBJECT_NAME_NO_PREFIX (0x2)
+    Symbol: "_foo_x86"
+    Dll: "test_x86.dll"
+}
+
+Member: test_x86.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_I386 (0x14C)
+    NumberOfSections: 3
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0xD6
+    NumberOfSymbols: 2
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x100
+        IMAGE_FILE_32BIT_MACHINE (0x100)
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x42
+    PointerToRawData: 0x8C
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$5"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x4
+    PointerToRawData: 0xCE
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+}
+ImageSectionHeader {
+    Index: 3
+    Name: ".idata$4"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x4
+    PointerToRawData: 0xD2
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "test_x86_NULL_THUNK_DATA"
+    Value: 0x0
+    Section: ".idata$5" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_x86.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_I386 (0x14C)
+    NumberOfSections: 2
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0xBA
+    NumberOfSymbols: 2
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x100
+        IMAGE_FILE_32BIT_MACHINE (0x100)
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x42
+    PointerToRawData: 0x64
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$3"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x14
+    PointerToRawData: 0xA6
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "__NULL_IMPORT_DESCRIPTOR"
+    Value: 0x0
+    Section: ".idata$3" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_x86.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_I386 (0x14C)
+    NumberOfSections: 3
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0x10E
+    NumberOfSymbols: 8
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x100
+        IMAGE_FILE_32BIT_MACHINE (0x100)
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x42
+    PointerToRawData: 0x8C
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$2"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x14
+    PointerToRawData: 0xCE
+    PointerToRelocations: 0xE2
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 3
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+    ImageRelocation {
+        VirtualAddress: 0xC
+        Symbol: ".idata$6" (0x3)
+        Type: IMAGE_REL_I386_DIR32NB (0x7)
+    }
+    ImageRelocation {
+        VirtualAddress: 0x0
+        Symbol: ".idata$4" (0x4)
+        Type: IMAGE_REL_I386_DIR32NB (0x7)
+    }
+    ImageRelocation {
+        VirtualAddress: 0x10
+        Symbol: ".idata$5" (0x5)
+        Type: IMAGE_REL_I386_DIR32NB (0x7)
+    }
+}
+ImageSectionHeader {
+    Index: 3
+    Name: ".idata$6"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0xE
+    PointerToRawData: 0x100
+    PointerToRelocations: 0xE2
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0200040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_2BYTES (0x200000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "__IMPORT_DESCRIPTOR_test_x86"
+    Value: 0x0
+    Section: ".idata$2" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 2
+    Name: ".idata$2"
+    Value: 0xC0000040
+    Section: ".idata$2" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 3
+    Name: ".idata$6"
+    Value: 0x0
+    Section: ".idata$6" (0x3)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 4
+    Name: ".idata$4"
+    Value: 0xC0000040
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 5
+    Name: ".idata$5"
+    Value: 0xC0000040
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 6
+    Name: "__NULL_IMPORT_DESCRIPTOR"
+    Value: 0x0
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 7
+    Name: "test_x86_NULL_THUNK_DATA"
+    Value: 0x0
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_arm64ec.dll
+Format: COFF import
+ImportObjectHeader {
+    Signature1: 0x0
+    Signature2: 0xFFFF
+    Version: 0
+    Machine: 0xA641
+    TimeDateStamp: 1687268223
+    SizeOfData: 0x2A
+    OrdinalOrHint: 0
+    ImportType: IMPORT_OBJECT_CODE (0x0)
+    NameType: IMPORT_OBJECT_NAME_EXPORTAS (0x4)
+    Symbol: "#foo_arm64ec"
+    Dll: "test_arm64ec.dll"
+    Export: "foo_arm64ec"
+}
+
+Member: test_arm64ec.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_ARM64 (0xAA64)
+    NumberOfSections: 3
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0xE2
+    NumberOfSymbols: 2
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x0
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x46
+    PointerToRawData: 0x8C
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$5"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x8
+    PointerToRawData: 0xD2
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0400040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_8BYTES (0x400000)
+}
+ImageSectionHeader {
+    Index: 3
+    Name: ".idata$4"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x8
+    PointerToRawData: 0xDA
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0400040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_8BYTES (0x400000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "test_arm64ec_NULL_THUNK_DATA"
+    Value: 0x0
+    Section: ".idata$5" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_arm64ec.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_ARM64 (0xAA64)
+    NumberOfSections: 2
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0xBE
+    NumberOfSymbols: 2
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x0
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x46
+    PointerToRawData: 0x64
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$3"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x14
+    PointerToRawData: 0xAA
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "__NULL_IMPORT_DESCRIPTOR"
+    Value: 0x0
+    Section: ".idata$3" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+
+Member: test_arm64ec.dll
+Format: COFF
+ImageFileHeader {
+    Machine: IMAGE_FILE_MACHINE_ARM64 (0xAA64)
+    NumberOfSections: 3
+    TimeDateStamp: 1687268223
+    PointerToSymbolTable: 0x116
+    NumberOfSymbols: 8
+    SizeOfOptionalHeader: 0x0
+    Characteristics: 0x0
+}
+ImageSectionHeader {
+    Index: 1
+    Name: ".debug$S"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x46
+    PointerToRawData: 0x8C
+    PointerToRelocations: 0x0
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0x42100040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_ALIGN_1BYTES (0x100000)
+}
+ImageSectionHeader {
+    Index: 2
+    Name: ".idata$2"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x14
+    PointerToRawData: 0xD2
+    PointerToRelocations: 0xE6
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 3
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0300040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_4BYTES (0x300000)
+    ImageRelocation {
+        VirtualAddress: 0xC
+        Symbol: ".idata$6" (0x3)
+        Type: IMAGE_REL_ARM64_ADDR32NB (0x2)
+    }
+    ImageRelocation {
+        VirtualAddress: 0x0
+        Symbol: ".idata$4" (0x4)
+        Type: IMAGE_REL_ARM64_ADDR32NB (0x2)
+    }
+    ImageRelocation {
+        VirtualAddress: 0x10
+        Symbol: ".idata$5" (0x5)
+        Type: IMAGE_REL_ARM64_ADDR32NB (0x2)
+    }
+}
+ImageSectionHeader {
+    Index: 3
+    Name: ".idata$6"
+    VirtualSize: 0x0
+    VirtualAddress: 0x0
+    SizeOfRawData: 0x12
+    PointerToRawData: 0x104
+    PointerToRelocations: 0xE6
+    PointerToLinenumbers: 0x0
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    Characteristics: 0xC0200040
+        IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+        IMAGE_SCN_MEM_READ (0x40000000)
+        IMAGE_SCN_MEM_WRITE (0x80000000)
+        IMAGE_SCN_ALIGN_2BYTES (0x200000)
+}
+ImageSymbol {
+    Index: 0
+    Name: "@comp.id"
+    Value: 0x1017DD9
+    Section: IMAGE_SYM_ABSOLUTE (-1)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 1
+    Name: "__IMPORT_DESCRIPTOR_test_arm64ec"
+    Value: 0x0
+    Section: ".idata$2" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 2
+    Name: ".idata$2"
+    Value: 0xC0000040
+    Section: ".idata$2" (0x2)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 3
+    Name: ".idata$6"
+    Value: 0x0
+    Section: ".idata$6" (0x3)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 4
+    Name: ".idata$4"
+    Value: 0xC0000040
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 5
+    Name: ".idata$5"
+    Value: 0xC0000040
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_SECTION (0x68)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 6
+    Name: "__NULL_IMPORT_DESCRIPTOR"
+    Value: 0x0
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}
+ImageSymbol {
+    Index: 7
+    Name: "test_arm64ec_NULL_THUNK_DATA"
+    Value: 0x0
+    Section: IMAGE_SYM_UNDEFINED (0)
+    Type: 0x0
+    BaseType: IMAGE_SYM_TYPE_NULL (0x0)
+    DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL (0x2)
+    NumberOfAuxSymbols: 0x0
+}

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -2873,10 +2873,14 @@ pub struct ImportObjectHeader {
     pub name_type: U16<LE>,
 }
 
+pub const IMPORT_OBJECT_TYPE_MASK: u16 = 0b11;
+pub const IMPORT_OBJECT_TYPE_SHIFT: u16 = 0;
 pub const IMPORT_OBJECT_CODE: u16 = 0;
 pub const IMPORT_OBJECT_DATA: u16 = 1;
 pub const IMPORT_OBJECT_CONST: u16 = 2;
 
+pub const IMPORT_OBJECT_NAME_MASK: u16 = 0b111;
+pub const IMPORT_OBJECT_NAME_SHIFT: u16 = 2;
 /// Import by ordinal
 pub const IMPORT_OBJECT_ORDINAL: u16 = 0;
 /// Import name == public symbol name.

--- a/src/read/coff/import.rs
+++ b/src/read/coff/import.rs
@@ -7,31 +7,24 @@ use crate::read::{Architecture, Error, ReadError, ReadRef, Result};
 use crate::{pe, ByteString, Bytes, LittleEndian as LE};
 
 /// A Windows short form description of a symbol to import.
-/// Used in Windows import libraries. This is not an object file.
+///
+/// Used in Windows import libraries to provide a mapping from
+/// a symbol name to a DLL export. This is not an object file.
 #[derive(Debug, Clone)]
-pub struct CoffImportFile<'data> {
+pub struct ImportFile<'data> {
     header: &'data pe::ImportObjectHeader,
+    kind: ImportType,
     dll: ByteString<'data>,
     symbol: ByteString<'data>,
-    kind: ImportType,
     import: Option<ByteString<'data>>,
 }
-impl<'data> CoffImportFile<'data> {
+
+impl<'data> ImportFile<'data> {
     /// Parse it.
     pub fn parse<R: ReadRef<'data>>(data: R) -> Result<Self> {
         let mut offset = 0;
         let header = pe::ImportObjectHeader::parse(data, &mut offset)?;
-        let data_size = header.size_of_data.get(LE);
-        let mut strings = Bytes(
-            data.read_bytes(&mut offset, data_size as u64)
-                .read_error("Invalid COFF import library data size")?,
-        );
-        let symbol = strings
-            .read_string()
-            .read_error("Could not read COFF import library symbol name")?;
-        let dll = strings
-            .read_string()
-            .read_error("Could not read COFF import library DLL name")?;
+        let data = header.parse_data(data, &mut offset)?;
 
         // Unmangles a name by removing a `?`, `@` or `_` prefix.
         fn strip_prefix(s: &[u8]) -> &[u8] {
@@ -42,29 +35,26 @@ impl<'data> CoffImportFile<'data> {
         }
         Ok(Self {
             header,
-            dll: ByteString(dll),
-            symbol: ByteString(symbol),
-            kind: match header.name_type.get(LE) & 0b11 {
+            dll: data.dll,
+            symbol: data.symbol,
+            kind: match header.import_type() {
                 pe::IMPORT_OBJECT_CODE => ImportType::Code,
                 pe::IMPORT_OBJECT_DATA => ImportType::Data,
                 pe::IMPORT_OBJECT_CONST => ImportType::Const,
-                0b11 => return Err(Error("Invalid COFF import library import type")),
-                _ => unreachable!("COFF import library ImportType must be a two bit number"),
+                _ => return Err(Error("Invalid COFF import library import type")),
             },
-            import: match (header.name_type.get(LE) >> 2) & 0b111 {
+            import: match header.name_type() {
                 pe::IMPORT_OBJECT_ORDINAL => None,
-                pe::IMPORT_OBJECT_NAME => Some(symbol),
-                pe::IMPORT_OBJECT_NAME_NO_PREFIX => Some(strip_prefix(symbol)),
-                pe::IMPORT_OBJECT_NAME_UNDECORATE => {
-                    Some(strip_prefix(symbol).split(|&b| b == b'@').next().unwrap())
-                }
-                pe::IMPORT_OBJECT_NAME_EXPORTAS => Some(
-                    strings
-                        .read_string()
-                        .read_error("Could not read COFF import library export name")?,
+                pe::IMPORT_OBJECT_NAME => Some(data.symbol()),
+                pe::IMPORT_OBJECT_NAME_NO_PREFIX => Some(strip_prefix(data.symbol())),
+                pe::IMPORT_OBJECT_NAME_UNDECORATE => Some(
+                    strip_prefix(data.symbol())
+                        .split(|&b| b == b'@')
+                        .next()
+                        .unwrap(),
                 ),
-                5..=7 => return Err(Error("Unknown COFF import library name type")),
-                _ => unreachable!("COFF import library name type must be a three bit number"),
+                pe::IMPORT_OBJECT_NAME_EXPORTAS => data.export(),
+                _ => return Err(Error("Unknown COFF import library name type")),
             }
             .map(ByteString),
         })
@@ -79,6 +69,11 @@ impl<'data> CoffImportFile<'data> {
             pe::IMAGE_FILE_MACHINE_AMD64 => Architecture::X86_64,
             _ => Architecture::Unknown,
         }
+    }
+
+    /// The public symbol name.
+    pub fn symbol(&self) -> &'data [u8] {
+        self.symbol.0
     }
 
     /// The name of the DLL to import the symbol from.
@@ -98,14 +93,9 @@ impl<'data> CoffImportFile<'data> {
     pub fn import_type(&self) -> ImportType {
         self.kind
     }
-
-    /// The public symbol name
-    pub fn symbol(&self) -> &'data [u8] {
-        self.symbol.0
-    }
 }
 
-/// The name or ordinal to import.
+/// The name or ordinal to import from a DLL.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImportName<'data> {
     /// Import by ordinal. Ordinarily this is a 1-based index.
@@ -114,12 +104,12 @@ pub enum ImportName<'data> {
     Name(&'data [u8]),
 }
 
-/// The kind of import.
+/// The kind of import symbol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ImportType {
-    /// Executable code
+    /// An executable code symbol.
     Code,
-    /// Some data
+    /// A data symbol.
     Data,
     /// A constant value.
     Const,
@@ -132,7 +122,7 @@ impl pe::ImportObjectHeader {
     /// Directly following this header will be the string data.
     pub fn parse<'data, R: ReadRef<'data>>(data: R, offset: &mut u64) -> Result<&'data Self> {
         let header = data
-            .read::<crate::pe::ImportObjectHeader>(offset)
+            .read::<pe::ImportObjectHeader>(offset)
             .read_error("Invalid COFF import library header size")?;
         if header.sig1.get(LE) != 0 || header.sig2.get(LE) != pe::IMPORT_OBJECT_HDR_SIG2 {
             Err(Error("Invalid COFF import library header"))
@@ -141,5 +131,79 @@ impl pe::ImportObjectHeader {
         } else {
             Ok(header)
         }
+    }
+
+    /// Parse the data following the header.
+    pub fn parse_data<'data, R: ReadRef<'data>>(
+        &self,
+        data: R,
+        offset: &mut u64,
+    ) -> Result<ImportObjectData<'data>> {
+        let mut data = Bytes(
+            data.read_bytes(offset, u64::from(self.size_of_data.get(LE)))
+                .read_error("Invalid COFF import library data size")?,
+        );
+        let symbol = data
+            .read_string()
+            .map(ByteString)
+            .read_error("Could not read COFF import library symbol name")?;
+        let dll = data
+            .read_string()
+            .map(ByteString)
+            .read_error("Could not read COFF import library DLL name")?;
+        let export = if self.name_type() == pe::IMPORT_OBJECT_NAME_EXPORTAS {
+            data.read_string()
+                .map(ByteString)
+                .map(Some)
+                .read_error("Could not read COFF import library export name")?
+        } else {
+            None
+        };
+        Ok(ImportObjectData {
+            symbol,
+            dll,
+            export,
+        })
+    }
+
+    /// The type of import.
+    ///
+    /// This is one of the `IMPORT_OBJECT_*` constants.
+    pub fn import_type(&self) -> u16 {
+        self.name_type.get(LE) & pe::IMPORT_OBJECT_TYPE_MASK
+    }
+
+    /// The type of import name.
+    ///
+    /// This is one of the `IMPORT_OBJECT_*` constants.
+    pub fn name_type(&self) -> u16 {
+        (self.name_type.get(LE) >> pe::IMPORT_OBJECT_NAME_SHIFT) & pe::IMPORT_OBJECT_NAME_MASK
+    }
+}
+
+/// The data following `ImportObjectHeader`.
+#[derive(Debug, Clone)]
+pub struct ImportObjectData<'data> {
+    symbol: ByteString<'data>,
+    dll: ByteString<'data>,
+    export: Option<ByteString<'data>>,
+}
+
+impl<'data> ImportObjectData<'data> {
+    /// The public symbol name.
+    pub fn symbol(&self) -> &'data [u8] {
+        self.symbol.0
+    }
+
+    /// The name of the DLL to import the symbol from.
+    pub fn dll(&self) -> &'data [u8] {
+        self.dll.0
+    }
+
+    /// The name exported from the DLL.
+    ///
+    /// This is only set if the name is not derived from the symbol name.
+    pub fn export(&self) -> Option<&'data [u8]> {
+        self.export.map(|export| export.0)
     }
 }


### PR DESCRIPTION
Add lower level parsing support for ImportObjectHeader and use it in the readobj example.

Also some style changes for the import object file support.

cc @ChrisDenton 