### PR TITLE
Implement `Sym` for `ElfSymbol32` and `ElfSymbol64`

### DIFF
--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -448,7 +448,7 @@ pub trait FileHeader: Debug + Pod {
     type CompressionHeader: CompressionHeader<Endian = Self::Endian, Word = Self::Word>;
     type NoteHeader: NoteHeader<Endian = Self::Endian>;
     type Dyn: Dyn<Endian = Self::Endian, Word = Self::Word>;
-    type Sym: Sym<Endian = Self::Endian, Word = Self::Word>;
+    type Sym: Sym<Endian = Self::Endian, Word = Self::Word> + Pod + Debug;
     type Rel: Rel<Endian = Self::Endian, Word = Self::Word>;
     type Rela: Rela<Endian = Self::Endian, Word = Self::Word> + From<Self::Rel>;
 

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -5,7 +5,6 @@ use core::slice;
 use core::str;
 
 use crate::endian::{self, Endianness};
-use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
     self, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, SectionIndex, SymbolFlags,
@@ -437,7 +436,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
 
 /// A trait for generic access to `Sym32` and `Sym64`.
 #[allow(missing_docs)]
-pub trait Sym: Debug + Pod {
+pub trait Sym {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -573,5 +572,113 @@ impl<Endian: endian::Endian> Sym for elf::Sym64<Endian> {
     #[inline]
     fn st_size(&self, endian: Self::Endian) -> Self::Word {
         self.st_size.get(endian)
+    }
+}
+
+impl<'data, 'file, Endian, R> Sym for ElfSymbol32<'data, 'file, Endian, R>
+where
+    Endian: endian::Endian,
+    R: ReadRef<'data>,
+{
+    type Word = u32;
+    type Endian = Endian;
+
+    #[inline]
+    fn st_name(&self, endian: Self::Endian) -> u32 {
+        self.symbol.st_name(endian)
+    }
+
+    #[inline]
+    fn st_info(&self) -> u8 {
+        self.symbol.st_info()
+    }
+
+    #[inline]
+    fn st_bind(&self) -> u8 {
+        self.symbol.st_bind()
+    }
+
+    #[inline]
+    fn st_type(&self) -> u8 {
+        self.symbol.st_type()
+    }
+
+    #[inline]
+    fn st_other(&self) -> u8 {
+        self.symbol.st_other()
+    }
+
+    #[inline]
+    fn st_visibility(&self) -> u8 {
+        self.symbol.st_visibility()
+    }
+
+    #[inline]
+    fn st_shndx(&self, endian: Self::Endian) -> u16 {
+        self.symbol.st_shndx(endian)
+    }
+
+    #[inline]
+    fn st_value(&self, endian: Self::Endian) -> Self::Word {
+        self.symbol.st_value(endian)
+    }
+
+    #[inline]
+    fn st_size(&self, endian: Self::Endian) -> Self::Word {
+        self.symbol.st_size(endian)
+    }
+}
+
+impl<'data, 'file, Endian, R> Sym for ElfSymbol64<'data, 'file, Endian, R>
+where
+    Endian: endian::Endian,
+    R: ReadRef<'data>,
+{
+    type Word = u64;
+    type Endian = Endian;
+
+    #[inline]
+    fn st_name(&self, endian: Self::Endian) -> u32 {
+        self.symbol.st_name(endian)
+    }
+
+    #[inline]
+    fn st_info(&self) -> u8 {
+        self.symbol.st_info()
+    }
+
+    #[inline]
+    fn st_bind(&self) -> u8 {
+        self.symbol.st_bind()
+    }
+
+    #[inline]
+    fn st_type(&self) -> u8 {
+        self.symbol.st_type()
+    }
+
+    #[inline]
+    fn st_other(&self) -> u8 {
+        self.symbol.st_other()
+    }
+
+    #[inline]
+    fn st_visibility(&self) -> u8 {
+        self.symbol.st_visibility()
+    }
+
+    #[inline]
+    fn st_shndx(&self, endian: Self::Endian) -> u16 {
+        self.symbol.st_shndx(endian)
+    }
+
+    #[inline]
+    fn st_value(&self, endian: Self::Endian) -> Self::Word {
+        self.symbol.st_value(endian)
+    }
+
+    #[inline]
+    fn st_size(&self, endian: Self::Endian) -> Self::Word {
+        self.symbol.st_size(endian)
     }
 }


### PR DESCRIPTION
I'm switching one of my projects from `goblin` to `object`, and getting access to raw ELF fields having an `ElfSymbol32`/`ElfSymbol64` seems... frustratingly impossible? Is there any particular reason why the `Sym` trait isn't just simply implemented for `ElfSymbol32` and `ElfSymbol64`, like I've done here in this PR?