### PR TITLE
ci: switch to powerpc64 for big endian test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
           # A 32-bit target.
           - "i686-unknown-linux-gnu"
           # A big-endian target
-          - "mips64-unknown-linux-gnuabi64"
+          - "powerpc64-unknown-linux-gnu"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -76,6 +76,9 @@ jobs:
           submodules: true
       - name: Install rust
         run: rustup update 1.60.0 && rustup default 1.60.0
+      - name: MSRV dependencies
+        run: |
+          cargo update -p memchr --precise 2.6.2
       - name: Test
         run: cargo test --verbose --no-default-features --features read,std
 


### PR DESCRIPTION
mips64 isn't available currently.