### PR TITLE
write/macho: change output to more closely match LLVM

### DIFF
--- a/crates/examples/src/objcopy.rs
+++ b/crates/examples/src/objcopy.rs
@@ -161,5 +161,17 @@ pub fn copy(in_data: &[u8]) -> Vec<u8> {
         });
     }
 
+    if let Some(in_build_version) = match &in_object {
+        object::File::MachO32(file) => file.build_version().unwrap(),
+        object::File::MachO64(file) => file.build_version().unwrap(),
+        _ => None,
+    } {
+        let mut out_build_version = object::write::MachOBuildVersion::default();
+        out_build_version.platform = in_build_version.platform.get(in_object.endianness());
+        out_build_version.minos = in_build_version.minos.get(in_object.endianness());
+        out_build_version.sdk = in_build_version.sdk.get(in_object.endianness());
+        out_object.set_macho_build_version(out_build_version);
+    }
+
     out_object.write().unwrap()
 }

--- a/crates/examples/testfiles/macho/base-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-aarch64.o.objcopy
@@ -5,8 +5,8 @@ MachHeader {
     CpuSubtype: 0x0
         CPU_SUBTYPE_ARM64_ALL (0x0)
     FileType: MH_OBJECT (0x1)
-    NumberOfCmds: 3
-    SizeOfCmds: 0x1A0
+    NumberOfCmds: 4
+    SizeOfCmds: 0x1B8
     Flags: MH_SUBSECTIONS_VIA_SYMBOLS (0x2000)
 }
 SegmentCommand {
@@ -15,7 +15,7 @@ SegmentCommand {
     SegmentName: ""
     VmAddress: 0x0
     VmSize: 0x68
-    FileOffset: 0x1C0
+    FileOffset: 0x1D8
     FileSize: 0x68
     MaxProt: 0x7
         VM_PROT_READ (0x1)
@@ -33,9 +33,9 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x0
         Size: 0x34
-        Offset: 0x1C0
+        Offset: 0x1D8
         Align: 0x2
-        RelocationOffset: 0x2B0
+        RelocationOffset: 0x2C8
         NumberOfRelocations: 0x3
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -72,7 +72,7 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x34
         Size: 0xD
-        Offset: 0x1F4
+        Offset: 0x20C
         Align: 0x0
         RelocationOffset: 0x0
         NumberOfRelocations: 0x0
@@ -84,9 +84,9 @@ SegmentCommand {
         SegmentName: "__LD"
         Address: 0x48
         Size: 0x20
-        Offset: 0x208
+        Offset: 0x220
         Align: 0x3
-        RelocationOffset: 0x2C8
+        RelocationOffset: 0x2E0
         NumberOfRelocations: 0x1
         Flags: 0x2000000
             S_REGULAR (0x0)
@@ -101,12 +101,20 @@ SegmentCommand {
         }
     }
 }
+BuildVersionCommand {
+    Cmd: LC_BUILD_VERSION (0x32)
+    CmdSize: 0x18
+    Platform: PLATFORM_MACOS (0x1)
+    MinOs: 0xD0000
+    Sdk: 0xD0300
+    NumberOfTools: 0x0
+}
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x228
+    SymbolOffset: 0x240
     NumberOfSymbols: 0x6
-    StringOffset: 0x288
+    StringOffset: 0x2A0
     StringSize: 0x28
     Nlist {
         Index: 0

--- a/crates/examples/testfiles/macho/base-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-aarch64.o.objcopy
@@ -35,7 +35,7 @@ SegmentCommand {
         Size: 0x34
         Offset: 0x1D8
         Align: 0x2
-        RelocationOffset: 0x2C8
+        RelocationOffset: 0x240
         NumberOfRelocations: 0x3
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -86,7 +86,7 @@ SegmentCommand {
         Size: 0x20
         Offset: 0x220
         Align: 0x3
-        RelocationOffset: 0x2E0
+        RelocationOffset: 0x258
         NumberOfRelocations: 0x1
         Flags: 0x2000000
             S_REGULAR (0x0)
@@ -112,9 +112,9 @@ BuildVersionCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x240
+    SymbolOffset: 0x260
     NumberOfSymbols: 0x6
-    StringOffset: 0x2A0
+    StringOffset: 0x2C0
     StringSize: 0x28
     Nlist {
         Index: 0

--- a/crates/examples/testfiles/macho/base-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-aarch64.o.objcopy
@@ -5,8 +5,8 @@ MachHeader {
     CpuSubtype: 0x0
         CPU_SUBTYPE_ARM64_ALL (0x0)
     FileType: MH_OBJECT (0x1)
-    NumberOfCmds: 2
-    SizeOfCmds: 0x150
+    NumberOfCmds: 3
+    SizeOfCmds: 0x1A0
     Flags: MH_SUBSECTIONS_VIA_SYMBOLS (0x2000)
 }
 SegmentCommand {
@@ -15,7 +15,7 @@ SegmentCommand {
     SegmentName: ""
     VmAddress: 0x0
     VmSize: 0x68
-    FileOffset: 0x170
+    FileOffset: 0x1C0
     FileSize: 0x68
     MaxProt: 0x7
         VM_PROT_READ (0x1)
@@ -33,9 +33,9 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x0
         Size: 0x34
-        Offset: 0x170
+        Offset: 0x1C0
         Align: 0x2
-        RelocationOffset: 0x260
+        RelocationOffset: 0x2B0
         NumberOfRelocations: 0x3
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -72,7 +72,7 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x34
         Size: 0xD
-        Offset: 0x1A4
+        Offset: 0x1F4
         Align: 0x0
         RelocationOffset: 0x0
         NumberOfRelocations: 0x0
@@ -84,9 +84,9 @@ SegmentCommand {
         SegmentName: "__LD"
         Address: 0x48
         Size: 0x20
-        Offset: 0x1B8
+        Offset: 0x208
         Align: 0x3
-        RelocationOffset: 0x278
+        RelocationOffset: 0x2C8
         NumberOfRelocations: 0x1
         Flags: 0x2000000
             S_REGULAR (0x0)
@@ -104,9 +104,9 @@ SegmentCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x1D8
+    SymbolOffset: 0x228
     NumberOfSymbols: 0x6
-    StringOffset: 0x238
+    StringOffset: 0x288
     StringSize: 0x28
     Nlist {
         Index: 0
@@ -161,4 +161,26 @@ SymtabCommand {
             REFERENCE_FLAG_UNDEFINED_NON_LAZY (0x0)
         Value: 0x0
     }
+}
+DysymtabCommand {
+    Cmd: LC_DYSYMTAB (0xB)
+    CmdSize: 0x50
+    IndexOfLocalSymbols: 0
+    NumberOfLocalSymbols: 4
+    IndexOfExternallyDefinedSymbols: 4
+    NumberOfExternallyDefinedSymbols: 1
+    IndexOfUndefinedSymbols: 5
+    NumberOfUndefinedSymbols: 1
+    TocOffset: 0x0
+    NumberOfTocEntries: 0
+    ModuleTableOffset: 0x0
+    NumberOfModuleTableEntries: 0
+    ExternalRefSymbolOffset: 0x0
+    NumberOfExternalRefSymbols: 0
+    IndirectSymbolOffset: 0x0
+    NumberOfIndirectSymbols: 0
+    ExternalRelocationOffset: 0x0
+    NumberOfExternalRelocations: 0
+    LocalRelocationOffset: 0x0
+    NumberOfLocalRelocations: 0
 }

--- a/crates/examples/testfiles/macho/base-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-x86_64.o.objcopy
@@ -35,7 +35,7 @@ SegmentCommand {
         Size: 0x25
         Offset: 0x228
         Align: 0x4
-        RelocationOffset: 0x2F0
+        RelocationOffset: 0x2C0
         NumberOfRelocations: 0x2
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -78,7 +78,7 @@ SegmentCommand {
         Size: 0x20
         Offset: 0x260
         Align: 0x3
-        RelocationOffset: 0x300
+        RelocationOffset: 0x2D0
         NumberOfRelocations: 0x1
         Flags: 0x2000000
             S_REGULAR (0x0)
@@ -120,9 +120,9 @@ BuildVersionCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x2C0
+    SymbolOffset: 0x2D8
     NumberOfSymbols: 0x2
-    StringOffset: 0x2E0
+    StringOffset: 0x2F8
     StringSize: 0xF
     Nlist {
         Index: 0

--- a/crates/examples/testfiles/macho/base-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-x86_64.o.objcopy
@@ -5,8 +5,8 @@ MachHeader {
     CpuSubtype: 0x3
         CPU_SUBTYPE_X86_64_ALL (0x3)
     FileType: MH_OBJECT (0x1)
-    NumberOfCmds: 3
-    SizeOfCmds: 0x1F0
+    NumberOfCmds: 4
+    SizeOfCmds: 0x208
     Flags: MH_SUBSECTIONS_VIA_SYMBOLS (0x2000)
 }
 SegmentCommand {
@@ -15,7 +15,7 @@ SegmentCommand {
     SegmentName: ""
     VmAddress: 0x0
     VmSize: 0x98
-    FileOffset: 0x210
+    FileOffset: 0x228
     FileSize: 0x98
     MaxProt: 0x7
         VM_PROT_READ (0x1)
@@ -33,9 +33,9 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x0
         Size: 0x25
-        Offset: 0x210
+        Offset: 0x228
         Align: 0x4
-        RelocationOffset: 0x2D8
+        RelocationOffset: 0x2F0
         NumberOfRelocations: 0x2
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -64,7 +64,7 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x25
         Size: 0xD
-        Offset: 0x235
+        Offset: 0x24D
         Align: 0x0
         RelocationOffset: 0x0
         NumberOfRelocations: 0x0
@@ -76,9 +76,9 @@ SegmentCommand {
         SegmentName: "__LD"
         Address: 0x38
         Size: 0x20
-        Offset: 0x248
+        Offset: 0x260
         Align: 0x3
-        RelocationOffset: 0x2E8
+        RelocationOffset: 0x300
         NumberOfRelocations: 0x1
         Flags: 0x2000000
             S_REGULAR (0x0)
@@ -98,7 +98,7 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x58
         Size: 0x40
-        Offset: 0x268
+        Offset: 0x280
         Align: 0x3
         RelocationOffset: 0x0
         NumberOfRelocations: 0x0
@@ -109,12 +109,20 @@ SegmentCommand {
             S_ATTR_LIVE_SUPPORT (0x8000000)
     }
 }
+BuildVersionCommand {
+    Cmd: LC_BUILD_VERSION (0x32)
+    CmdSize: 0x18
+    Platform: PLATFORM_MACOS (0x1)
+    MinOs: 0xC0000
+    Sdk: 0xD0100
+    NumberOfTools: 0x0
+}
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x2A8
+    SymbolOffset: 0x2C0
     NumberOfSymbols: 0x2
-    StringOffset: 0x2C8
+    StringOffset: 0x2E0
     StringSize: 0xF
     Nlist {
         Index: 0

--- a/crates/examples/testfiles/macho/base-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-x86_64.o.objcopy
@@ -5,8 +5,8 @@ MachHeader {
     CpuSubtype: 0x3
         CPU_SUBTYPE_X86_64_ALL (0x3)
     FileType: MH_OBJECT (0x1)
-    NumberOfCmds: 2
-    SizeOfCmds: 0x1A0
+    NumberOfCmds: 3
+    SizeOfCmds: 0x1F0
     Flags: MH_SUBSECTIONS_VIA_SYMBOLS (0x2000)
 }
 SegmentCommand {
@@ -15,7 +15,7 @@ SegmentCommand {
     SegmentName: ""
     VmAddress: 0x0
     VmSize: 0x98
-    FileOffset: 0x1C0
+    FileOffset: 0x210
     FileSize: 0x98
     MaxProt: 0x7
         VM_PROT_READ (0x1)
@@ -33,9 +33,9 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x0
         Size: 0x25
-        Offset: 0x1C0
+        Offset: 0x210
         Align: 0x4
-        RelocationOffset: 0x288
+        RelocationOffset: 0x2D8
         NumberOfRelocations: 0x2
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -64,7 +64,7 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x25
         Size: 0xD
-        Offset: 0x1E5
+        Offset: 0x235
         Align: 0x0
         RelocationOffset: 0x0
         NumberOfRelocations: 0x0
@@ -76,9 +76,9 @@ SegmentCommand {
         SegmentName: "__LD"
         Address: 0x38
         Size: 0x20
-        Offset: 0x1F8
+        Offset: 0x248
         Align: 0x3
-        RelocationOffset: 0x298
+        RelocationOffset: 0x2E8
         NumberOfRelocations: 0x1
         Flags: 0x2000000
             S_REGULAR (0x0)
@@ -98,7 +98,7 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x58
         Size: 0x40
-        Offset: 0x218
+        Offset: 0x268
         Align: 0x3
         RelocationOffset: 0x0
         NumberOfRelocations: 0x0
@@ -112,9 +112,9 @@ SegmentCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x258
+    SymbolOffset: 0x2A8
     NumberOfSymbols: 0x2
-    StringOffset: 0x278
+    StringOffset: 0x2C8
     StringSize: 0xF
     Nlist {
         Index: 0
@@ -137,4 +137,26 @@ SymtabCommand {
             REFERENCE_FLAG_UNDEFINED_NON_LAZY (0x0)
         Value: 0x0
     }
+}
+DysymtabCommand {
+    Cmd: LC_DYSYMTAB (0xB)
+    CmdSize: 0x50
+    IndexOfLocalSymbols: 0
+    NumberOfLocalSymbols: 0
+    IndexOfExternallyDefinedSymbols: 0
+    NumberOfExternallyDefinedSymbols: 1
+    IndexOfUndefinedSymbols: 1
+    NumberOfUndefinedSymbols: 1
+    TocOffset: 0x0
+    NumberOfTocEntries: 0
+    ModuleTableOffset: 0x0
+    NumberOfModuleTableEntries: 0
+    ExternalRefSymbolOffset: 0x0
+    NumberOfExternalRefSymbols: 0
+    IndirectSymbolOffset: 0x0
+    NumberOfIndirectSymbols: 0
+    ExternalRelocationOffset: 0x0
+    NumberOfExternalRelocations: 0
+    LocalRelocationOffset: 0x0
+    NumberOfLocalRelocations: 0
 }

--- a/crates/examples/testfiles/macho/base-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-x86_64.o.objcopy
@@ -123,7 +123,7 @@ SymtabCommand {
     SymbolOffset: 0x2D8
     NumberOfSymbols: 0x2
     StringOffset: 0x2F8
-    StringSize: 0xF
+    StringSize: 0x10
     Nlist {
         Index: 0
         String: "_main" (0x1)

--- a/crates/examples/testfiles/macho/reloc-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/reloc-aarch64.o.objcopy
@@ -5,8 +5,8 @@ MachHeader {
     CpuSubtype: 0x0
         CPU_SUBTYPE_ARM64_ALL (0x0)
     FileType: MH_OBJECT (0x1)
-    NumberOfCmds: 2
-    SizeOfCmds: 0x100
+    NumberOfCmds: 3
+    SizeOfCmds: 0x150
     Flags: MH_SUBSECTIONS_VIA_SYMBOLS (0x2000)
 }
 SegmentCommand {
@@ -15,7 +15,7 @@ SegmentCommand {
     SegmentName: ""
     VmAddress: 0x0
     VmSize: 0x48
-    FileOffset: 0x120
+    FileOffset: 0x170
     FileSize: 0x48
     MaxProt: 0x7
         VM_PROT_READ (0x1)
@@ -33,9 +33,9 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x0
         Size: 0x28
-        Offset: 0x120
+        Offset: 0x170
         Align: 0x0
-        RelocationOffset: 0x1D4
+        RelocationOffset: 0x224
         NumberOfRelocations: 0xD
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -152,9 +152,9 @@ SegmentCommand {
         SegmentName: "__DATA"
         Address: 0x28
         Size: 0x20
-        Offset: 0x148
+        Offset: 0x198
         Align: 0x0
-        RelocationOffset: 0x23C
+        RelocationOffset: 0x28C
         NumberOfRelocations: 0x7
         Flags: S_REGULAR (0x0)
         RelocationInfo {
@@ -218,9 +218,9 @@ SegmentCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x168
+    SymbolOffset: 0x1B8
     NumberOfSymbols: 0x5
-    StringOffset: 0x1B8
+    StringOffset: 0x208
     StringSize: 0x1B
     Nlist {
         Index: 0
@@ -268,4 +268,26 @@ SymtabCommand {
             REFERENCE_FLAG_UNDEFINED_NON_LAZY (0x0)
         Value: 0x0
     }
+}
+DysymtabCommand {
+    Cmd: LC_DYSYMTAB (0xB)
+    CmdSize: 0x50
+    IndexOfLocalSymbols: 0
+    NumberOfLocalSymbols: 3
+    IndexOfExternallyDefinedSymbols: 3
+    NumberOfExternallyDefinedSymbols: 0
+    IndexOfUndefinedSymbols: 3
+    NumberOfUndefinedSymbols: 2
+    TocOffset: 0x0
+    NumberOfTocEntries: 0
+    ModuleTableOffset: 0x0
+    NumberOfModuleTableEntries: 0
+    ExternalRefSymbolOffset: 0x0
+    NumberOfExternalRefSymbols: 0
+    IndirectSymbolOffset: 0x0
+    NumberOfIndirectSymbols: 0
+    ExternalRelocationOffset: 0x0
+    NumberOfExternalRelocations: 0
+    LocalRelocationOffset: 0x0
+    NumberOfLocalRelocations: 0
 }

--- a/crates/examples/testfiles/macho/reloc-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/reloc-aarch64.o.objcopy
@@ -35,7 +35,7 @@ SegmentCommand {
         Size: 0x28
         Offset: 0x170
         Align: 0x0
-        RelocationOffset: 0x224
+        RelocationOffset: 0x1B8
         NumberOfRelocations: 0xD
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -154,7 +154,7 @@ SegmentCommand {
         Size: 0x20
         Offset: 0x198
         Align: 0x0
-        RelocationOffset: 0x28C
+        RelocationOffset: 0x220
         NumberOfRelocations: 0x7
         Flags: S_REGULAR (0x0)
         RelocationInfo {
@@ -218,9 +218,9 @@ SegmentCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x1B8
+    SymbolOffset: 0x258
     NumberOfSymbols: 0x5
-    StringOffset: 0x208
+    StringOffset: 0x2A8
     StringSize: 0x1B
     Nlist {
         Index: 0

--- a/crates/examples/testfiles/macho/reloc-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/reloc-aarch64.o.objcopy
@@ -221,7 +221,7 @@ SymtabCommand {
     SymbolOffset: 0x258
     NumberOfSymbols: 0x5
     StringOffset: 0x2A8
-    StringSize: 0x1B
+    StringSize: 0x20
     Nlist {
         Index: 0
         String: "ltmp0" (0x11)

--- a/crates/examples/testfiles/macho/reloc-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/reloc-x86_64.o.objcopy
@@ -5,8 +5,8 @@ MachHeader {
     CpuSubtype: 0x3
         CPU_SUBTYPE_X86_64_ALL (0x3)
     FileType: MH_OBJECT (0x1)
-    NumberOfCmds: 2
-    SizeOfCmds: 0x100
+    NumberOfCmds: 3
+    SizeOfCmds: 0x150
     Flags: 0x0
 }
 SegmentCommand {
@@ -15,7 +15,7 @@ SegmentCommand {
     SegmentName: ""
     VmAddress: 0x0
     VmSize: 0x6B
-    FileOffset: 0x120
+    FileOffset: 0x170
     FileSize: 0x6B
     MaxProt: 0x7
         VM_PROT_READ (0x1)
@@ -33,9 +33,9 @@ SegmentCommand {
         SegmentName: "__TEXT"
         Address: 0x0
         Size: 0x53
-        Offset: 0x120
+        Offset: 0x170
         Align: 0x0
-        RelocationOffset: 0x1BC
+        RelocationOffset: 0x20C
         NumberOfRelocations: 0xB
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -136,9 +136,9 @@ SegmentCommand {
         SegmentName: "__DATA"
         Address: 0x53
         Size: 0x18
-        Offset: 0x173
+        Offset: 0x1C3
         Align: 0x0
-        RelocationOffset: 0x214
+        RelocationOffset: 0x264
         NumberOfRelocations: 0x4
         Flags: S_REGULAR (0x0)
         RelocationInfo {
@@ -178,9 +178,9 @@ SegmentCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x190
+    SymbolOffset: 0x1E0
     NumberOfSymbols: 0x2
-    StringOffset: 0x1B0
+    StringOffset: 0x200
     StringSize: 0x9
     Nlist {
         Index: 0
@@ -198,4 +198,26 @@ SymtabCommand {
         Desc: 0x0
         Value: 0x5
     }
+}
+DysymtabCommand {
+    Cmd: LC_DYSYMTAB (0xB)
+    CmdSize: 0x50
+    IndexOfLocalSymbols: 0
+    NumberOfLocalSymbols: 2
+    IndexOfExternallyDefinedSymbols: 2
+    NumberOfExternallyDefinedSymbols: 0
+    IndexOfUndefinedSymbols: 2
+    NumberOfUndefinedSymbols: 0
+    TocOffset: 0x0
+    NumberOfTocEntries: 0
+    ModuleTableOffset: 0x0
+    NumberOfModuleTableEntries: 0
+    ExternalRefSymbolOffset: 0x0
+    NumberOfExternalRefSymbols: 0
+    IndirectSymbolOffset: 0x0
+    NumberOfIndirectSymbols: 0
+    ExternalRelocationOffset: 0x0
+    NumberOfExternalRelocations: 0
+    LocalRelocationOffset: 0x0
+    NumberOfLocalRelocations: 0
 }

--- a/crates/examples/testfiles/macho/reloc-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/reloc-x86_64.o.objcopy
@@ -181,7 +181,7 @@ SymtabCommand {
     SymbolOffset: 0x258
     NumberOfSymbols: 0x2
     StringOffset: 0x278
-    StringSize: 0x9
+    StringSize: 0x10
     Nlist {
         Index: 0
         String: "_g1" (0x5)

--- a/crates/examples/testfiles/macho/reloc-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/reloc-x86_64.o.objcopy
@@ -35,7 +35,7 @@ SegmentCommand {
         Size: 0x53
         Offset: 0x170
         Align: 0x0
-        RelocationOffset: 0x20C
+        RelocationOffset: 0x1E0
         NumberOfRelocations: 0xB
         Flags: 0x80000400
             S_REGULAR (0x0)
@@ -138,7 +138,7 @@ SegmentCommand {
         Size: 0x18
         Offset: 0x1C3
         Align: 0x0
-        RelocationOffset: 0x264
+        RelocationOffset: 0x238
         NumberOfRelocations: 0x4
         Flags: S_REGULAR (0x0)
         RelocationInfo {
@@ -178,9 +178,9 @@ SegmentCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x1E0
+    SymbolOffset: 0x258
     NumberOfSymbols: 0x2
-    StringOffset: 0x200
+    StringOffset: 0x278
     StringSize: 0x9
     Nlist {
         Index: 0

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -162,6 +162,34 @@ where
             .get(index)
             .read_error("Invalid Mach-O segment index")
     }
+
+    /// Returns the endianness.
+    pub fn endian(&self) -> Mach::Endian {
+        self.endian
+    }
+
+    /// Returns the raw data.
+    pub fn data(&self) -> R {
+        self.data
+    }
+
+    /// Returns the raw Mach-O file header.
+    pub fn raw_header(&self) -> &'data Mach {
+        self.header
+    }
+
+    /// Return the `LC_BUILD_VERSION` load command if present.
+    pub fn build_version(&self) -> Result<Option<&'data macho::BuildVersionCommand<Mach::Endian>>> {
+        let mut commands = self
+            .header
+            .load_commands(self.endian, self.data, self.header_offset)?;
+        while let Some(command) = commands.next()? {
+            if let Some(build_version) = command.build_version()? {
+                return Ok(Some(build_version));
+            }
+        }
+        Ok(None)
+    }
 }
 
 impl<'data, Mach, R> read::private::Sealed for MachOFile<'data, Mach, R>

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -247,6 +247,15 @@ impl<'data, E: Endian> LoadCommandData<'data, E> {
             Ok(None)
         }
     }
+
+    /// Try to parse this command as a `BuildVersionCommand`.
+    pub fn build_version(self) -> Result<Option<&'data macho::BuildVersionCommand<E>>> {
+        if self.cmd == macho::LC_BUILD_VERSION {
+            Some(self.data()).transpose()
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// A `LoadCommand` that has been interpreted according to its `cmd` field.

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -461,6 +461,7 @@ impl<'a> Object<'a> {
         // Start with null name.
         let mut strtab_data = vec![0];
         strtab.write(1, &mut strtab_data);
+        write_align(&mut strtab_data, pointer_align);
         offset += strtab_data.len();
 
         // Start writing.

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -218,39 +218,11 @@ fn macho_x86_64_tls() {
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok("_tls1"));
-    assert_eq!(symbol.kind(), SymbolKind::Tls);
-    assert_eq!(symbol.section_index(), Some(thread_vars_index));
-    assert_eq!(symbol.scope(), SymbolScope::Linkage);
-    assert_eq!(symbol.is_weak(), false);
-    assert_eq!(symbol.is_undefined(), false);
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
     let tls1_init_symbol = symbol.index();
     assert_eq!(symbol.name(), Ok("_tls1$tlv$init"));
     assert_eq!(symbol.kind(), SymbolKind::Tls);
     assert_eq!(symbol.section_index(), Some(thread_data_index));
     assert_eq!(symbol.scope(), SymbolScope::Compilation);
-    assert_eq!(symbol.is_weak(), false);
-    assert_eq!(symbol.is_undefined(), false);
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
-    let tlv_bootstrap_symbol = symbol.index();
-    assert_eq!(symbol.name(), Ok("__tlv_bootstrap"));
-    assert_eq!(symbol.kind(), SymbolKind::Unknown);
-    assert_eq!(symbol.section_index(), None);
-    assert_eq!(symbol.scope(), SymbolScope::Unknown);
-    assert_eq!(symbol.is_weak(), false);
-    assert_eq!(symbol.is_undefined(), true);
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok("_tls2"));
-    assert_eq!(symbol.kind(), SymbolKind::Tls);
-    assert_eq!(symbol.section_index(), Some(thread_vars_index));
-    assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), false);
 
@@ -263,6 +235,34 @@ fn macho_x86_64_tls() {
     assert_eq!(symbol.scope(), SymbolScope::Compilation);
     assert_eq!(symbol.is_weak(), false);
     assert_eq!(symbol.is_undefined(), false);
+
+    let symbol = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Ok("_tls1"));
+    assert_eq!(symbol.kind(), SymbolKind::Tls);
+    assert_eq!(symbol.section_index(), Some(thread_vars_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+
+    let symbol = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    assert_eq!(symbol.name(), Ok("_tls2"));
+    assert_eq!(symbol.kind(), SymbolKind::Tls);
+    assert_eq!(symbol.section_index(), Some(thread_vars_index));
+    assert_eq!(symbol.scope(), SymbolScope::Linkage);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), false);
+
+    let symbol = symbols.next().unwrap();
+    println!("{:?}", symbol);
+    let tlv_bootstrap_symbol = symbol.index();
+    assert_eq!(symbol.name(), Ok("__tlv_bootstrap"));
+    assert_eq!(symbol.kind(), SymbolKind::Unknown);
+    assert_eq!(symbol.section_index(), None);
+    assert_eq!(symbol.scope(), SymbolScope::Unknown);
+    assert_eq!(symbol.is_weak(), false);
+    assert_eq!(symbol.is_undefined(), true);
 
     let mut relocations = thread_vars.relocations();
 


### PR DESCRIPTION
After this, the output of objcopy is identical to the input for the test files that are updated by this pull request.