### PR TITLE
remove debug assert

### DIFF
--- a/src/write/pe.rs
+++ b/src/write/pe.rs
@@ -688,7 +688,6 @@ impl<'a> Writer<'a> {
                 self.relocs.push(U16::new(LE, 0));
                 block.count += 1;
             }
-            debug_assert!(block.virtual_address < virtual_address);
         }
         self.relocs.push(reloc);
         self.reloc_blocks.push(RelocBlock {


### PR DESCRIPTION
Why was this here? Was this on accident left in? Does the PE specification say the relocation blocks need to be sorted somewhere? I was unable to find anything that said as much. Tested and working...

I have commented my thoughts below to explain why that line is not good!

```
pub fn add_reloc(&mut self, mut virtual_address: u32, typ: u16) {
        let reloc = U16::new(LE, typ << 12 | (virtual_address & 0xfff) as u16);
        virtual_address &= !0xfff;

        // Is there a last relocation block?
        if let Some(block) = self.reloc_blocks.last_mut() {
            // Does the last block have the same aligned virtual address?
            if block.virtual_address == virtual_address {
                // If so we can just add it here and call it a day...
                self.relocs.push(reloc);
                block.count += 1;
                return;
            }
            // Otherwise, pad this block up to meet PE alignment requirement if it needs.
            if block.count & 1 != 0 {
                self.relocs.push(U16::new(LE, 0));
                block.count += 1;
            }
            // THIS IS THE OFFENDING LINE... This should not be here. There is no order requirement.
            //debug_assert!(block.virtual_address < virtual_address);
        }
        // Push the reloc to the list and create a new block.
        self.relocs.push(reloc);
        self.reloc_blocks.push(RelocBlock {
            virtual_address,
            count: 1,
        });
    }
```

