### PR TITLE
elf: Update LoongArch relocation types per LoongArch ABI v2.20

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -3170,6 +3170,7 @@ const FLAGS_R_LOONGARCH: &[Flag<u32>] = &flags!(
     R_LARCH_ADD_ULEB128,
     R_LARCH_SUB_ULEB128,
     R_LARCH_64_PCREL,
+    R_LARCH_CALL36,
 );
 const FLAGS_NT_CORE: &[Flag<u32>] = &flags!(
     NT_PRSTATUS,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6055,7 +6055,7 @@ pub const R_LARCH_32_PCREL: u32 = 99;
 /// Paired with a normal relocation at the same address to indicate the
 /// instruction can be relaxed
 pub const R_LARCH_RELAX: u32 = 100;
-/// Delete an instruction, should be only used internally by the linker
+/// Reserved
 pub const R_LARCH_DELETE: u32 = 101;
 /// Delete some bytes to ensure the instruction at PC + A aligned to
 /// `A.next_power_of_two()`-byte boundary
@@ -6074,6 +6074,9 @@ pub const R_LARCH_ADD_ULEB128: u32 = 107;
 pub const R_LARCH_SUB_ULEB128: u32 = 108;
 /// 64-bit PC relative
 pub const R_LARCH_64_PCREL: u32 = 109;
+/// 18..=37 bits of `S + A - PC` into the `pcaddu18i` instruction at `PC`,
+/// and 2..=17 bits of `S + A - PC` into the `jirl` instruction at `PC + 4`
+pub const R_LARCH_CALL36: u32 = 110;
 
 // Xtensa values Rel*::r_type`.
 pub const R_XTENSA_NONE: u32 = 0;

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -616,6 +616,7 @@ impl<'a> Object<'a> {
                             (RelocationKind::Absolute, _, 32) => elf::R_LARCH_32,
                             (RelocationKind::Absolute, _, 64) => elf::R_LARCH_64,
                             (RelocationKind::Relative, _, 32) => elf::R_LARCH_32_PCREL,
+                            (RelocationKind::Relative, _, 64) => elf::R_LARCH_64_PCREL,
                             (RelocationKind::Relative, RelocationEncoding::LoongArchBranch, 16)
                             | (
                                 RelocationKind::PltRelative,


### PR DESCRIPTION
- R_LARCH_DELETE is reserved by the ABI now (the BFD linker will stop using it for relaxation as well).
- R_LARCH_CALL36 is added for function calls under medium code model.

Link: https://github.com/loongson/la-abi-specs/releases/v2.20
Link: https://sourceware.org/pipermail/binutils/2023-October/129938.html