### PR TITLE
read/coff: improve detection of auxiliary symbols for sections

### DIFF
--- a/crates/examples/testfiles/pe/base-bigobj.o.objdump
+++ b/crates/examples/testfiles/pe/base-bigobj.o.objdump
@@ -21,7 +21,7 @@ Segment { name: ".rdata$zzz", address: 0, size: 0 }
 
 Symbols
 0: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-2: Symbol { name: "printf", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+2: Symbol { name: "printf", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 4: Symbol { name: "main", address: 51, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 5: Symbol { name: ".text", address: 0, size: 75, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 7: Symbol { name: ".data", address: 0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
@@ -51,4 +51,5 @@ Symbols
 Dynamic symbols
 
 Symbol map
+0x0 "printf"
 0x51 "main"

--- a/crates/examples/testfiles/pe/base-gnu.exe.objdump
+++ b/crates/examples/testfiles/pe/base-gnu.exe.objdump
@@ -45,36 +45,36 @@ Segment { name: ".debug_ranges", address: 140049000, size: 14f0 }
 
 Symbols
 0: Symbol { name: "crtexe.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-2: Symbol { name: "__mingw_invalidParameterHandler", address: 140001000, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+2: Symbol { name: "__mingw_invalidParameterHandler", address: 140001000, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 4: Symbol { name: "pre_c_init", address: 140001010, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-5: Symbol { name: ".rdata$.refptr.__mingw_initltsdrot_force", address: 140009740, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-7: Symbol { name: ".rdata$.refptr.__mingw_initltsdyn_force", address: 140009750, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-9: Symbol { name: ".rdata$.refptr.__mingw_initltssuo_force", address: 140009760, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-11: Symbol { name: ".rdata$.refptr.__image_base__", address: 1400096e0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-13: Symbol { name: ".rdata$.refptr.__mingw_app_type", address: 140009730, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+5: Symbol { name: ".rdata$.refptr.__mingw_initltsdrot_force", address: 140009740, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+7: Symbol { name: ".rdata$.refptr.__mingw_initltsdyn_force", address: 140009750, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+9: Symbol { name: ".rdata$.refptr.__mingw_initltssuo_force", address: 140009760, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+11: Symbol { name: ".rdata$.refptr.__image_base__", address: 1400096e0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+13: Symbol { name: ".rdata$.refptr.__mingw_app_type", address: 140009730, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 15: Symbol { name: "managedapp", address: 14000c020, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-16: Symbol { name: ".rdata$.refptr._fmode", address: 140009810, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-18: Symbol { name: ".rdata$.refptr._commode", address: 1400097f0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-20: Symbol { name: ".rdata$.refptr._MINGW_INSTALL_DEBUG_MATHERR", address: 140009690, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+16: Symbol { name: ".rdata$.refptr._fmode", address: 140009810, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+18: Symbol { name: ".rdata$.refptr._commode", address: 1400097f0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+20: Symbol { name: ".rdata$.refptr._MINGW_INSTALL_DEBUG_MATHERR", address: 140009690, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 22: Symbol { name: "pre_cpp_init", address: 140001130, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-23: Symbol { name: ".rdata$.refptr._newmode", address: 140009840, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+23: Symbol { name: ".rdata$.refptr._newmode", address: 140009840, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 25: Symbol { name: "envp", address: 14000c028, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 26: Symbol { name: "argv", address: 14000c030, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 27: Symbol { name: "argc", address: 14000c038, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 28: Symbol { name: "startinfo", address: 14000c018, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-29: Symbol { name: ".rdata$.refptr._dowildcard", address: 140009800, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+29: Symbol { name: ".rdata$.refptr._dowildcard", address: 140009800, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 31: Symbol { name: "__tmainCRTStartup", address: 140001180, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-32: Symbol { name: ".rdata$.refptr.__native_startup_lock", address: 140009780, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-34: Symbol { name: ".rdata$.refptr.__native_startup_state", address: 140009790, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+32: Symbol { name: ".rdata$.refptr.__native_startup_lock", address: 140009780, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+34: Symbol { name: ".rdata$.refptr.__native_startup_state", address: 140009790, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 36: Symbol { name: "has_cctor", address: 14000c01c, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-37: Symbol { name: ".rdata$.refptr.__dyn_tls_init_callback", address: 1400096d0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-39: Symbol { name: ".rdata$.refptr.__mingw_oldexcpt_handler", address: 140009770, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-41: Symbol { name: ".rdata$.refptr.__imp___initenv", address: 1400096f0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+37: Symbol { name: ".rdata$.refptr.__dyn_tls_init_callback", address: 1400096d0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+39: Symbol { name: ".rdata$.refptr.__mingw_oldexcpt_handler", address: 140009770, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+41: Symbol { name: ".rdata$.refptr.__imp___initenv", address: 1400096f0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 43: Symbol { name: "mainret", address: 14000c024, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-44: Symbol { name: ".rdata$.refptr.__xc_z", address: 1400097c0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-46: Symbol { name: ".rdata$.refptr.__xc_a", address: 1400097b0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-48: Symbol { name: ".rdata$.refptr.__xi_z", address: 1400097e0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-50: Symbol { name: ".rdata$.refptr.__xi_a", address: 1400097d0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+44: Symbol { name: ".rdata$.refptr.__xc_z", address: 1400097c0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+46: Symbol { name: ".rdata$.refptr.__xc_a", address: 1400097b0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+48: Symbol { name: ".rdata$.refptr.__xi_z", address: 1400097e0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+50: Symbol { name: ".rdata$.refptr.__xi_a", address: 1400097d0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 52: Symbol { name: "WinMainCRTStartup", address: 1400014b0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 53: Symbol { name: ".l_startw", address: 1400014b4, size: 0, kind: Label, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 54: Symbol { name: ".l_endw", address: 1400014c7, size: 0, kind: Label, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
@@ -82,15 +82,15 @@ Symbols
 56: Symbol { name: ".l_start", address: 1400014d4, size: 0, kind: Label, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 57: Symbol { name: ".l_end", address: 1400014e7, size: 0, kind: Label, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 58: Symbol { name: "atexit", address: 1400014f0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-59: Symbol { name: ".rdata$.refptr._gnu_exception_handler", address: 140009820, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-61: Symbol { name: ".rdata$.refptr._matherr", address: 140009830, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+59: Symbol { name: ".rdata$.refptr._gnu_exception_handler", address: 140009820, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+61: Symbol { name: ".rdata$.refptr._matherr", address: 140009830, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 63: Symbol { name: ".text", address: 140001000, size: 509, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 65: Symbol { name: ".data", address: 140008000, size: 4, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 67: Symbol { name: ".bss", address: 14000c000, size: 3c, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 69: Symbol { name: ".xdata", address: 14000b000, size: 70, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 71: Symbol { name: ".pdata", address: 14000a000, size: 54, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
-73: Symbol { name: ".CRT$XCAA", address: 14000e008, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-75: Symbol { name: ".CRT$XIAA", address: 14000e020, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
+73: Symbol { name: ".CRT$XCAA", address: 14000e008, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+75: Symbol { name: ".CRT$XIAA", address: 14000e020, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 77: Symbol { name: ".debug_frame", address: 140032000, size: 1e8, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 79: Symbol { name: ".debug_info", address: 140013000, size: 2840, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 81: Symbol { name: ".debug_abbrev", address: 140026000, size: 53d, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
@@ -99,176 +99,176 @@ Symbols
 87: Symbol { name: ".debug_ranges", address: 140049000, size: 100, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 89: Symbol { name: ".debug_line", address: 14002a000, size: 61c, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 91: Symbol { name: ".debug_str", address: 140035000, size: 303, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
-93: Symbol { name: ".rdata$zzz", address: 140009850, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+93: Symbol { name: ".rdata$zzz", address: 140009850, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 95: Symbol { name: "cygming-crtbegin.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 97: Symbol { name: "__gcc_register_frame", address: 140001510, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 99: Symbol { name: "__gcc_deregister_frame", address: 140001520, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-100: Symbol { name: ".text", address: 140001510, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-102: Symbol { name: ".data", address: 140008010, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-104: Symbol { name: ".bss", address: 14000c040, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-106: Symbol { name: ".xdata", address: 14000b070, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-108: Symbol { name: ".pdata", address: 14000a054, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-110: Symbol { name: ".rdata$zzz", address: 140009880, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+100: Symbol { name: ".text", address: 140001510, size: 11, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+102: Symbol { name: ".data", address: 140008010, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+104: Symbol { name: ".bss", address: 14000c040, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+106: Symbol { name: ".xdata", address: 14000b070, size: 8, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+108: Symbol { name: ".pdata", address: 14000a054, size: 18, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+110: Symbol { name: ".rdata$zzz", address: 140009880, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 112: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 114: Symbol { name: "printf", address: 140001530, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 116: Symbol { name: "main", address: 140001581, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-117: Symbol { name: ".text", address: 140001530, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-119: Symbol { name: ".data", address: 140008010, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-121: Symbol { name: ".bss", address: 14000c040, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-123: Symbol { name: ".xdata", address: 14000b078, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-125: Symbol { name: ".pdata", address: 14000a06c, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
+117: Symbol { name: ".text", address: 140001530, size: 75, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+119: Symbol { name: ".data", address: 140008010, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+121: Symbol { name: ".bss", address: 14000c040, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+123: Symbol { name: ".xdata", address: 14000b078, size: 18, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+125: Symbol { name: ".pdata", address: 14000a06c, size: 18, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 127: Symbol { name: ".rdata", address: 140009000, size: d, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
-129: Symbol { name: ".rdata$zzz", address: 1400098b0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+129: Symbol { name: ".rdata$zzz", address: 1400098b0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 131: Symbol { name: "gccmain.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 133: Symbol { name: "__do_global_dtors", address: 1400015b0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 135: Symbol { name: "p.0", address: 140008010, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
 136: Symbol { name: "__do_global_ctors", address: 1400015f0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-137: Symbol { name: ".rdata$.refptr.__CTOR_LIST__", address: 1400096a0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+137: Symbol { name: ".rdata$.refptr.__CTOR_LIST__", address: 1400096a0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 139: Symbol { name: "__main", address: 140001660, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 140: Symbol { name: "initialized", address: 14000c040, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-141: Symbol { name: ".text", address: 1400015b0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-143: Symbol { name: ".data", address: 140008010, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-145: Symbol { name: ".bss", address: 14000c040, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-147: Symbol { name: ".xdata", address: 14000b090, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-149: Symbol { name: ".pdata", address: 14000a084, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-151: Symbol { name: ".debug_frame", address: 1400321e8, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-153: Symbol { name: ".debug_info", address: 140015840, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-155: Symbol { name: ".debug_abbrev", address: 14002653d, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-157: Symbol { name: ".debug_loc", address: 140036563, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-159: Symbol { name: ".debug_aranges", address: 140012030, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-161: Symbol { name: ".debug_line", address: 14002a61c, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-163: Symbol { name: ".rdata$zzz", address: 1400098e0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+141: Symbol { name: ".text", address: 1400015b0, size: cf, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+143: Symbol { name: ".data", address: 140008010, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+145: Symbol { name: ".bss", address: 14000c040, size: 4, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+147: Symbol { name: ".xdata", address: 14000b090, size: 18, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+149: Symbol { name: ".pdata", address: 14000a084, size: 24, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+151: Symbol { name: ".debug_frame", address: 1400321e8, size: a8, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+153: Symbol { name: ".debug_info", address: 140015840, size: 5e8, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+155: Symbol { name: ".debug_abbrev", address: 14002653d, size: 133, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+157: Symbol { name: ".debug_loc", address: 140036563, size: 89, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+159: Symbol { name: ".debug_aranges", address: 140012030, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+161: Symbol { name: ".debug_line", address: 14002a61c, size: 1bb, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+163: Symbol { name: ".rdata$zzz", address: 1400098e0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 165: Symbol { name: "natstart.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-167: Symbol { name: ".text", address: 140001680, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-169: Symbol { name: ".data", address: 140008020, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-171: Symbol { name: ".bss", address: 14000c050, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-173: Symbol { name: ".debug_info", address: 140015e28, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-175: Symbol { name: ".debug_abbrev", address: 140026670, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-177: Symbol { name: ".debug_aranges", address: 140012060, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-179: Symbol { name: ".debug_line", address: 14002a7d7, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-181: Symbol { name: ".debug_str", address: 140035303, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-183: Symbol { name: ".rdata$zzz", address: 140009910, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+167: Symbol { name: ".text", address: 140001680, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+169: Symbol { name: ".data", address: 140008020, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+171: Symbol { name: ".bss", address: 14000c050, size: c, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+173: Symbol { name: ".debug_info", address: 140015e28, size: 589, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+175: Symbol { name: ".debug_abbrev", address: 140026670, size: b2, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+177: Symbol { name: ".debug_aranges", address: 140012060, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+179: Symbol { name: ".debug_line", address: 14002a7d7, size: 105, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+181: Symbol { name: ".debug_str", address: 140035303, size: 18, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+183: Symbol { name: ".rdata$zzz", address: 140009910, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 185: Symbol { name: "wildcard.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-187: Symbol { name: ".text", address: 140001680, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-189: Symbol { name: ".data", address: 140008030, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-191: Symbol { name: ".bss", address: 14000c060, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-193: Symbol { name: ".debug_info", address: 1400163b1, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-195: Symbol { name: ".debug_abbrev", address: 140026722, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-197: Symbol { name: ".debug_aranges", address: 140012080, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-199: Symbol { name: ".debug_line", address: 14002a8dc, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-201: Symbol { name: ".rdata$zzz", address: 140009940, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+187: Symbol { name: ".text", address: 140001680, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+189: Symbol { name: ".data", address: 140008030, size: 4, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+191: Symbol { name: ".bss", address: 14000c060, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+193: Symbol { name: ".debug_info", address: 1400163b1, size: f2, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+195: Symbol { name: ".debug_abbrev", address: 140026722, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+197: Symbol { name: ".debug_aranges", address: 140012080, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+199: Symbol { name: ".debug_line", address: 14002a8dc, size: 64, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+201: Symbol { name: ".rdata$zzz", address: 140009940, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 203: Symbol { name: "dllargv.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 205: Symbol { name: "_setargv", address: 140001680, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-207: Symbol { name: ".text", address: 140001680, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-209: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-211: Symbol { name: ".bss", address: 14000c060, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-213: Symbol { name: ".xdata", address: 14000b0a8, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-215: Symbol { name: ".pdata", address: 14000a0a8, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-217: Symbol { name: ".debug_frame", address: 140032290, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-219: Symbol { name: ".debug_info", address: 1400164a3, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-221: Symbol { name: ".debug_abbrev", address: 140026750, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-223: Symbol { name: ".debug_aranges", address: 1400120a0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-225: Symbol { name: ".debug_line", address: 14002a940, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-227: Symbol { name: ".rdata$zzz", address: 140009970, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+207: Symbol { name: ".text", address: 140001680, size: 3, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+209: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+211: Symbol { name: ".bss", address: 14000c060, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+213: Symbol { name: ".xdata", address: 14000b0a8, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+215: Symbol { name: ".pdata", address: 14000a0a8, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+217: Symbol { name: ".debug_frame", address: 140032290, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+219: Symbol { name: ".debug_info", address: 1400164a3, size: 1cf, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+221: Symbol { name: ".debug_abbrev", address: 140026750, size: 3b, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+223: Symbol { name: ".debug_aranges", address: 1400120a0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+225: Symbol { name: ".debug_line", address: 14002a940, size: 7f, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+227: Symbol { name: ".rdata$zzz", address: 140009970, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 229: Symbol { name: "_newmode.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-231: Symbol { name: ".text", address: 140001690, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-233: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-235: Symbol { name: ".bss", address: 14000c060, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-237: Symbol { name: ".debug_info", address: 140016672, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-239: Symbol { name: ".debug_abbrev", address: 14002678b, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-241: Symbol { name: ".debug_aranges", address: 1400120d0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-243: Symbol { name: ".debug_line", address: 14002a9bf, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-245: Symbol { name: ".rdata$zzz", address: 1400099a0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+231: Symbol { name: ".text", address: 140001690, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+233: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+235: Symbol { name: ".bss", address: 14000c060, size: 4, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+237: Symbol { name: ".debug_info", address: 140016672, size: ef, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+239: Symbol { name: ".debug_abbrev", address: 14002678b, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+241: Symbol { name: ".debug_aranges", address: 1400120d0, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+243: Symbol { name: ".debug_line", address: 14002a9bf, size: 64, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+245: Symbol { name: ".rdata$zzz", address: 1400099a0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 247: Symbol { name: "tlssup.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 249: Symbol { name: "__dyn_tls_dtor", address: 140001690, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 251: Symbol { name: "__dyn_tls_init", address: 1400016c0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-252: Symbol { name: ".rdata$.refptr._CRT_MT", address: 140009680, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+252: Symbol { name: ".rdata$.refptr._CRT_MT", address: 140009680, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
 254: Symbol { name: "__xd_a", address: 14000e050, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
 255: Symbol { name: "__xd_z", address: 14000e058, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
 256: Symbol { name: "__tlregdtor", address: 140001750, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-257: Symbol { name: ".text", address: 140001690, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-259: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-261: Symbol { name: ".bss", address: 14000c070, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-263: Symbol { name: ".xdata", address: 14000b0ac, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-265: Symbol { name: ".pdata", address: 14000a0b4, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-267: Symbol { name: ".CRT$XLD", address: 14000e040, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-269: Symbol { name: ".CRT$XLC", address: 14000e038, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-271: Symbol { name: ".rdata", address: 140009020, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-273: Symbol { name: ".CRT$XDZ", address: 14000e058, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-275: Symbol { name: ".CRT$XDA", address: 14000e050, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-277: Symbol { name: ".CRT$XLZ", address: 14000e048, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-279: Symbol { name: ".CRT$XLA", address: 14000e030, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-281: Symbol { name: ".tls$ZZZ", address: 14000f008, size: 0, kind: Data, section: Section(SectionIndex(9)), scope: Compilation, weak: false, flags: None }
+257: Symbol { name: ".text", address: 140001690, size: c3, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+259: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+261: Symbol { name: ".bss", address: 14000c070, size: 10, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+263: Symbol { name: ".xdata", address: 14000b0ac, size: 18, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+265: Symbol { name: ".pdata", address: 14000a0b4, size: 24, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+267: Symbol { name: ".CRT$XLD", address: 14000e040, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+269: Symbol { name: ".CRT$XLC", address: 14000e038, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+271: Symbol { name: ".rdata", address: 140009020, size: 48, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+273: Symbol { name: ".CRT$XDZ", address: 14000e058, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+275: Symbol { name: ".CRT$XDA", address: 14000e050, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+277: Symbol { name: ".CRT$XLZ", address: 14000e048, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+279: Symbol { name: ".CRT$XLA", address: 14000e030, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+281: Symbol { name: ".tls$ZZZ", address: 14000f008, size: 8, kind: Section, section: Section(SectionIndex(9)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 283: Symbol { name: ".tls", address: 14000f000, size: 8, kind: Section, section: Section(SectionIndex(9)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
-285: Symbol { name: ".debug_frame", address: 1400322c0, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-287: Symbol { name: ".debug_info", address: 140016761, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-289: Symbol { name: ".debug_abbrev", address: 1400267b9, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-291: Symbol { name: ".debug_loc", address: 1400365ec, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-293: Symbol { name: ".debug_aranges", address: 1400120f0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-295: Symbol { name: ".debug_line", address: 14002aa23, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-297: Symbol { name: ".debug_str", address: 14003531b, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-299: Symbol { name: ".rdata$zzz", address: 1400099d0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+285: Symbol { name: ".debug_frame", address: 1400322c0, size: f0, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+287: Symbol { name: ".debug_info", address: 140016761, size: 73e, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+289: Symbol { name: ".debug_abbrev", address: 1400267b9, size: 1bf, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+291: Symbol { name: ".debug_loc", address: 1400365ec, size: 314, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+293: Symbol { name: ".debug_aranges", address: 1400120f0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+295: Symbol { name: ".debug_line", address: 14002aa23, size: 1a7, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+297: Symbol { name: ".debug_str", address: 14003531b, size: 33, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+299: Symbol { name: ".rdata$zzz", address: 1400099d0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 301: Symbol { name: "xncommod.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-303: Symbol { name: ".text", address: 140001760, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-305: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-307: Symbol { name: ".bss", address: 14000c080, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-309: Symbol { name: ".debug_info", address: 140016e9f, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-311: Symbol { name: ".debug_abbrev", address: 140026978, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-313: Symbol { name: ".debug_aranges", address: 140012120, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-315: Symbol { name: ".debug_line", address: 14002abca, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-317: Symbol { name: ".rdata$zzz", address: 140009a00, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+303: Symbol { name: ".text", address: 140001760, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+305: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+307: Symbol { name: ".bss", address: 14000c080, size: 4, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+309: Symbol { name: ".debug_info", address: 140016e9f, size: ef, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+311: Symbol { name: ".debug_abbrev", address: 140026978, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+313: Symbol { name: ".debug_aranges", address: 140012120, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+315: Symbol { name: ".debug_line", address: 14002abca, size: 64, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+317: Symbol { name: ".rdata$zzz", address: 140009a00, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 319: Symbol { name: "cinitexe.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-321: Symbol { name: ".text", address: 140001760, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-323: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-325: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-327: Symbol { name: ".CRT$XCZ", address: 14000e010, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
+321: Symbol { name: ".text", address: 140001760, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+323: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+325: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+327: Symbol { name: ".CRT$XCZ", address: 14000e010, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 329: Symbol { name: ".CRT$XCA", address: 14000e000, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
-331: Symbol { name: ".CRT$XIZ", address: 14000e028, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-333: Symbol { name: ".CRT$XIA", address: 14000e018, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: None }
-335: Symbol { name: ".debug_info", address: 140016f8e, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-337: Symbol { name: ".debug_abbrev", address: 1400269a6, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-339: Symbol { name: ".debug_aranges", address: 140012140, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-341: Symbol { name: ".debug_line", address: 14002ac2e, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-343: Symbol { name: ".rdata$zzz", address: 140009a30, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+331: Symbol { name: ".CRT$XIZ", address: 14000e028, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+333: Symbol { name: ".CRT$XIA", address: 14000e018, size: 8, kind: Section, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+335: Symbol { name: ".debug_info", address: 140016f8e, size: 1e8, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+337: Symbol { name: ".debug_abbrev", address: 1400269a6, size: 5f, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+339: Symbol { name: ".debug_aranges", address: 140012140, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+341: Symbol { name: ".debug_line", address: 14002ac2e, size: 64, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+343: Symbol { name: ".rdata$zzz", address: 140009a30, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 345: Symbol { name: "merr.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 347: Symbol { name: "_matherr", address: 140001760, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-349: Symbol { name: ".text", address: 140001760, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-351: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-353: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-355: Symbol { name: ".rdata", address: 140009080, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-357: Symbol { name: ".xdata", address: 14000b0c4, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-359: Symbol { name: ".pdata", address: 14000a0d8, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-361: Symbol { name: ".debug_frame", address: 1400323b0, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-363: Symbol { name: ".debug_info", address: 140017176, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-365: Symbol { name: ".debug_abbrev", address: 140026a05, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-367: Symbol { name: ".debug_loc", address: 140036900, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-369: Symbol { name: ".debug_aranges", address: 140012160, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-371: Symbol { name: ".debug_line", address: 14002ac92, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-373: Symbol { name: ".debug_str", address: 14003534e, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-375: Symbol { name: ".rdata$zzz", address: 140009a60, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+349: Symbol { name: ".text", address: 140001760, size: f8, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+351: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+353: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+355: Symbol { name: ".rdata", address: 140009080, size: 140, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+357: Symbol { name: ".xdata", address: 14000b0c4, size: 18, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+359: Symbol { name: ".pdata", address: 14000a0d8, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+361: Symbol { name: ".debug_frame", address: 1400323b0, size: 78, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+363: Symbol { name: ".debug_info", address: 140017176, size: 2cb, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+365: Symbol { name: ".debug_abbrev", address: 140026a05, size: e1, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+367: Symbol { name: ".debug_loc", address: 140036900, size: 10d, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+369: Symbol { name: ".debug_aranges", address: 140012160, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+371: Symbol { name: ".debug_line", address: 14002ac92, size: 11b, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+373: Symbol { name: ".debug_str", address: 14003534e, size: 10, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+375: Symbol { name: ".rdata$zzz", address: 140009a60, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 377: Symbol { name: "CRT_fp10.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 379: Symbol { name: "_fpreset", address: 140001860, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 381: Symbol { name: "fpreset", address: 140001860, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-382: Symbol { name: ".text", address: 140001860, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-384: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-386: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-388: Symbol { name: ".xdata", address: 14000b0dc, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-390: Symbol { name: ".pdata", address: 14000a0e4, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-392: Symbol { name: ".debug_frame", address: 140032428, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-394: Symbol { name: ".debug_info", address: 140017441, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-396: Symbol { name: ".debug_abbrev", address: 140026ae6, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-398: Symbol { name: ".debug_aranges", address: 140012190, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-400: Symbol { name: ".debug_line", address: 14002adad, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-402: Symbol { name: ".rdata$zzz", address: 140009a90, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+382: Symbol { name: ".text", address: 140001860, size: 3, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+384: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+386: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+388: Symbol { name: ".xdata", address: 14000b0dc, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+390: Symbol { name: ".pdata", address: 14000a0e4, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+392: Symbol { name: ".debug_frame", address: 140032428, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+394: Symbol { name: ".debug_info", address: 140017441, size: fc, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+396: Symbol { name: ".debug_abbrev", address: 140026ae6, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+398: Symbol { name: ".debug_aranges", address: 140012190, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+400: Symbol { name: ".debug_line", address: 14002adad, size: 82, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+402: Symbol { name: ".rdata$zzz", address: 140009a90, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 404: Symbol { name: "mingw_helpers.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-406: Symbol { name: ".text", address: 140001870, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-408: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-410: Symbol { name: ".bss", address: 14000c090, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-412: Symbol { name: ".debug_info", address: 14001753d, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-414: Symbol { name: ".debug_abbrev", address: 140026b14, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-416: Symbol { name: ".debug_aranges", address: 1400121c0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-418: Symbol { name: ".debug_line", address: 14002ae2f, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-420: Symbol { name: ".rdata$zzz", address: 140009ac0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+406: Symbol { name: ".text", address: 140001870, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+408: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+410: Symbol { name: ".bss", address: 14000c090, size: 4, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+412: Symbol { name: ".debug_info", address: 14001753d, size: fc, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+414: Symbol { name: ".debug_abbrev", address: 140026b14, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+416: Symbol { name: ".debug_aranges", address: 1400121c0, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+418: Symbol { name: ".debug_line", address: 14002ae2f, size: 69, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+420: Symbol { name: ".rdata$zzz", address: 140009ac0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 422: Symbol { name: "pseudo-reloc.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 424: Symbol { name: "__report_error", address: 140001870, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 426: Symbol { name: "mark_section_writable", address: 1400018e0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
@@ -276,65 +276,65 @@ Symbols
 428: Symbol { name: "the_secs", address: 14000c0a8, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 429: Symbol { name: "_pei386_runtime_relocator", address: 140001a50, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 430: Symbol { name: "was_init.0", address: 14000c0a0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-431: Symbol { name: ".rdata$.refptr.__RUNTIME_PSEUDO_RELOC_LIST_END__", address: 1400096b0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-433: Symbol { name: ".rdata$.refptr.__RUNTIME_PSEUDO_RELOC_LIST__", address: 1400096c0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-435: Symbol { name: ".text", address: 140001870, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-437: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-439: Symbol { name: ".bss", address: 14000c0a0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-441: Symbol { name: ".rdata", address: 1400091c0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-443: Symbol { name: ".xdata", address: 14000b0e0, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-445: Symbol { name: ".pdata", address: 14000a0f0, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-447: Symbol { name: ".debug_frame", address: 140032458, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-449: Symbol { name: ".debug_info", address: 140017639, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-451: Symbol { name: ".debug_abbrev", address: 140026b42, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-453: Symbol { name: ".debug_loc", address: 140036a0d, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-455: Symbol { name: ".debug_aranges", address: 1400121e0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-457: Symbol { name: ".debug_ranges", address: 140049100, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-459: Symbol { name: ".debug_line", address: 14002ae98, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-461: Symbol { name: ".debug_str", address: 14003535e, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-463: Symbol { name: ".rdata$zzz", address: 140009af0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+431: Symbol { name: ".rdata$.refptr.__RUNTIME_PSEUDO_RELOC_LIST_END__", address: 1400096b0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+433: Symbol { name: ".rdata$.refptr.__RUNTIME_PSEUDO_RELOC_LIST__", address: 1400096c0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+435: Symbol { name: ".text", address: 140001870, size: 45e, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+437: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+439: Symbol { name: ".bss", address: 14000c0a0, size: 10, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+441: Symbol { name: ".rdata", address: 1400091c0, size: 102, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+443: Symbol { name: ".xdata", address: 14000b0e0, size: 30, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+445: Symbol { name: ".pdata", address: 14000a0f0, size: 24, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+447: Symbol { name: ".debug_frame", address: 140032458, size: 160, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+449: Symbol { name: ".debug_info", address: 140017639, size: 12a9, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+451: Symbol { name: ".debug_abbrev", address: 140026b42, size: 36d, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+453: Symbol { name: ".debug_loc", address: 140036a0d, size: bd1, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+455: Symbol { name: ".debug_aranges", address: 1400121e0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+457: Symbol { name: ".debug_ranges", address: 140049100, size: 300, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+459: Symbol { name: ".debug_line", address: 14002ae98, size: 542, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+461: Symbol { name: ".debug_str", address: 14003535e, size: 90, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+463: Symbol { name: ".rdata$zzz", address: 140009af0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 465: Symbol { name: "usermatherr.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 467: Symbol { name: "__mingw_raise_matherr", address: 140001cd0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 469: Symbol { name: "stUserMathErr", address: 14000c0b0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 470: Symbol { name: "__mingw_setusermatherr", address: 140001d20, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-471: Symbol { name: ".text", address: 140001cd0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-473: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-475: Symbol { name: ".bss", address: 14000c0b0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-477: Symbol { name: ".xdata", address: 14000b110, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-479: Symbol { name: ".pdata", address: 14000a114, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-481: Symbol { name: ".debug_frame", address: 1400325b8, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-483: Symbol { name: ".debug_info", address: 1400188e2, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-485: Symbol { name: ".debug_abbrev", address: 140026eaf, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-487: Symbol { name: ".debug_loc", address: 1400375de, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-489: Symbol { name: ".debug_aranges", address: 140012210, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-491: Symbol { name: ".debug_line", address: 14002b3da, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-493: Symbol { name: ".debug_str", address: 1400353ee, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-495: Symbol { name: ".rdata$zzz", address: 140009b20, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+471: Symbol { name: ".text", address: 140001cd0, size: 5c, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+473: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+475: Symbol { name: ".bss", address: 14000c0b0, size: 8, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+477: Symbol { name: ".xdata", address: 14000b110, size: c, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+479: Symbol { name: ".pdata", address: 14000a114, size: 18, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+481: Symbol { name: ".debug_frame", address: 1400325b8, size: 58, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+483: Symbol { name: ".debug_info", address: 1400188e2, size: 35f, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+485: Symbol { name: ".debug_abbrev", address: 140026eaf, size: fa, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+487: Symbol { name: ".debug_loc", address: 1400375de, size: 137, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+489: Symbol { name: ".debug_aranges", address: 140012210, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+491: Symbol { name: ".debug_line", address: 14002b3da, size: 11e, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+493: Symbol { name: ".debug_str", address: 1400353ee, size: 11, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+495: Symbol { name: ".rdata$zzz", address: 140009b20, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 497: Symbol { name: "xtxtmode.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-499: Symbol { name: ".text", address: 140001d30, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-501: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-503: Symbol { name: ".bss", address: 14000c0c0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-505: Symbol { name: ".debug_info", address: 140018c41, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-507: Symbol { name: ".debug_abbrev", address: 140026fa9, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-509: Symbol { name: ".debug_aranges", address: 140012240, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-511: Symbol { name: ".debug_line", address: 14002b4f8, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-513: Symbol { name: ".rdata$zzz", address: 140009b50, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+499: Symbol { name: ".text", address: 140001d30, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+501: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+503: Symbol { name: ".bss", address: 14000c0c0, size: 4, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+505: Symbol { name: ".debug_info", address: 140018c41, size: ed, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+507: Symbol { name: ".debug_abbrev", address: 140026fa9, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+509: Symbol { name: ".debug_aranges", address: 140012240, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+511: Symbol { name: ".debug_line", address: 14002b4f8, size: 64, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+513: Symbol { name: ".rdata$zzz", address: 140009b50, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 515: Symbol { name: "crt_handler.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 517: Symbol { name: "_gnu_exception_handler", address: 140001d30, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-519: Symbol { name: ".text", address: 140001d30, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-521: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-523: Symbol { name: ".bss", address: 14000c0d0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-525: Symbol { name: ".xdata", address: 14000b11c, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-527: Symbol { name: ".rdata", address: 1400092d0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-529: Symbol { name: ".pdata", address: 14000a12c, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-531: Symbol { name: ".debug_frame", address: 140032610, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-533: Symbol { name: ".debug_info", address: 140018d2e, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-535: Symbol { name: ".debug_abbrev", address: 140026fd7, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-537: Symbol { name: ".debug_loc", address: 140037715, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-539: Symbol { name: ".debug_aranges", address: 140012260, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-541: Symbol { name: ".debug_line", address: 14002b55c, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-543: Symbol { name: ".debug_str", address: 1400353ff, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-545: Symbol { name: ".rdata$zzz", address: 140009b80, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+519: Symbol { name: ".text", address: 140001d30, size: 1ba, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+521: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+523: Symbol { name: ".bss", address: 14000c0d0, size: 8, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+525: Symbol { name: ".xdata", address: 14000b11c, size: 8, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+527: Symbol { name: ".rdata", address: 1400092d0, size: 28, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+529: Symbol { name: ".pdata", address: 14000a12c, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+531: Symbol { name: ".debug_frame", address: 140032610, size: 88, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+533: Symbol { name: ".debug_info", address: 140018d2e, size: fe8, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+535: Symbol { name: ".debug_abbrev", address: 140026fd7, size: 27b, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+537: Symbol { name: ".debug_loc", address: 140037715, size: 356, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+539: Symbol { name: ".debug_aranges", address: 140012260, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+541: Symbol { name: ".debug_line", address: 14002b55c, size: 25b, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+543: Symbol { name: ".debug_str", address: 1400353ff, size: 19, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+545: Symbol { name: ".rdata$zzz", address: 140009b80, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 547: Symbol { name: "tlsthrd.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 549: Symbol { name: "__mingwthr_run_key_dtors.part.0", address: 140001ef0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 551: Symbol { name: "__mingwthr_cs", address: 14000c100, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
@@ -343,38 +343,38 @@ Symbols
 554: Symbol { name: "__mingwthr_cs_init", address: 14000c0e8, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 555: Symbol { name: "___w64_mingwthr_remove_key_dtor", address: 140001fe0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 556: Symbol { name: "__mingw_TLScallback", address: 140002070, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-557: Symbol { name: ".text", address: 140001ef0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-559: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-561: Symbol { name: ".bss", address: 14000c0e0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-563: Symbol { name: ".xdata", address: 14000b124, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-565: Symbol { name: ".pdata", address: 14000a138, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-567: Symbol { name: ".debug_frame", address: 140032698, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-569: Symbol { name: ".debug_info", address: 140019d16, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-571: Symbol { name: ".debug_abbrev", address: 140027252, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-573: Symbol { name: ".debug_loc", address: 140037a6b, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-575: Symbol { name: ".debug_aranges", address: 140012290, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-577: Symbol { name: ".debug_ranges", address: 140049400, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-579: Symbol { name: ".debug_line", address: 14002b7b7, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-581: Symbol { name: ".debug_str", address: 140035418, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-583: Symbol { name: ".rdata$zzz", address: 140009bb0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+557: Symbol { name: ".text", address: 140001ef0, size: 262, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+559: Symbol { name: ".data", address: 140008040, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+561: Symbol { name: ".bss", address: 14000c0e0, size: 48, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+563: Symbol { name: ".xdata", address: 14000b124, size: 2c, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+565: Symbol { name: ".pdata", address: 14000a138, size: 30, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+567: Symbol { name: ".debug_frame", address: 140032698, size: 1c0, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+569: Symbol { name: ".debug_info", address: 140019d16, size: 9dc, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+571: Symbol { name: ".debug_abbrev", address: 140027252, size: 204, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+573: Symbol { name: ".debug_loc", address: 140037a6b, size: 728, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+575: Symbol { name: ".debug_aranges", address: 140012290, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+577: Symbol { name: ".debug_ranges", address: 140049400, size: 30, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+579: Symbol { name: ".debug_line", address: 14002b7b7, size: 325, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+581: Symbol { name: ".debug_str", address: 140035418, size: 7c, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+583: Symbol { name: ".rdata$zzz", address: 140009bb0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 585: Symbol { name: "tlsmcrt.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-587: Symbol { name: ".text", address: 140002160, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-589: Symbol { name: ".data", address: 140008040, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-591: Symbol { name: ".bss", address: 14000c140, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-593: Symbol { name: ".debug_info", address: 14001a6f2, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-595: Symbol { name: ".debug_abbrev", address: 140027456, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-597: Symbol { name: ".debug_aranges", address: 1400122c0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-599: Symbol { name: ".debug_line", address: 14002badc, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-601: Symbol { name: ".rdata$zzz", address: 140009be0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+587: Symbol { name: ".text", address: 140002160, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+589: Symbol { name: ".data", address: 140008040, size: 4, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+591: Symbol { name: ".bss", address: 14000c140, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+593: Symbol { name: ".debug_info", address: 14001a6f2, size: ed, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+595: Symbol { name: ".debug_abbrev", address: 140027456, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+597: Symbol { name: ".debug_aranges", address: 1400122c0, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+599: Symbol { name: ".debug_line", address: 14002badc, size: 63, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+601: Symbol { name: ".rdata$zzz", address: 140009be0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 603: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-605: Symbol { name: ".text", address: 140002160, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-607: Symbol { name: ".data", address: 140008050, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-609: Symbol { name: ".bss", address: 14000c140, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-611: Symbol { name: ".debug_info", address: 14001a7df, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-613: Symbol { name: ".debug_abbrev", address: 140027484, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-615: Symbol { name: ".debug_aranges", address: 1400122e0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-617: Symbol { name: ".debug_line", address: 14002bb3f, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-619: Symbol { name: ".rdata$zzz", address: 140009c10, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+605: Symbol { name: ".text", address: 140002160, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+607: Symbol { name: ".data", address: 140008050, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+609: Symbol { name: ".bss", address: 14000c140, size: 2, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+611: Symbol { name: ".debug_info", address: 14001a7df, size: 142, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+613: Symbol { name: ".debug_abbrev", address: 140027484, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+615: Symbol { name: ".debug_aranges", address: 1400122e0, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+617: Symbol { name: ".debug_line", address: 14002bb3f, size: 6d, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+619: Symbol { name: ".rdata$zzz", address: 140009c10, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 621: Symbol { name: "pesect.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 623: Symbol { name: "_ValidateImageBase", address: 140002160, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 625: Symbol { name: "_FindPESection", address: 140002190, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
@@ -385,62 +385,62 @@ Symbols
 630: Symbol { name: "_GetPEImageBase", address: 1400023b0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 631: Symbol { name: "_IsNonwritableInCurrentImage", address: 1400023f0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 632: Symbol { name: "__mingw_enum_import_library_names", address: 140002480, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-633: Symbol { name: ".text", address: 140002160, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-635: Symbol { name: ".data", address: 140008050, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-637: Symbol { name: ".bss", address: 14000c150, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-639: Symbol { name: ".xdata", address: 14000b150, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-641: Symbol { name: ".pdata", address: 14000a168, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-643: Symbol { name: ".debug_frame", address: 140032858, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-645: Symbol { name: ".debug_info", address: 14001a921, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-647: Symbol { name: ".debug_abbrev", address: 1400274b2, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-649: Symbol { name: ".debug_loc", address: 140038193, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-651: Symbol { name: ".debug_aranges", address: 140012300, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-653: Symbol { name: ".debug_ranges", address: 140049430, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-655: Symbol { name: ".debug_line", address: 14002bbac, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-657: Symbol { name: ".debug_str", address: 140035494, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-659: Symbol { name: ".rdata$zzz", address: 140009c40, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+633: Symbol { name: ".text", address: 140002160, size: 3de, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+635: Symbol { name: ".data", address: 140008050, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+637: Symbol { name: ".bss", address: 14000c150, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+639: Symbol { name: ".xdata", address: 14000b150, size: 2c, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+641: Symbol { name: ".pdata", address: 14000a168, size: 6c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+643: Symbol { name: ".debug_frame", address: 140032858, size: 158, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+645: Symbol { name: ".debug_info", address: 14001a921, size: 15d9, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+647: Symbol { name: ".debug_abbrev", address: 1400274b2, size: 256, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+649: Symbol { name: ".debug_loc", address: 140038193, size: be1, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+651: Symbol { name: ".debug_aranges", address: 140012300, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+653: Symbol { name: ".debug_ranges", address: 140049430, size: 330, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+655: Symbol { name: ".debug_line", address: 14002bbac, size: 5ed, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+657: Symbol { name: ".debug_str", address: 140035494, size: 54, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+659: Symbol { name: ".rdata$zzz", address: 140009c40, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 661: Symbol { name: "fake", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-663: Symbol { name: ".debug_info", address: 14001befa, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-665: Symbol { name: ".debug_abbrev", address: 140027708, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-667: Symbol { name: ".debug_line", address: 14002c199, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-669: Symbol { name: ".text", address: 140002540, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-671: Symbol { name: ".data", address: 140008050, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-673: Symbol { name: ".bss", address: 14000c150, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-675: Symbol { name: ".debug_aranges", address: 140012330, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-677: Symbol { name: ".debug_str", address: 1400354e8, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
+663: Symbol { name: ".debug_info", address: 14001befa, size: 2e, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+665: Symbol { name: ".debug_abbrev", address: 140027708, size: 14, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+667: Symbol { name: ".debug_line", address: 14002c199, size: 72, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+669: Symbol { name: ".text", address: 140002540, size: 32, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+671: Symbol { name: ".data", address: 140008050, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+673: Symbol { name: ".bss", address: 14000c150, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+675: Symbol { name: ".debug_aranges", address: 140012330, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+677: Symbol { name: ".debug_str", address: 1400354e8, size: 8a, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 679: Symbol { name: "libgcc2.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-681: Symbol { name: ".text", address: 140002580, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-683: Symbol { name: ".data", address: 140008050, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-685: Symbol { name: ".bss", address: 14000c150, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-687: Symbol { name: ".debug_info", address: 14001bf28, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-689: Symbol { name: ".debug_abbrev", address: 14002771c, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-691: Symbol { name: ".debug_aranges", address: 140012360, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-693: Symbol { name: ".debug_line", address: 14002c20b, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-695: Symbol { name: ".rdata$zzz", address: 140009c70, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+681: Symbol { name: ".text", address: 140002580, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+683: Symbol { name: ".data", address: 140008050, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+685: Symbol { name: ".bss", address: 14000c150, size: 20, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+687: Symbol { name: ".debug_info", address: 14001bf28, size: ddc, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+689: Symbol { name: ".debug_abbrev", address: 14002771c, size: 93, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+691: Symbol { name: ".debug_aranges", address: 140012360, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+693: Symbol { name: ".debug_line", address: 14002c20b, size: 8c, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+695: Symbol { name: ".rdata$zzz", address: 140009c70, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 697: Symbol { name: "mingw_matherr.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-699: Symbol { name: ".text", address: 140002580, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-701: Symbol { name: ".data", address: 140008050, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-703: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-705: Symbol { name: ".debug_info", address: 14001cd04, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-707: Symbol { name: ".debug_abbrev", address: 1400277af, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-709: Symbol { name: ".debug_aranges", address: 140012380, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-711: Symbol { name: ".debug_line", address: 14002c297, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-713: Symbol { name: ".rdata$zzz", address: 140009ca0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+699: Symbol { name: ".text", address: 140002580, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+701: Symbol { name: ".data", address: 140008050, size: 4, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+703: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+705: Symbol { name: ".debug_info", address: 14001cd04, size: 109, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+707: Symbol { name: ".debug_abbrev", address: 1400277af, size: 2e, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+709: Symbol { name: ".debug_aranges", address: 140012380, size: 20, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+711: Symbol { name: ".debug_line", address: 14002c297, size: 6a, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+713: Symbol { name: ".rdata$zzz", address: 140009ca0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 715: Symbol { name: "mingw_vfprintf.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 717: Symbol { name: "__mingw_vfprintf", address: 140002580, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-719: Symbol { name: ".text", address: 140002580, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-721: Symbol { name: ".data", address: 140008060, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-723: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-725: Symbol { name: ".xdata", address: 14000b17c, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-727: Symbol { name: ".pdata", address: 14000a1d4, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-729: Symbol { name: ".debug_frame", address: 1400329b0, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-731: Symbol { name: ".debug_info", address: 14001ce0d, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-733: Symbol { name: ".debug_abbrev", address: 1400277dd, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-735: Symbol { name: ".debug_loc", address: 140038d74, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-737: Symbol { name: ".debug_aranges", address: 1400123a0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-739: Symbol { name: ".debug_line", address: 14002c301, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-741: Symbol { name: ".debug_str", address: 140035572, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-743: Symbol { name: ".rdata$zzz", address: 140009cd0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+719: Symbol { name: ".text", address: 140002580, size: 47, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+721: Symbol { name: ".data", address: 140008060, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+723: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+725: Symbol { name: ".xdata", address: 14000b17c, size: c, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+727: Symbol { name: ".pdata", address: 14000a1d4, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+729: Symbol { name: ".debug_frame", address: 1400329b0, size: 78, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+731: Symbol { name: ".debug_info", address: 14001ce0d, size: 374, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+733: Symbol { name: ".debug_abbrev", address: 1400277dd, size: fb, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+735: Symbol { name: ".debug_loc", address: 140038d74, size: 145, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+737: Symbol { name: ".debug_aranges", address: 1400123a0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+739: Symbol { name: ".debug_line", address: 14002c301, size: 10c, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+741: Symbol { name: ".debug_str", address: 140035572, size: 28, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+743: Symbol { name: ".rdata$zzz", address: 140009cd0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 745: Symbol { name: "mingw_pformat.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 747: Symbol { name: "__pformat_cvt", address: 1400025d0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 749: Symbol { name: "fpi.0", address: 140008060, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
@@ -459,74 +459,74 @@ Symbols
 762: Symbol { name: "__pformat_gfloat", address: 140003b50, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 763: Symbol { name: "__pformat_xldouble", address: 140003cc0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 764: Symbol { name: "__mingw_pformat", address: 140004200, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-765: Symbol { name: ".text", address: 1400025d0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-767: Symbol { name: ".data", address: 140008060, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-769: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-771: Symbol { name: ".xdata", address: 14000b188, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-773: Symbol { name: ".pdata", address: 14000a1e0, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-775: Symbol { name: ".rdata", address: 140009300, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-777: Symbol { name: ".debug_frame", address: 140032a28, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-779: Symbol { name: ".debug_info", address: 14001d181, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-781: Symbol { name: ".debug_abbrev", address: 1400278d8, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-783: Symbol { name: ".debug_loc", address: 140038eb9, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-785: Symbol { name: ".debug_aranges", address: 1400123d0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-787: Symbol { name: ".debug_ranges", address: 140049760, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-789: Symbol { name: ".debug_line", address: 14002c40d, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-791: Symbol { name: ".debug_str", address: 14003559a, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-793: Symbol { name: ".rdata$zzz", address: 140009d00, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+765: Symbol { name: ".text", address: 1400025d0, size: 25df, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+767: Symbol { name: ".data", address: 140008060, size: 18, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+769: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+771: Symbol { name: ".xdata", address: 14000b188, size: f4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+773: Symbol { name: ".pdata", address: 14000a1e0, size: c0, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+775: Symbol { name: ".rdata", address: 140009300, size: 18c, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+777: Symbol { name: ".debug_frame", address: 140032a28, size: 7d8, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+779: Symbol { name: ".debug_info", address: 14001d181, size: 2b8a, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+781: Symbol { name: ".debug_abbrev", address: 1400278d8, size: 47d, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+783: Symbol { name: ".debug_loc", address: 140038eb9, size: 4cee, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+785: Symbol { name: ".debug_aranges", address: 1400123d0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+787: Symbol { name: ".debug_ranges", address: 140049760, size: 850, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+789: Symbol { name: ".debug_line", address: 14002c40d, size: 2212, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+791: Symbol { name: ".debug_str", address: 14003559a, size: 83, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+793: Symbol { name: ".rdata$zzz", address: 140009d00, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 795: Symbol { name: "dmisc.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 797: Symbol { name: "__rv_alloc_D2A", address: 140004bb0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 799: Symbol { name: "__nrv_alloc_D2A", address: 140004bf0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 800: Symbol { name: "__freedtoa", address: 140004c70, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 801: Symbol { name: "__quorem_D2A", address: 140004c90, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-802: Symbol { name: ".text", address: 140004bb0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-804: Symbol { name: ".data", address: 140008080, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-806: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-808: Symbol { name: ".xdata", address: 14000b27c, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-810: Symbol { name: ".pdata", address: 14000a2a0, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-812: Symbol { name: ".debug_frame", address: 140033200, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-814: Symbol { name: ".debug_info", address: 14001fd0b, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-816: Symbol { name: ".debug_abbrev", address: 140027d55, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-818: Symbol { name: ".debug_loc", address: 14003dba7, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-820: Symbol { name: ".debug_aranges", address: 140012400, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-822: Symbol { name: ".debug_ranges", address: 140049fb0, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-824: Symbol { name: ".debug_line", address: 14002e61f, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-826: Symbol { name: ".debug_str", address: 14003561d, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-828: Symbol { name: ".rdata$zzz", address: 140009d30, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+802: Symbol { name: ".text", address: 140004bb0, size: 256, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+804: Symbol { name: ".data", address: 140008080, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+806: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+808: Symbol { name: ".xdata", address: 14000b27c, size: 30, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+810: Symbol { name: ".pdata", address: 14000a2a0, size: 30, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+812: Symbol { name: ".debug_frame", address: 140033200, size: 180, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+814: Symbol { name: ".debug_info", address: 14001fd0b, size: 5b0, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+816: Symbol { name: ".debug_abbrev", address: 140027d55, size: 19b, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+818: Symbol { name: ".debug_loc", address: 14003dba7, size: a59, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+820: Symbol { name: ".debug_aranges", address: 140012400, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+822: Symbol { name: ".debug_ranges", address: 140049fb0, size: 60, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+824: Symbol { name: ".debug_line", address: 14002e61f, size: 3ed, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+826: Symbol { name: ".debug_str", address: 14003561d, size: 2c, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+828: Symbol { name: ".rdata$zzz", address: 140009d30, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 830: Symbol { name: "gdtoa.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 832: Symbol { name: "__gdtoa", address: 140004e10, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-834: Symbol { name: ".rdata$.refptr.__tens_D2A", address: 1400097a0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-836: Symbol { name: ".text", address: 140004e10, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-838: Symbol { name: ".data", address: 140008080, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-840: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-842: Symbol { name: ".rdata", address: 140009490, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-844: Symbol { name: ".xdata", address: 14000b2ac, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-846: Symbol { name: ".pdata", address: 14000a2d0, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-848: Symbol { name: ".debug_frame", address: 140033380, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-850: Symbol { name: ".debug_info", address: 1400202bb, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-852: Symbol { name: ".debug_abbrev", address: 140027ef0, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-854: Symbol { name: ".debug_loc", address: 14003e600, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-856: Symbol { name: ".debug_aranges", address: 140012430, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-858: Symbol { name: ".debug_ranges", address: 14004a010, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-860: Symbol { name: ".debug_line", address: 14002ea0c, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-862: Symbol { name: ".debug_str", address: 140035649, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-864: Symbol { name: ".rdata$zzz", address: 140009d60, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+834: Symbol { name: ".rdata$.refptr.__tens_D2A", address: 1400097a0, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+836: Symbol { name: ".text", address: 140004e10, size: 1707, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+838: Symbol { name: ".data", address: 140008080, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+840: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+842: Symbol { name: ".rdata", address: 140009490, size: 88, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+844: Symbol { name: ".xdata", address: 14000b2ac, size: 1c, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+846: Symbol { name: ".pdata", address: 14000a2d0, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+848: Symbol { name: ".debug_frame", address: 140033380, size: 128, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+850: Symbol { name: ".debug_info", address: 1400202bb, size: 116b, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+852: Symbol { name: ".debug_abbrev", address: 140027ef0, size: 29d, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+854: Symbol { name: ".debug_loc", address: 14003e600, size: 5537, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+856: Symbol { name: ".debug_aranges", address: 140012430, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+858: Symbol { name: ".debug_ranges", address: 14004a010, size: a0, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+860: Symbol { name: ".debug_line", address: 14002ea0c, size: 11dc, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+862: Symbol { name: ".debug_str", address: 140035649, size: c6, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+864: Symbol { name: ".rdata$zzz", address: 140009d60, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 866: Symbol { name: "gmisc.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 868: Symbol { name: "__rshift_D2A", address: 140006520, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 870: Symbol { name: "__trailz_D2A", address: 140006620, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-871: Symbol { name: ".text", address: 140006520, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-873: Symbol { name: ".data", address: 140008080, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-875: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-877: Symbol { name: ".xdata", address: 14000b2c8, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-879: Symbol { name: ".pdata", address: 14000a2dc, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-881: Symbol { name: ".debug_frame", address: 1400334a8, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-883: Symbol { name: ".debug_info", address: 140021426, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-885: Symbol { name: ".debug_abbrev", address: 14002818d, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-887: Symbol { name: ".debug_loc", address: 140043b37, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-889: Symbol { name: ".debug_aranges", address: 140012460, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-891: Symbol { name: ".debug_line", address: 14002fbe8, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-893: Symbol { name: ".debug_str", address: 14003570f, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-895: Symbol { name: ".rdata$zzz", address: 140009d90, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+871: Symbol { name: ".text", address: 140006520, size: 143, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+873: Symbol { name: ".data", address: 140008080, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+875: Symbol { name: ".bss", address: 14000c170, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+877: Symbol { name: ".xdata", address: 14000b2c8, size: 14, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+879: Symbol { name: ".pdata", address: 14000a2dc, size: 18, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+881: Symbol { name: ".debug_frame", address: 1400334a8, size: d8, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+883: Symbol { name: ".debug_info", address: 140021426, size: 3cd, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+885: Symbol { name: ".debug_abbrev", address: 14002818d, size: 13b, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+887: Symbol { name: ".debug_loc", address: 140043b37, size: 55e, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+889: Symbol { name: ".debug_aranges", address: 140012460, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+891: Symbol { name: ".debug_line", address: 14002fbe8, size: 21d, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+893: Symbol { name: ".debug_str", address: 14003570f, size: 9, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+895: Symbol { name: ".rdata$zzz", address: 140009d90, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 897: Symbol { name: "misc.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 899: Symbol { name: "dtoa_lock", address: 140006670, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 901: Symbol { name: "dtoa_CS_init", address: 14000caf0, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
@@ -549,49 +549,49 @@ Symbols
 918: Symbol { name: "__b2d_D2A", address: 140007110, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 919: Symbol { name: "__d2b_D2A", address: 140007230, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 920: Symbol { name: "__strcp_D2A", address: 140007340, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-921: Symbol { name: ".text", address: 140006670, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-923: Symbol { name: ".data", address: 140008080, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-925: Symbol { name: ".bss", address: 14000c180, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-927: Symbol { name: ".xdata", address: 14000b2dc, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-929: Symbol { name: ".pdata", address: 14000a2f4, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-931: Symbol { name: ".rdata", address: 140009520, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-933: Symbol { name: ".debug_frame", address: 140033580, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-935: Symbol { name: ".debug_info", address: 1400217f3, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-937: Symbol { name: ".debug_abbrev", address: 1400282c8, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-939: Symbol { name: ".debug_loc", address: 140044095, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-941: Symbol { name: ".debug_aranges", address: 140012490, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-943: Symbol { name: ".debug_ranges", address: 14004a0b0, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-945: Symbol { name: ".debug_line", address: 14002fe05, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-947: Symbol { name: ".debug_str", address: 140035718, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-949: Symbol { name: ".rdata$zzz", address: 140009dc0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+921: Symbol { name: ".text", address: 140006670, size: cfa, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+923: Symbol { name: ".data", address: 140008080, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+925: Symbol { name: ".bss", address: 14000c180, size: 9d0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+927: Symbol { name: ".xdata", address: 14000b2dc, size: ac, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+929: Symbol { name: ".pdata", address: 14000a2f4, size: a8, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+931: Symbol { name: ".rdata", address: 140009520, size: 148, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+933: Symbol { name: ".debug_frame", address: 140033580, size: 620, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+935: Symbol { name: ".debug_info", address: 1400217f3, size: 1ad5, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+937: Symbol { name: ".debug_abbrev", address: 1400282c8, size: 43a, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+939: Symbol { name: ".debug_loc", address: 140044095, size: 2d2f, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+941: Symbol { name: ".debug_aranges", address: 140012490, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+943: Symbol { name: ".debug_ranges", address: 14004a0b0, size: 3b0, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+945: Symbol { name: ".debug_line", address: 14002fe05, size: 103c, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+947: Symbol { name: ".debug_str", address: 140035718, size: 70, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+949: Symbol { name: ".rdata$zzz", address: 140009dc0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 951: Symbol { name: "strnlen.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 953: Symbol { name: "strnlen", address: 140007370, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-955: Symbol { name: ".text", address: 140007370, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-957: Symbol { name: ".data", address: 140008090, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-959: Symbol { name: ".bss", address: 14000cb60, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-961: Symbol { name: ".xdata", address: 14000b388, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-963: Symbol { name: ".pdata", address: 14000a39c, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-965: Symbol { name: ".debug_frame", address: 140033ba0, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-967: Symbol { name: ".debug_info", address: 1400232c8, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-969: Symbol { name: ".debug_abbrev", address: 140028702, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-971: Symbol { name: ".debug_loc", address: 140046dc4, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-973: Symbol { name: ".debug_aranges", address: 1400124c0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-975: Symbol { name: ".debug_line", address: 140030e41, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-977: Symbol { name: ".rdata$zzz", address: 140009df0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+955: Symbol { name: ".text", address: 140007370, size: 28, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+957: Symbol { name: ".data", address: 140008090, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+959: Symbol { name: ".bss", address: 14000cb60, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+961: Symbol { name: ".xdata", address: 14000b388, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+963: Symbol { name: ".pdata", address: 14000a39c, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+965: Symbol { name: ".debug_frame", address: 140033ba0, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+967: Symbol { name: ".debug_info", address: 1400232c8, size: 1e0, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+969: Symbol { name: ".debug_abbrev", address: 140028702, size: 81, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+971: Symbol { name: ".debug_loc", address: 140046dc4, size: 3a, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+973: Symbol { name: ".debug_aranges", address: 1400124c0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+975: Symbol { name: ".debug_line", address: 140030e41, size: f7, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+977: Symbol { name: ".rdata$zzz", address: 140009df0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 979: Symbol { name: "wcsnlen.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 981: Symbol { name: "wcsnlen", address: 1400073a0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-983: Symbol { name: ".text", address: 1400073a0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-985: Symbol { name: ".data", address: 140008090, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-987: Symbol { name: ".bss", address: 14000cb60, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-989: Symbol { name: ".xdata", address: 14000b38c, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-991: Symbol { name: ".pdata", address: 14000a3a8, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-993: Symbol { name: ".debug_frame", address: 140033bd0, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-995: Symbol { name: ".debug_info", address: 1400234a8, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-997: Symbol { name: ".debug_abbrev", address: 140028783, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-999: Symbol { name: ".debug_loc", address: 140046dfe, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-1001: Symbol { name: ".debug_aranges", address: 1400124f0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1003: Symbol { name: ".debug_line", address: 140030f38, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1005: Symbol { name: ".rdata$zzz", address: 140009e20, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+983: Symbol { name: ".text", address: 1400073a0, size: 27, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+985: Symbol { name: ".data", address: 140008090, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+987: Symbol { name: ".bss", address: 14000cb60, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+989: Symbol { name: ".xdata", address: 14000b38c, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+991: Symbol { name: ".pdata", address: 14000a3a8, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+993: Symbol { name: ".debug_frame", address: 140033bd0, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+995: Symbol { name: ".debug_info", address: 1400234a8, size: 1f3, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+997: Symbol { name: ".debug_abbrev", address: 140028783, size: 95, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+999: Symbol { name: ".debug_loc", address: 140046dfe, size: 7c, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1001: Symbol { name: ".debug_aranges", address: 1400124f0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1003: Symbol { name: ".debug_line", address: 140030f38, size: 112, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1005: Symbol { name: ".rdata$zzz", address: 140009e20, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1007: Symbol { name: ".text", address: 1400073d0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 1008: Symbol { name: ".data", address: 140008090, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
 1009: Symbol { name: ".bss", address: 14000cb60, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
@@ -789,137 +789,137 @@ Symbols
 1203: Symbol { name: "internal_mbstate.1", address: 14000cb64, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 1204: Symbol { name: "mbrlen", address: 1400077a0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 1205: Symbol { name: "s_mbstate.0", address: 14000cb60, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1206: Symbol { name: ".text", address: 1400074a0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1208: Symbol { name: ".data", address: 140008090, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1210: Symbol { name: ".bss", address: 14000cb60, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1212: Symbol { name: ".xdata", address: 14000b390, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1214: Symbol { name: ".pdata", address: 14000a3b4, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1216: Symbol { name: ".debug_frame", address: 140033c00, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1218: Symbol { name: ".debug_info", address: 14002369b, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1220: Symbol { name: ".debug_abbrev", address: 140028818, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1222: Symbol { name: ".debug_loc", address: 140046e7a, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-1224: Symbol { name: ".debug_aranges", address: 140012520, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1226: Symbol { name: ".debug_ranges", address: 14004a460, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-1228: Symbol { name: ".debug_line", address: 14003104a, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1230: Symbol { name: ".debug_str", address: 140035788, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-1232: Symbol { name: ".rdata$zzz", address: 140009e50, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1206: Symbol { name: ".text", address: 1400074a0, size: 35a, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1208: Symbol { name: ".data", address: 140008090, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1210: Symbol { name: ".bss", address: 14000cb60, size: c, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1212: Symbol { name: ".xdata", address: 14000b390, size: 40, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1214: Symbol { name: ".pdata", address: 14000a3b4, size: 30, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1216: Symbol { name: ".debug_frame", address: 140033c00, size: 260, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1218: Symbol { name: ".debug_info", address: 14002369b, size: 723, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1220: Symbol { name: ".debug_abbrev", address: 140028818, size: 179, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1222: Symbol { name: ".debug_loc", address: 140046e7a, size: a4f, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1224: Symbol { name: ".debug_aranges", address: 140012520, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1226: Symbol { name: ".debug_ranges", address: 14004a460, size: 30, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1228: Symbol { name: ".debug_line", address: 14003104a, size: 35b, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1230: Symbol { name: ".debug_str", address: 140035788, size: 69, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1232: Symbol { name: ".rdata$zzz", address: 140009e50, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1234: Symbol { name: "wcrtomb.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1236: Symbol { name: "__wcrtomb_cp", address: 140007800, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 1238: Symbol { name: "wcrtomb", address: 140007890, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 1239: Symbol { name: "wcsrtombs", address: 1400078e0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1240: Symbol { name: ".text", address: 140007800, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1242: Symbol { name: ".data", address: 140008090, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1244: Symbol { name: ".bss", address: 14000cb70, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1246: Symbol { name: ".xdata", address: 14000b3d0, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1248: Symbol { name: ".pdata", address: 14000a3e4, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1250: Symbol { name: ".debug_frame", address: 140033e60, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1252: Symbol { name: ".debug_info", address: 140023dbe, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1254: Symbol { name: ".debug_abbrev", address: 140028991, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1256: Symbol { name: ".debug_loc", address: 1400478c9, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-1258: Symbol { name: ".debug_aranges", address: 140012550, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1260: Symbol { name: ".debug_ranges", address: 14004a490, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-1262: Symbol { name: ".debug_line", address: 1400313a5, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1264: Symbol { name: ".debug_str", address: 1400357f1, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-1266: Symbol { name: ".rdata$zzz", address: 140009e80, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1240: Symbol { name: ".text", address: 140007800, size: 1d6, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1242: Symbol { name: ".data", address: 140008090, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1244: Symbol { name: ".bss", address: 14000cb70, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1246: Symbol { name: ".xdata", address: 14000b3d0, size: 28, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1248: Symbol { name: ".pdata", address: 14000a3e4, size: 24, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1250: Symbol { name: ".debug_frame", address: 140033e60, size: 158, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1252: Symbol { name: ".debug_info", address: 140023dbe, size: 567, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1254: Symbol { name: ".debug_abbrev", address: 140028991, size: 14a, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1256: Symbol { name: ".debug_loc", address: 1400478c9, size: 6cb, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1258: Symbol { name: ".debug_aranges", address: 140012550, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1260: Symbol { name: ".debug_ranges", address: 14004a490, size: 30, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1262: Symbol { name: ".debug_line", address: 1400313a5, size: 26f, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1264: Symbol { name: ".debug_str", address: 1400357f1, size: 47, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1266: Symbol { name: ".rdata$zzz", address: 140009e80, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1268: Symbol { name: "acrt_iob_func.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1270: Symbol { name: "__acrt_iob_func", address: 1400079e0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1272: Symbol { name: ".text", address: 1400079e0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1274: Symbol { name: ".data", address: 140008090, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1276: Symbol { name: ".bss", address: 14000cb70, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1278: Symbol { name: ".xdata", address: 14000b3f8, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1280: Symbol { name: ".pdata", address: 14000a408, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1282: Symbol { name: ".debug_frame", address: 140033fb8, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1284: Symbol { name: ".debug_info", address: 140024325, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1286: Symbol { name: ".debug_abbrev", address: 140028adb, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1288: Symbol { name: ".debug_loc", address: 140047f94, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-1290: Symbol { name: ".debug_aranges", address: 140012580, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1292: Symbol { name: ".debug_line", address: 140031614, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1294: Symbol { name: ".debug_str", address: 140035838, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-1296: Symbol { name: ".rdata$zzz", address: 140009eb0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1272: Symbol { name: ".text", address: 1400079e0, size: 1f, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1274: Symbol { name: ".data", address: 140008090, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1276: Symbol { name: ".bss", address: 14000cb70, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1278: Symbol { name: ".xdata", address: 14000b3f8, size: 8, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1280: Symbol { name: ".pdata", address: 14000a408, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1282: Symbol { name: ".debug_frame", address: 140033fb8, size: 50, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1284: Symbol { name: ".debug_info", address: 140024325, size: 2d4, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1286: Symbol { name: ".debug_abbrev", address: 140028adb, size: ce, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1288: Symbol { name: ".debug_loc", address: 140047f94, size: 4f, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1290: Symbol { name: ".debug_aranges", address: 140012580, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1292: Symbol { name: ".debug_line", address: 140031614, size: dc, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1294: Symbol { name: ".debug_str", address: 140035838, size: b, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1296: Symbol { name: ".rdata$zzz", address: 140009eb0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1298: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1300: Symbol { name: "mingw_get_invalid_parameter_handler", address: 140007a00, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 1302: Symbol { name: "handler", address: 14000cb70, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
 1303: Symbol { name: "_get_invalid_parameter_handler", address: 140007a00, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 1304: Symbol { name: "mingw_set_invalid_parameter_handler", address: 140007a10, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 1305: Symbol { name: "_set_invalid_parameter_handler", address: 140007a10, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1306: Symbol { name: ".text", address: 140007a00, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1308: Symbol { name: ".data", address: 1400080a0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1310: Symbol { name: ".bss", address: 14000cb70, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1312: Symbol { name: ".xdata", address: 14000b400, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1314: Symbol { name: ".pdata", address: 14000a414, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1316: Symbol { name: ".debug_frame", address: 140034008, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1318: Symbol { name: ".debug_info", address: 1400245f9, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1320: Symbol { name: ".debug_abbrev", address: 140028ba9, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1322: Symbol { name: ".debug_loc", address: 140047fe3, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-1324: Symbol { name: ".debug_aranges", address: 1400125b0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1326: Symbol { name: ".debug_line", address: 1400316f0, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1328: Symbol { name: ".rdata$zzz", address: 140009ee0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1306: Symbol { name: ".text", address: 140007a00, size: 1b, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1308: Symbol { name: ".data", address: 1400080a0, size: 10, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1310: Symbol { name: ".bss", address: 14000cb70, size: 8, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1312: Symbol { name: ".xdata", address: 14000b400, size: 8, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1314: Symbol { name: ".pdata", address: 14000a414, size: 18, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1316: Symbol { name: ".debug_frame", address: 140034008, size: 48, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1318: Symbol { name: ".debug_info", address: 1400245f9, size: 6ca, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1320: Symbol { name: ".debug_abbrev", address: 140028ba9, size: 15f, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1322: Symbol { name: ".debug_loc", address: 140047fe3, size: 53, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1324: Symbol { name: ".debug_aranges", address: 1400125b0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1326: Symbol { name: ".debug_line", address: 1400316f0, size: 17c, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1328: Symbol { name: ".rdata$zzz", address: 140009ee0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1330: Symbol { name: "mingw_lock.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1332: Symbol { name: "_lock_file", address: 140007a20, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 1334: Symbol { name: "_unlock_file", address: 140007a90, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1335: Symbol { name: ".text", address: 140007a20, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1337: Symbol { name: ".data", address: 1400080b0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1339: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1341: Symbol { name: ".xdata", address: 14000b408, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1343: Symbol { name: ".pdata", address: 14000a42c, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1345: Symbol { name: ".debug_frame", address: 140034050, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1347: Symbol { name: ".debug_info", address: 140024cc3, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1349: Symbol { name: ".debug_abbrev", address: 140028d08, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1351: Symbol { name: ".debug_loc", address: 140048036, size: 0, kind: Data, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: None }
-1353: Symbol { name: ".debug_aranges", address: 1400125e0, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1355: Symbol { name: ".debug_ranges", address: 14004a4c0, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: None }
-1357: Symbol { name: ".debug_line", address: 14003186c, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1359: Symbol { name: ".debug_str", address: 140035843, size: 0, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
-1361: Symbol { name: ".rdata$zzz", address: 140009f10, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1335: Symbol { name: ".text", address: 140007a20, size: d0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1337: Symbol { name: ".data", address: 1400080b0, size: 10, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1339: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1341: Symbol { name: ".xdata", address: 14000b408, size: 10, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1343: Symbol { name: ".pdata", address: 14000a42c, size: 18, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1345: Symbol { name: ".debug_frame", address: 140034050, size: b8, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1347: Symbol { name: ".debug_info", address: 140024cc3, size: a51, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1349: Symbol { name: ".debug_abbrev", address: 140028d08, size: 1c5, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1351: Symbol { name: ".debug_loc", address: 140048036, size: 1a6, kind: Section, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1353: Symbol { name: ".debug_aranges", address: 1400125e0, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1355: Symbol { name: ".debug_ranges", address: 14004a4c0, size: 30, kind: Section, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1357: Symbol { name: ".debug_line", address: 14003186c, size: 225, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1359: Symbol { name: ".debug_str", address: 140035843, size: 3a, kind: Section, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1361: Symbol { name: ".rdata$zzz", address: 140009f10, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1363: Symbol { name: "__p__acmdln.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1365: Symbol { name: "__p__acmdln", address: 140007af0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1367: Symbol { name: ".rdata$.refptr.__imp__acmdln", address: 140009700, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-1369: Symbol { name: ".text", address: 140007af0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1371: Symbol { name: ".data", address: 1400080c0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1373: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1375: Symbol { name: ".xdata", address: 14000b418, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1377: Symbol { name: ".pdata", address: 14000a444, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1379: Symbol { name: ".debug_frame", address: 140034108, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1381: Symbol { name: ".debug_info", address: 140025714, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1383: Symbol { name: ".debug_abbrev", address: 140028ecd, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1385: Symbol { name: ".debug_aranges", address: 140012610, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1387: Symbol { name: ".debug_line", address: 140031a91, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1389: Symbol { name: ".rdata$zzz", address: 140009f40, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1367: Symbol { name: ".rdata$.refptr.__imp__acmdln", address: 140009700, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+1369: Symbol { name: ".text", address: 140007af0, size: b, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1371: Symbol { name: ".data", address: 1400080c0, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1373: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1375: Symbol { name: ".xdata", address: 14000b418, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1377: Symbol { name: ".pdata", address: 14000a444, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1379: Symbol { name: ".debug_frame", address: 140034108, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1381: Symbol { name: ".debug_info", address: 140025714, size: 176, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1383: Symbol { name: ".debug_abbrev", address: 140028ecd, size: 82, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1385: Symbol { name: ".debug_aranges", address: 140012610, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1387: Symbol { name: ".debug_line", address: 140031a91, size: 87, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1389: Symbol { name: ".rdata$zzz", address: 140009f40, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1391: Symbol { name: "__p__commode.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1393: Symbol { name: "__p__commode", address: 140007b00, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1395: Symbol { name: ".rdata$.refptr.__imp__commode", address: 140009710, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-1397: Symbol { name: ".text", address: 140007b00, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1399: Symbol { name: ".data", address: 1400080d0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1401: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1403: Symbol { name: ".xdata", address: 14000b41c, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1405: Symbol { name: ".pdata", address: 14000a450, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1407: Symbol { name: ".debug_frame", address: 140034138, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1409: Symbol { name: ".debug_info", address: 14002588a, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1411: Symbol { name: ".debug_abbrev", address: 140028f4f, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1413: Symbol { name: ".debug_aranges", address: 140012640, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1415: Symbol { name: ".debug_line", address: 140031b18, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1417: Symbol { name: ".rdata$zzz", address: 140009f70, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1395: Symbol { name: ".rdata$.refptr.__imp__commode", address: 140009710, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+1397: Symbol { name: ".text", address: 140007b00, size: b, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1399: Symbol { name: ".data", address: 1400080d0, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1401: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1403: Symbol { name: ".xdata", address: 14000b41c, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1405: Symbol { name: ".pdata", address: 14000a450, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1407: Symbol { name: ".debug_frame", address: 140034138, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1409: Symbol { name: ".debug_info", address: 14002588a, size: 165, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1411: Symbol { name: ".debug_abbrev", address: 140028f4f, size: 73, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1413: Symbol { name: ".debug_aranges", address: 140012640, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1415: Symbol { name: ".debug_line", address: 140031b18, size: 88, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1417: Symbol { name: ".rdata$zzz", address: 140009f70, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1419: Symbol { name: "__p__fmode.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1421: Symbol { name: "__p__fmode", address: 140007b10, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
-1423: Symbol { name: ".rdata$.refptr.__imp__fmode", address: 140009720, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
-1425: Symbol { name: ".text", address: 140007b10, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1427: Symbol { name: ".data", address: 1400080e0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1429: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1431: Symbol { name: ".xdata", address: 14000b420, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1433: Symbol { name: ".pdata", address: 14000a45c, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1435: Symbol { name: ".debug_frame", address: 140034168, size: 0, kind: Data, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: None }
-1437: Symbol { name: ".debug_info", address: 1400259ef, size: 0, kind: Data, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: None }
-1439: Symbol { name: ".debug_abbrev", address: 140028fc2, size: 0, kind: Data, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: None }
-1441: Symbol { name: ".debug_aranges", address: 140012670, size: 0, kind: Data, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: None }
-1443: Symbol { name: ".debug_line", address: 140031ba0, size: 0, kind: Data, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: None }
-1445: Symbol { name: ".rdata$zzz", address: 140009fa0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1423: Symbol { name: ".rdata$.refptr.__imp__fmode", address: 140009720, size: 8, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 2, associative_section: None } }
+1425: Symbol { name: ".text", address: 140007b10, size: b, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1427: Symbol { name: ".data", address: 1400080e0, size: 8, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1429: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1431: Symbol { name: ".xdata", address: 14000b420, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1433: Symbol { name: ".pdata", address: 14000a45c, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1435: Symbol { name: ".debug_frame", address: 140034168, size: 30, kind: Section, section: Section(SectionIndex(10)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1437: Symbol { name: ".debug_info", address: 1400259ef, size: 15d, kind: Section, section: Section(SectionIndex(d)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1439: Symbol { name: ".debug_abbrev", address: 140028fc2, size: 73, kind: Section, section: Section(SectionIndex(e)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1441: Symbol { name: ".debug_aranges", address: 140012670, size: 30, kind: Section, section: Section(SectionIndex(c)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1443: Symbol { name: ".debug_line", address: 140031ba0, size: 86, kind: Section, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1445: Symbol { name: ".rdata$zzz", address: 140009fa0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1447: Symbol { name: "fake", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1449: Symbol { name: "hname", address: 14000d0b4, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1450: Symbol { name: "fthunk", address: 14000d24c, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
-1451: Symbol { name: ".text", address: 140007b20, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1453: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1455: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1457: Symbol { name: ".idata$2", address: 14000d014, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
+1451: Symbol { name: ".text", address: 140007b20, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1453: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1455: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1457: Symbol { name: ".idata$2", address: 14000d014, size: 14, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1459: Symbol { name: ".idata$4", address: 14000d0b4, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1460: Symbol { name: ".idata$5", address: 14000d24c, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1461: Symbol { name: ".text", address: 140007b20, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
@@ -965,12 +965,12 @@ Symbols
 1501: Symbol { name: ".idata$4", address: 14000d0bc, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1502: Symbol { name: ".idata$6", address: 14000d4a0, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1503: Symbol { name: "fake", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-1505: Symbol { name: ".text", address: 140007b50, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1507: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1509: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1511: Symbol { name: ".idata$4", address: 14000d1cc, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
-1513: Symbol { name: ".idata$5", address: 14000d364, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
-1515: Symbol { name: ".idata$7", address: 14000d704, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
+1505: Symbol { name: ".text", address: 140007b50, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1507: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1509: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1511: Symbol { name: ".idata$4", address: 14000d1cc, size: 8, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1513: Symbol { name: ".idata$5", address: 14000d364, size: 8, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1515: Symbol { name: ".idata$7", address: 14000d704, size: b, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1517: Symbol { name: ".text", address: 140007b50, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 1518: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
 1519: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
@@ -1072,19 +1072,19 @@ Symbols
 1615: Symbol { name: "fake", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1617: Symbol { name: "hname", address: 14000d03c, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1618: Symbol { name: "fthunk", address: 14000d1d4, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
-1619: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1621: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1623: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
+1619: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1621: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1623: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1625: Symbol { name: ".idata$2", address: 14000d000, size: 14, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1627: Symbol { name: ".idata$4", address: 14000d03c, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1628: Symbol { name: ".idata$5", address: 14000d1d4, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1629: Symbol { name: "fake", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-1631: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1633: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1635: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1637: Symbol { name: ".idata$4", address: 14000d0ac, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
-1639: Symbol { name: ".idata$5", address: 14000d244, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
-1641: Symbol { name: ".idata$7", address: 14000d668, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
+1631: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1633: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1635: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1637: Symbol { name: ".idata$4", address: 14000d0ac, size: 8, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1639: Symbol { name: ".idata$5", address: 14000d244, size: 8, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1641: Symbol { name: ".idata$7", address: 14000d668, size: d, kind: Section, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1643: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 1644: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
 1645: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
@@ -1101,14 +1101,14 @@ Symbols
 1656: Symbol { name: ".idata$6", address: 14000d53e, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: None }
 1657: Symbol { name: "cygming-crtend.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 1659: Symbol { name: "register_frame_ctor", address: 140007bc0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1661: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1663: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Data, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: None }
-1665: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Data, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: None }
-1667: Symbol { name: ".text.startup", address: 140007bc0, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1669: Symbol { name: ".xdata.startup", address: 14000b424, size: 0, kind: Data, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: None }
-1671: Symbol { name: ".pdata.startup", address: 14000a468, size: 0, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: None }
-1673: Symbol { name: ".ctors.65535", address: 140007bd8, size: 0, kind: Data, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
-1675: Symbol { name: ".rdata$zzz", address: 140009fd0, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: None }
+1661: Symbol { name: ".text", address: 140007bc0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1663: Symbol { name: ".data", address: 1400080f0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1665: Symbol { name: ".bss", address: 14000cb80, size: 0, kind: Section, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1667: Symbol { name: ".text.startup", address: 140007bc0, size: 5, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1669: Symbol { name: ".xdata.startup", address: 14000b424, size: 4, kind: Section, section: Section(SectionIndex(5)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1671: Symbol { name: ".pdata.startup", address: 14000a468, size: c, kind: Section, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1673: Symbol { name: ".ctors.65535", address: 140007bd8, size: 8, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+1675: Symbol { name: ".rdata$zzz", address: 140009fd0, size: 2b, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 1677: Symbol { name: ".rsrc", address: 140010000, size: 0, kind: Data, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
 1678: Symbol { name: "__xc_z", address: 14000e010, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Linkage, weak: false, flags: None }
 1679: Symbol { name: "___RUNTIME_PSEUDO_RELOC_LIST__", address: 14000a000, size: 0, kind: Data, section: Section(SectionIndex(3)), scope: Linkage, weak: false, flags: None }
@@ -1403,6 +1403,7 @@ Symbol map
 0x0 "__loader_flags__"
 0x0 "__minor_subsystem_version__"
 0x0 "__minor_image_version__"
+0x140001000 "__mingw_invalidParameterHandler"
 0x140001010 "pre_c_init"
 0x140001130 "pre_cpp_init"
 0x140001180 "__tmainCRTStartup"
@@ -1410,51 +1411,30 @@ Symbol map
 0x1400014d0 "mainCRTStartup"
 0x1400014f0 "atexit"
 0x140001510 "__gcc_register_frame"
-0x140001510 ".text"
 0x140001520 "__gcc_deregister_frame"
 0x140001530 "printf"
-0x140001530 ".text"
 0x140001581 "main"
 0x1400015b0 "__do_global_dtors"
-0x1400015b0 ".text"
 0x1400015f0 "__do_global_ctors"
 0x140001660 "__main"
-0x140001680 ".text"
-0x140001680 ".text"
 0x140001680 "_setargv"
-0x140001680 ".text"
-0x140001690 ".text"
 0x140001690 "__dyn_tls_dtor"
-0x140001690 ".text"
 0x1400016c0 "__dyn_tls_init"
 0x140001750 "__tlregdtor"
-0x140001760 ".text"
-0x140001760 ".text"
 0x140001760 "_matherr"
-0x140001760 ".text"
 0x140001860 "_fpreset"
 0x140001860 "fpreset"
-0x140001860 ".text"
-0x140001870 ".text"
 0x140001870 "__report_error"
-0x140001870 ".text"
 0x1400018e0 "mark_section_writable"
 0x140001a50 "_pei386_runtime_relocator"
 0x140001cd0 "__mingw_raise_matherr"
-0x140001cd0 ".text"
 0x140001d20 "__mingw_setusermatherr"
-0x140001d30 ".text"
 0x140001d30 "_gnu_exception_handler"
-0x140001d30 ".text"
 0x140001ef0 "__mingwthr_run_key_dtors.part.0"
-0x140001ef0 ".text"
 0x140001f60 "___w64_mingwthr_add_key_dtor"
 0x140001fe0 "___w64_mingwthr_remove_key_dtor"
 0x140002070 "__mingw_TLScallback"
-0x140002160 ".text"
-0x140002160 ".text"
 0x140002160 "_ValidateImageBase"
-0x140002160 ".text"
 0x140002190 "_FindPESection"
 0x1400021e0 "_FindPESectionByName"
 0x140002280 "__mingw_GetSectionForAddress"
@@ -1463,14 +1443,9 @@ Symbol map
 0x1400023b0 "_GetPEImageBase"
 0x1400023f0 "_IsNonwritableInCurrentImage"
 0x140002480 "__mingw_enum_import_library_names"
-0x140002540 ".text"
 0x140002540 "___chkstk_ms"
-0x140002580 ".text"
-0x140002580 ".text"
 0x140002580 "__mingw_vfprintf"
-0x140002580 ".text"
 0x1400025d0 "__pformat_cvt"
-0x1400025d0 ".text"
 0x1400026f0 "__pformat_putc"
 0x140002750 "__pformat_wputchars"
 0x1400028b0 "__pformat_putchars"
@@ -1487,17 +1462,13 @@ Symbol map
 0x140003cc0 "__pformat_xldouble"
 0x140004200 "__mingw_pformat"
 0x140004bb0 "__rv_alloc_D2A"
-0x140004bb0 ".text"
 0x140004bf0 "__nrv_alloc_D2A"
 0x140004c70 "__freedtoa"
 0x140004c90 "__quorem_D2A"
 0x140004e10 "__gdtoa"
-0x140004e10 ".text"
 0x140006520 "__rshift_D2A"
-0x140006520 ".text"
 0x140006620 "__trailz_D2A"
 0x140006670 "dtoa_lock"
-0x140006670 ".text"
 0x140006750 "dtoa_lock_cleanup"
 0x1400067a0 "__Balloc_D2A"
 0x1400068a0 "__Bfree_D2A"
@@ -1512,9 +1483,7 @@ Symbol map
 0x140007230 "__d2b_D2A"
 0x140007340 "__strcp_D2A"
 0x140007370 "strnlen"
-0x140007370 ".text"
 0x1400073a0 "wcsnlen"
-0x1400073a0 ".text"
 0x1400073d0 ".text"
 0x1400073d0 "wcslen"
 0x1400073d8 ".text"
@@ -1569,31 +1538,22 @@ Symbol map
 0x140007498 ".text"
 0x140007498 "__C_specific_handler"
 0x1400074a0 "__mbrtowc_cp"
-0x1400074a0 ".text"
 0x140007620 "mbrtowc"
 0x140007690 "mbsrtowcs"
 0x1400077a0 "mbrlen"
 0x140007800 "__wcrtomb_cp"
-0x140007800 ".text"
 0x140007890 "wcrtomb"
 0x1400078e0 "wcsrtombs"
 0x1400079e0 "__acrt_iob_func"
-0x1400079e0 ".text"
 0x140007a00 "mingw_get_invalid_parameter_handler"
 0x140007a00 "_get_invalid_parameter_handler"
-0x140007a00 ".text"
 0x140007a10 "mingw_set_invalid_parameter_handler"
 0x140007a10 "_set_invalid_parameter_handler"
 0x140007a20 "_lock_file"
-0x140007a20 ".text"
 0x140007a90 "_unlock_file"
 0x140007af0 "__p__acmdln"
-0x140007af0 ".text"
 0x140007b00 "__p__commode"
-0x140007b00 ".text"
 0x140007b10 "__p__fmode"
-0x140007b10 ".text"
-0x140007b20 ".text"
 0x140007b20 ".text"
 0x140007b20 "_unlock"
 0x140007b28 ".text"
@@ -1605,7 +1565,6 @@ Symbol map
 0x140007b38 "___mb_cur_max_func"
 0x140007b40 ".text"
 0x140007b40 "___lc_codepage_func"
-0x140007b50 ".text"
 0x140007b50 ".text"
 0x140007b50 "WideCharToMultiByte"
 0x140007b58 ".text"
@@ -1636,61 +1595,21 @@ Symbol map
 0x140007bb8 "DeleteCriticalSection"
 0x140007bc0 ".text"
 0x140007bc0 ".text"
-0x140007bc0 ".text"
-0x140007bc0 ".text"
 0x140007bc0 "register_frame_ctor"
-0x140007bc0 ".text"
-0x140007bc0 ".text.startup"
 0x140007bd0 "__CTOR_LIST__"
 0x140007bd0 "___CTOR_LIST__"
-0x140007bd8 ".ctors.65535"
 0x140007be8 "___DTOR_LIST__"
 0x140007be8 "__DTOR_LIST__"
 0x140008000 "__data_start__"
 0x140008000 "__mingw_winmain_nShowCmd"
-0x140008010 ".data"
-0x140008010 ".data"
 0x140008010 "p.0"
-0x140008010 ".data"
-0x140008020 ".data"
 0x140008020 "__native_vcclrit_reason"
 0x140008024 "__native_dllmain_reason"
-0x140008030 ".data"
 0x140008030 "_dowildcard"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
-0x140008040 ".data"
 0x140008040 "_CRT_MT"
-0x140008050 ".data"
-0x140008050 ".data"
-0x140008050 ".data"
-0x140008050 ".data"
-0x140008050 ".data"
 0x140008050 "_MINGW_INSTALL_DEBUG_MATHERR"
-0x140008060 ".data"
 0x140008060 "fpi.0"
-0x140008060 ".data"
-0x140008080 ".data"
-0x140008080 ".data"
-0x140008080 ".data"
 0x140008080 "pmem_next"
-0x140008080 ".data"
-0x140008090 ".data"
-0x140008090 ".data"
-0x140008090 ".data"
-0x140008090 ".data"
-0x140008090 ".data"
 0x140008090 ".data"
 0x140008090 ".data"
 0x140008090 ".data"
@@ -1719,17 +1638,12 @@ Symbol map
 0x140008090 ".data"
 0x140008090 ".data"
 0x140008090 "__imp___acrt_iob_func"
-0x1400080a0 ".data"
 0x1400080a0 "__imp__get_invalid_parameter_handler"
 0x1400080a8 "__imp__set_invalid_parameter_handler"
-0x1400080b0 ".data"
 0x1400080b0 "__imp__unlock_file"
 0x1400080b8 "__imp__lock_file"
-0x1400080c0 ".data"
 0x1400080c0 "__imp___p__acmdln"
-0x1400080d0 ".data"
 0x1400080d0 "__imp___p__commode"
-0x1400080e0 ".data"
 0x1400080e0 "__imp___p__fmode"
 0x1400080f0 ".data"
 0x1400080f0 ".data"
@@ -1753,188 +1667,48 @@ Symbol map
 0x1400080f0 ".data"
 0x1400080f0 ".data"
 0x1400080f0 ".data"
-0x1400080f0 ".data"
-0x1400080f0 ".data"
-0x1400080f0 ".data"
-0x1400080f0 ".data"
-0x1400080f0 ".data"
 0x1400080f0 "__data_end__"
-0x140009020 ".rdata"
 0x140009020 "__dyn_tls_init_callback"
 0x140009040 "_tls_used"
-0x140009080 ".rdata"
-0x1400091c0 ".rdata"
-0x1400092d0 ".rdata"
-0x140009300 ".rdata"
-0x140009490 ".rdata"
 0x140009520 "p05.0"
-0x140009520 ".rdata"
 0x140009540 "__tens_D2A"
 0x140009600 "__tinytens_D2A"
 0x140009640 "__bigtens_D2A"
-0x140009680 ".rdata$.refptr._CRT_MT"
 0x140009680 ".refptr._CRT_MT"
-0x140009690 ".rdata$.refptr._MINGW_INSTALL_DEBUG_MATHERR"
 0x140009690 ".refptr._MINGW_INSTALL_DEBUG_MATHERR"
-0x1400096a0 ".rdata$.refptr.__CTOR_LIST__"
 0x1400096a0 ".refptr.__CTOR_LIST__"
-0x1400096b0 ".rdata$.refptr.__RUNTIME_PSEUDO_RELOC_LIST_END__"
 0x1400096b0 ".refptr.__RUNTIME_PSEUDO_RELOC_LIST_END__"
-0x1400096c0 ".rdata$.refptr.__RUNTIME_PSEUDO_RELOC_LIST__"
 0x1400096c0 ".refptr.__RUNTIME_PSEUDO_RELOC_LIST__"
-0x1400096d0 ".rdata$.refptr.__dyn_tls_init_callback"
 0x1400096d0 ".refptr.__dyn_tls_init_callback"
-0x1400096e0 ".rdata$.refptr.__image_base__"
 0x1400096e0 ".refptr.__image_base__"
-0x1400096f0 ".rdata$.refptr.__imp___initenv"
 0x1400096f0 ".refptr.__imp___initenv"
-0x140009700 ".rdata$.refptr.__imp__acmdln"
 0x140009700 ".refptr.__imp__acmdln"
-0x140009710 ".rdata$.refptr.__imp__commode"
 0x140009710 ".refptr.__imp__commode"
-0x140009720 ".rdata$.refptr.__imp__fmode"
 0x140009720 ".refptr.__imp__fmode"
-0x140009730 ".rdata$.refptr.__mingw_app_type"
 0x140009730 ".refptr.__mingw_app_type"
-0x140009740 ".rdata$.refptr.__mingw_initltsdrot_force"
 0x140009740 ".refptr.__mingw_initltsdrot_force"
-0x140009750 ".rdata$.refptr.__mingw_initltsdyn_force"
 0x140009750 ".refptr.__mingw_initltsdyn_force"
-0x140009760 ".rdata$.refptr.__mingw_initltssuo_force"
 0x140009760 ".refptr.__mingw_initltssuo_force"
-0x140009770 ".rdata$.refptr.__mingw_oldexcpt_handler"
 0x140009770 ".refptr.__mingw_oldexcpt_handler"
-0x140009780 ".rdata$.refptr.__native_startup_lock"
 0x140009780 ".refptr.__native_startup_lock"
-0x140009790 ".rdata$.refptr.__native_startup_state"
 0x140009790 ".refptr.__native_startup_state"
-0x1400097a0 ".rdata$.refptr.__tens_D2A"
 0x1400097a0 ".refptr.__tens_D2A"
-0x1400097b0 ".rdata$.refptr.__xc_a"
 0x1400097b0 ".refptr.__xc_a"
-0x1400097c0 ".rdata$.refptr.__xc_z"
 0x1400097c0 ".refptr.__xc_z"
-0x1400097d0 ".rdata$.refptr.__xi_a"
 0x1400097d0 ".refptr.__xi_a"
-0x1400097e0 ".rdata$.refptr.__xi_z"
 0x1400097e0 ".refptr.__xi_z"
-0x1400097f0 ".rdata$.refptr._commode"
 0x1400097f0 ".refptr._commode"
-0x140009800 ".rdata$.refptr._dowildcard"
 0x140009800 ".refptr._dowildcard"
-0x140009810 ".rdata$.refptr._fmode"
 0x140009810 ".refptr._fmode"
-0x140009820 ".rdata$.refptr._gnu_exception_handler"
 0x140009820 ".refptr._gnu_exception_handler"
-0x140009830 ".rdata$.refptr._matherr"
 0x140009830 ".refptr._matherr"
-0x140009840 ".rdata$.refptr._newmode"
 0x140009840 ".refptr._newmode"
-0x140009850 ".rdata$zzz"
-0x140009880 ".rdata$zzz"
-0x1400098b0 ".rdata$zzz"
-0x1400098e0 ".rdata$zzz"
-0x140009910 ".rdata$zzz"
-0x140009940 ".rdata$zzz"
-0x140009970 ".rdata$zzz"
-0x1400099a0 ".rdata$zzz"
-0x1400099d0 ".rdata$zzz"
-0x140009a00 ".rdata$zzz"
-0x140009a30 ".rdata$zzz"
-0x140009a60 ".rdata$zzz"
-0x140009a90 ".rdata$zzz"
-0x140009ac0 ".rdata$zzz"
-0x140009af0 ".rdata$zzz"
-0x140009b20 ".rdata$zzz"
-0x140009b50 ".rdata$zzz"
-0x140009b80 ".rdata$zzz"
-0x140009bb0 ".rdata$zzz"
-0x140009be0 ".rdata$zzz"
-0x140009c10 ".rdata$zzz"
-0x140009c40 ".rdata$zzz"
-0x140009c70 ".rdata$zzz"
-0x140009ca0 ".rdata$zzz"
-0x140009cd0 ".rdata$zzz"
-0x140009d00 ".rdata$zzz"
-0x140009d30 ".rdata$zzz"
-0x140009d60 ".rdata$zzz"
-0x140009d90 ".rdata$zzz"
-0x140009dc0 ".rdata$zzz"
-0x140009df0 ".rdata$zzz"
-0x140009e20 ".rdata$zzz"
-0x140009e50 ".rdata$zzz"
-0x140009e80 ".rdata$zzz"
-0x140009eb0 ".rdata$zzz"
-0x140009ee0 ".rdata$zzz"
-0x140009f10 ".rdata$zzz"
-0x140009f40 ".rdata$zzz"
-0x140009f70 ".rdata$zzz"
-0x140009fa0 ".rdata$zzz"
-0x140009fd0 ".rdata$zzz"
 0x14000a000 "___RUNTIME_PSEUDO_RELOC_LIST__"
 0x14000a000 "__rt_psrelocs_start"
 0x14000a000 "___RUNTIME_PSEUDO_RELOC_LIST_END__"
 0x14000a000 "__RUNTIME_PSEUDO_RELOC_LIST__"
 0x14000a000 "__rt_psrelocs_end"
 0x14000a000 "__RUNTIME_PSEUDO_RELOC_LIST_END__"
-0x14000a054 ".pdata"
-0x14000a06c ".pdata"
-0x14000a084 ".pdata"
-0x14000a0a8 ".pdata"
-0x14000a0b4 ".pdata"
-0x14000a0d8 ".pdata"
-0x14000a0e4 ".pdata"
-0x14000a0f0 ".pdata"
-0x14000a114 ".pdata"
-0x14000a12c ".pdata"
-0x14000a138 ".pdata"
-0x14000a168 ".pdata"
-0x14000a1d4 ".pdata"
-0x14000a1e0 ".pdata"
-0x14000a2a0 ".pdata"
-0x14000a2d0 ".pdata"
-0x14000a2dc ".pdata"
-0x14000a2f4 ".pdata"
-0x14000a39c ".pdata"
-0x14000a3a8 ".pdata"
-0x14000a3b4 ".pdata"
-0x14000a3e4 ".pdata"
-0x14000a408 ".pdata"
-0x14000a414 ".pdata"
-0x14000a42c ".pdata"
-0x14000a444 ".pdata"
-0x14000a450 ".pdata"
-0x14000a45c ".pdata"
-0x14000a468 ".pdata.startup"
-0x14000b070 ".xdata"
-0x14000b078 ".xdata"
-0x14000b090 ".xdata"
-0x14000b0a8 ".xdata"
-0x14000b0ac ".xdata"
-0x14000b0c4 ".xdata"
-0x14000b0dc ".xdata"
-0x14000b0e0 ".xdata"
-0x14000b110 ".xdata"
-0x14000b11c ".xdata"
-0x14000b124 ".xdata"
-0x14000b150 ".xdata"
-0x14000b17c ".xdata"
-0x14000b188 ".xdata"
-0x14000b27c ".xdata"
-0x14000b2ac ".xdata"
-0x14000b2c8 ".xdata"
-0x14000b2dc ".xdata"
-0x14000b388 ".xdata"
-0x14000b38c ".xdata"
-0x14000b390 ".xdata"
-0x14000b3d0 ".xdata"
-0x14000b3f8 ".xdata"
-0x14000b400 ".xdata"
-0x14000b408 ".xdata"
-0x14000b418 ".xdata"
-0x14000b41c ".xdata"
-0x14000b420 ".xdata"
-0x14000b424 ".xdata.startup"
 0x14000c000 "__mingw_module_is_dll"
 0x14000c000 "__bss_start__"
 0x14000c008 "__mingw_winmain_lpCmdLine"
@@ -1946,56 +1720,26 @@ Symbol map
 0x14000c028 "envp"
 0x14000c030 "argv"
 0x14000c038 "argc"
-0x14000c040 ".bss"
-0x14000c040 ".bss"
 0x14000c040 "initialized"
-0x14000c040 ".bss"
-0x14000c050 ".bss"
 0x14000c050 "__native_startup_lock"
 0x14000c058 "__native_startup_state"
-0x14000c060 ".bss"
-0x14000c060 ".bss"
-0x14000c060 ".bss"
 0x14000c060 "_newmode"
-0x14000c070 ".bss"
 0x14000c070 "__mingw_initltssuo_force"
 0x14000c074 "__mingw_initltsdyn_force"
 0x14000c078 "__mingw_initltsdrot_force"
 0x14000c07c "_tls_index"
-0x14000c080 ".bss"
 0x14000c080 "_commode"
-0x14000c090 ".bss"
-0x14000c090 ".bss"
-0x14000c090 ".bss"
-0x14000c090 ".bss"
 0x14000c090 "__mingw_app_type"
 0x14000c0a0 "was_init.0"
-0x14000c0a0 ".bss"
 0x14000c0a4 "maxSections"
 0x14000c0a8 "the_secs"
 0x14000c0b0 "stUserMathErr"
-0x14000c0b0 ".bss"
-0x14000c0c0 ".bss"
 0x14000c0c0 "_fmode"
-0x14000c0d0 ".bss"
 0x14000c0d0 "__mingw_oldexcpt_handler"
 0x14000c0e0 "key_dtor_list"
-0x14000c0e0 ".bss"
 0x14000c0e8 "__mingwthr_cs_init"
 0x14000c100 "__mingwthr_cs"
-0x14000c140 ".bss"
-0x14000c140 ".bss"
-0x14000c150 ".bss"
-0x14000c150 ".bss"
-0x14000c150 ".bss"
-0x14000c170 ".bss"
-0x14000c170 ".bss"
-0x14000c170 ".bss"
-0x14000c170 ".bss"
-0x14000c170 ".bss"
-0x14000c170 ".bss"
 0x14000c180 "p5s"
-0x14000c180 ".bss"
 0x14000c1a0 "private_mem"
 0x14000caa0 "freelist"
 0x14000caf0 "dtoa_CS_init"
@@ -2027,25 +1771,10 @@ Symbol map
 0x14000cb60 ".bss"
 0x14000cb60 ".bss"
 0x14000cb60 ".bss"
-0x14000cb60 ".bss"
-0x14000cb60 ".bss"
 0x14000cb60 "s_mbstate.0"
-0x14000cb60 ".bss"
 0x14000cb64 "internal_mbstate.1"
 0x14000cb68 "internal_mbstate.2"
-0x14000cb70 ".bss"
-0x14000cb70 ".bss"
 0x14000cb70 "handler"
-0x14000cb70 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
-0x14000cb80 ".bss"
 0x14000cb80 ".bss"
 0x14000cb80 ".bss"
 0x14000cb80 ".bss"
@@ -2070,7 +1799,6 @@ Symbol map
 0x14000cb80 ".bss"
 0x14000cb80 "__bss_end__"
 0x14000d000 "_head_lib64_libkernel32_a"
-0x14000d014 ".idata$2"
 0x14000d014 "_head_lib64_libmsvcrt_os_a"
 0x14000d03c ".idata$4"
 0x14000d03c "hname"
@@ -2088,7 +1816,6 @@ Symbol map
 0x14000d094 ".idata$4"
 0x14000d09c ".idata$4"
 0x14000d0a4 ".idata$4"
-0x14000d0ac ".idata$4"
 0x14000d0b4 ".idata$4"
 0x14000d0b4 "hname"
 0x14000d0b4 ".idata$4"
@@ -2126,7 +1853,6 @@ Symbol map
 0x14000d1b4 ".idata$4"
 0x14000d1bc ".idata$4"
 0x14000d1c4 ".idata$4"
-0x14000d1cc ".idata$4"
 0x14000d1d4 ".idata$5"
 0x14000d1d4 "fthunk"
 0x14000d1d4 ".idata$5"
@@ -2158,7 +1884,6 @@ Symbol map
 0x14000d234 "__imp_VirtualQuery"
 0x14000d23c ".idata$5"
 0x14000d23c "__imp_WideCharToMultiByte"
-0x14000d244 ".idata$5"
 0x14000d24c ".idata$5"
 0x14000d24c "fthunk"
 0x14000d24c ".idata$5"
@@ -2231,7 +1956,6 @@ Symbol map
 0x14000d354 "__imp_vfprintf"
 0x14000d35c ".idata$5"
 0x14000d35c "__imp_wcslen"
-0x14000d364 ".idata$5"
 0x14000d36c ".idata$6"
 0x14000d36c "__IAT_end__"
 0x14000d384 ".idata$6"
@@ -2296,7 +2020,6 @@ Symbol map
 0x14000d65c ".idata$7"
 0x14000d660 ".idata$7"
 0x14000d664 ".idata$7"
-0x14000d668 ".idata$7"
 0x14000d668 "__lib64_libkernel32_a_iname"
 0x14000d678 ".idata$7"
 0x14000d67c ".idata$7"
@@ -2333,271 +2056,30 @@ Symbol map
 0x14000d6f8 ".idata$7"
 0x14000d6fc ".idata$7"
 0x14000d700 ".idata$7"
-0x14000d704 ".idata$7"
 0x14000d704 "__lib64_libmsvcrt_os_a_iname"
 0x14000e000 "___crt_xc_start__"
 0x14000e000 "__xc_a"
-0x14000e008 ".CRT$XCAA"
 0x14000e008 "__mingw_pcppinit"
-0x14000e010 ".CRT$XCZ"
 0x14000e010 "__xc_z"
-0x14000e018 ".CRT$XIA"
 0x14000e018 "___crt_xi_start__"
 0x14000e018 "___crt_xc_end__"
 0x14000e018 "__xi_a"
-0x14000e020 ".CRT$XIAA"
 0x14000e020 "__mingw_pcinit"
-0x14000e028 ".CRT$XIZ"
 0x14000e028 "__xi_z"
-0x14000e030 ".CRT$XLA"
 0x14000e030 "__xl_a"
 0x14000e030 "___crt_xl_start__"
 0x14000e030 "___crt_xi_end__"
-0x14000e038 ".CRT$XLC"
 0x14000e038 "__xl_c"
-0x14000e040 ".CRT$XLD"
 0x14000e040 "__xl_d"
-0x14000e048 ".CRT$XLZ"
 0x14000e048 "__xl_z"
 0x14000e050 "__xd_a"
-0x14000e050 ".CRT$XDA"
 0x14000e050 "___crt_xp_start__"
 0x14000e050 "___crt_xp_end__"
 0x14000e050 "___crt_xt_start__"
 0x14000e050 "___crt_xt_end__"
 0x14000e058 "__xd_z"
-0x14000e058 ".CRT$XDZ"
 0x14000f000 "___tls_start__"
 0x14000f000 "_tls_start"
-0x14000f008 ".tls$ZZZ"
 0x14000f008 "_tls_end"
 0x14000f010 "___tls_end__"
 0x140010000 ".rsrc"
-0x140012030 ".debug_aranges"
-0x140012060 ".debug_aranges"
-0x140012080 ".debug_aranges"
-0x1400120a0 ".debug_aranges"
-0x1400120d0 ".debug_aranges"
-0x1400120f0 ".debug_aranges"
-0x140012120 ".debug_aranges"
-0x140012140 ".debug_aranges"
-0x140012160 ".debug_aranges"
-0x140012190 ".debug_aranges"
-0x1400121c0 ".debug_aranges"
-0x1400121e0 ".debug_aranges"
-0x140012210 ".debug_aranges"
-0x140012240 ".debug_aranges"
-0x140012260 ".debug_aranges"
-0x140012290 ".debug_aranges"
-0x1400122c0 ".debug_aranges"
-0x1400122e0 ".debug_aranges"
-0x140012300 ".debug_aranges"
-0x140012330 ".debug_aranges"
-0x140012360 ".debug_aranges"
-0x140012380 ".debug_aranges"
-0x1400123a0 ".debug_aranges"
-0x1400123d0 ".debug_aranges"
-0x140012400 ".debug_aranges"
-0x140012430 ".debug_aranges"
-0x140012460 ".debug_aranges"
-0x140012490 ".debug_aranges"
-0x1400124c0 ".debug_aranges"
-0x1400124f0 ".debug_aranges"
-0x140012520 ".debug_aranges"
-0x140012550 ".debug_aranges"
-0x140012580 ".debug_aranges"
-0x1400125b0 ".debug_aranges"
-0x1400125e0 ".debug_aranges"
-0x140012610 ".debug_aranges"
-0x140012640 ".debug_aranges"
-0x140012670 ".debug_aranges"
-0x140015840 ".debug_info"
-0x140015e28 ".debug_info"
-0x1400163b1 ".debug_info"
-0x1400164a3 ".debug_info"
-0x140016672 ".debug_info"
-0x140016761 ".debug_info"
-0x140016e9f ".debug_info"
-0x140016f8e ".debug_info"
-0x140017176 ".debug_info"
-0x140017441 ".debug_info"
-0x14001753d ".debug_info"
-0x140017639 ".debug_info"
-0x1400188e2 ".debug_info"
-0x140018c41 ".debug_info"
-0x140018d2e ".debug_info"
-0x140019d16 ".debug_info"
-0x14001a6f2 ".debug_info"
-0x14001a7df ".debug_info"
-0x14001a921 ".debug_info"
-0x14001befa ".debug_info"
-0x14001bf28 ".debug_info"
-0x14001cd04 ".debug_info"
-0x14001ce0d ".debug_info"
-0x14001d181 ".debug_info"
-0x14001fd0b ".debug_info"
-0x1400202bb ".debug_info"
-0x140021426 ".debug_info"
-0x1400217f3 ".debug_info"
-0x1400232c8 ".debug_info"
-0x1400234a8 ".debug_info"
-0x14002369b ".debug_info"
-0x140023dbe ".debug_info"
-0x140024325 ".debug_info"
-0x1400245f9 ".debug_info"
-0x140024cc3 ".debug_info"
-0x140025714 ".debug_info"
-0x14002588a ".debug_info"
-0x1400259ef ".debug_info"
-0x14002653d ".debug_abbrev"
-0x140026670 ".debug_abbrev"
-0x140026722 ".debug_abbrev"
-0x140026750 ".debug_abbrev"
-0x14002678b ".debug_abbrev"
-0x1400267b9 ".debug_abbrev"
-0x140026978 ".debug_abbrev"
-0x1400269a6 ".debug_abbrev"
-0x140026a05 ".debug_abbrev"
-0x140026ae6 ".debug_abbrev"
-0x140026b14 ".debug_abbrev"
-0x140026b42 ".debug_abbrev"
-0x140026eaf ".debug_abbrev"
-0x140026fa9 ".debug_abbrev"
-0x140026fd7 ".debug_abbrev"
-0x140027252 ".debug_abbrev"
-0x140027456 ".debug_abbrev"
-0x140027484 ".debug_abbrev"
-0x1400274b2 ".debug_abbrev"
-0x140027708 ".debug_abbrev"
-0x14002771c ".debug_abbrev"
-0x1400277af ".debug_abbrev"
-0x1400277dd ".debug_abbrev"
-0x1400278d8 ".debug_abbrev"
-0x140027d55 ".debug_abbrev"
-0x140027ef0 ".debug_abbrev"
-0x14002818d ".debug_abbrev"
-0x1400282c8 ".debug_abbrev"
-0x140028702 ".debug_abbrev"
-0x140028783 ".debug_abbrev"
-0x140028818 ".debug_abbrev"
-0x140028991 ".debug_abbrev"
-0x140028adb ".debug_abbrev"
-0x140028ba9 ".debug_abbrev"
-0x140028d08 ".debug_abbrev"
-0x140028ecd ".debug_abbrev"
-0x140028f4f ".debug_abbrev"
-0x140028fc2 ".debug_abbrev"
-0x14002a61c ".debug_line"
-0x14002a7d7 ".debug_line"
-0x14002a8dc ".debug_line"
-0x14002a940 ".debug_line"
-0x14002a9bf ".debug_line"
-0x14002aa23 ".debug_line"
-0x14002abca ".debug_line"
-0x14002ac2e ".debug_line"
-0x14002ac92 ".debug_line"
-0x14002adad ".debug_line"
-0x14002ae2f ".debug_line"
-0x14002ae98 ".debug_line"
-0x14002b3da ".debug_line"
-0x14002b4f8 ".debug_line"
-0x14002b55c ".debug_line"
-0x14002b7b7 ".debug_line"
-0x14002badc ".debug_line"
-0x14002bb3f ".debug_line"
-0x14002bbac ".debug_line"
-0x14002c199 ".debug_line"
-0x14002c20b ".debug_line"
-0x14002c297 ".debug_line"
-0x14002c301 ".debug_line"
-0x14002c40d ".debug_line"
-0x14002e61f ".debug_line"
-0x14002ea0c ".debug_line"
-0x14002fbe8 ".debug_line"
-0x14002fe05 ".debug_line"
-0x140030e41 ".debug_line"
-0x140030f38 ".debug_line"
-0x14003104a ".debug_line"
-0x1400313a5 ".debug_line"
-0x140031614 ".debug_line"
-0x1400316f0 ".debug_line"
-0x14003186c ".debug_line"
-0x140031a91 ".debug_line"
-0x140031b18 ".debug_line"
-0x140031ba0 ".debug_line"
-0x1400321e8 ".debug_frame"
-0x140032290 ".debug_frame"
-0x1400322c0 ".debug_frame"
-0x1400323b0 ".debug_frame"
-0x140032428 ".debug_frame"
-0x140032458 ".debug_frame"
-0x1400325b8 ".debug_frame"
-0x140032610 ".debug_frame"
-0x140032698 ".debug_frame"
-0x140032858 ".debug_frame"
-0x1400329b0 ".debug_frame"
-0x140032a28 ".debug_frame"
-0x140033200 ".debug_frame"
-0x140033380 ".debug_frame"
-0x1400334a8 ".debug_frame"
-0x140033580 ".debug_frame"
-0x140033ba0 ".debug_frame"
-0x140033bd0 ".debug_frame"
-0x140033c00 ".debug_frame"
-0x140033e60 ".debug_frame"
-0x140033fb8 ".debug_frame"
-0x140034008 ".debug_frame"
-0x140034050 ".debug_frame"
-0x140034108 ".debug_frame"
-0x140034138 ".debug_frame"
-0x140034168 ".debug_frame"
-0x140035303 ".debug_str"
-0x14003531b ".debug_str"
-0x14003534e ".debug_str"
-0x14003535e ".debug_str"
-0x1400353ee ".debug_str"
-0x1400353ff ".debug_str"
-0x140035418 ".debug_str"
-0x140035494 ".debug_str"
-0x1400354e8 ".debug_str"
-0x140035572 ".debug_str"
-0x14003559a ".debug_str"
-0x14003561d ".debug_str"
-0x140035649 ".debug_str"
-0x14003570f ".debug_str"
-0x140035718 ".debug_str"
-0x140035788 ".debug_str"
-0x1400357f1 ".debug_str"
-0x140035838 ".debug_str"
-0x140035843 ".debug_str"
-0x140036563 ".debug_loc"
-0x1400365ec ".debug_loc"
-0x140036900 ".debug_loc"
-0x140036a0d ".debug_loc"
-0x1400375de ".debug_loc"
-0x140037715 ".debug_loc"
-0x140037a6b ".debug_loc"
-0x140038193 ".debug_loc"
-0x140038d74 ".debug_loc"
-0x140038eb9 ".debug_loc"
-0x14003dba7 ".debug_loc"
-0x14003e600 ".debug_loc"
-0x140043b37 ".debug_loc"
-0x140044095 ".debug_loc"
-0x140046dc4 ".debug_loc"
-0x140046dfe ".debug_loc"
-0x140046e7a ".debug_loc"
-0x1400478c9 ".debug_loc"
-0x140047f94 ".debug_loc"
-0x140047fe3 ".debug_loc"
-0x140048036 ".debug_loc"
-0x140049100 ".debug_ranges"
-0x140049400 ".debug_ranges"
-0x140049430 ".debug_ranges"
-0x140049760 ".debug_ranges"
-0x140049fb0 ".debug_ranges"
-0x14004a010 ".debug_ranges"
-0x14004a0b0 ".debug_ranges"
-0x14004a460 ".debug_ranges"
-0x14004a490 ".debug_ranges"
-0x14004a4c0 ".debug_ranges"

--- a/crates/examples/testfiles/pe/base-gnu.exe.readobj
+++ b/crates/examples/testfiles/pe/base-gnu.exe.readobj
@@ -521,6 +521,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 7
@@ -532,6 +542,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 9
@@ -543,6 +563,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 11
@@ -554,6 +584,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 13
@@ -565,6 +605,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 15
@@ -587,6 +637,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 18
@@ -598,6 +658,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 20
@@ -609,6 +679,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 22
@@ -631,6 +711,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 25
@@ -686,6 +776,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 31
@@ -708,6 +808,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 34
@@ -719,6 +829,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 36
@@ -741,6 +861,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 39
@@ -752,6 +882,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 41
@@ -763,6 +903,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 43
@@ -785,6 +935,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 46
@@ -796,6 +956,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 48
@@ -807,6 +977,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 50
@@ -818,6 +998,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 52
@@ -906,6 +1096,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 61
@@ -917,6 +1117,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 63
@@ -1033,6 +1243,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 75
@@ -1044,6 +1264,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 77
@@ -1223,6 +1453,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 95
@@ -1277,6 +1517,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x11
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 102
@@ -1288,6 +1538,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 104
@@ -1299,6 +1559,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 106
@@ -1310,6 +1580,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 108
@@ -1321,6 +1601,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 110
@@ -1332,6 +1622,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 112
@@ -1386,6 +1686,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x75
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 119
@@ -1397,6 +1707,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 121
@@ -1408,6 +1728,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 123
@@ -1419,6 +1749,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 125
@@ -1430,6 +1770,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 127
@@ -1462,6 +1812,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 131
@@ -1527,6 +1887,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 139
@@ -1560,6 +1930,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xCF
+        NumberOfRelocations: 7
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 143
@@ -1571,6 +1951,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 145
@@ -1582,6 +1972,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 147
@@ -1593,6 +1993,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 149
@@ -1604,6 +2014,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x24
+        NumberOfRelocations: 9
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 151
@@ -1615,6 +2035,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xA8
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 153
@@ -1626,6 +2056,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5E8
+        NumberOfRelocations: 15
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 155
@@ -1637,6 +2077,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x133
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 157
@@ -1648,6 +2098,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x89
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 159
@@ -1659,6 +2119,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 161
@@ -1670,6 +2140,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1BB
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 163
@@ -1681,6 +2161,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 165
@@ -1706,6 +2196,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 169
@@ -1717,6 +2217,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 171
@@ -1728,6 +2238,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 173
@@ -1739,6 +2259,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x589
+        NumberOfRelocations: 8
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 175
@@ -1750,6 +2280,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB2
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 177
@@ -1761,6 +2301,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 179
@@ -1772,6 +2322,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x105
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 181
@@ -1783,6 +2343,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 183
@@ -1794,6 +2364,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 185
@@ -1819,6 +2399,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 189
@@ -1830,6 +2420,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 191
@@ -1841,6 +2441,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 193
@@ -1852,6 +2462,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xF2
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 195
@@ -1863,6 +2483,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 197
@@ -1874,6 +2504,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 199
@@ -1885,6 +2525,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x64
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 201
@@ -1896,6 +2546,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 203
@@ -1939,6 +2599,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 209
@@ -1950,6 +2620,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 211
@@ -1961,6 +2641,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 213
@@ -1972,6 +2662,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 215
@@ -1983,6 +2683,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 217
@@ -1994,6 +2704,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 219
@@ -2005,6 +2725,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1CF
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 221
@@ -2016,6 +2746,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 223
@@ -2027,6 +2767,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 225
@@ -2038,6 +2788,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x7F
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 227
@@ -2049,6 +2809,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 229
@@ -2074,6 +2844,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 233
@@ -2085,6 +2865,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 235
@@ -2096,6 +2886,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 237
@@ -2107,6 +2907,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xEF
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 239
@@ -2118,6 +2928,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 241
@@ -2129,6 +2949,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 243
@@ -2140,6 +2970,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x64
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 245
@@ -2151,6 +2991,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 247
@@ -2205,6 +3055,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 254
@@ -2249,6 +3109,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC3
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 259
@@ -2260,6 +3130,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 261
@@ -2271,6 +3151,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 263
@@ -2282,6 +3172,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 265
@@ -2293,6 +3193,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x24
+        NumberOfRelocations: 9
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 267
@@ -2304,6 +3214,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 269
@@ -2315,6 +3235,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 271
@@ -2326,6 +3256,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x48
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 273
@@ -2337,6 +3277,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 275
@@ -2348,6 +3298,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 277
@@ -2359,6 +3319,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 279
@@ -2370,6 +3340,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 281
@@ -2381,6 +3361,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 283
@@ -2413,6 +3403,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xF0
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 287
@@ -2424,6 +3424,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x73E
+        NumberOfRelocations: 54
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 289
@@ -2435,6 +3445,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1BF
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 291
@@ -2446,6 +3466,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x314
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 293
@@ -2457,6 +3487,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 295
@@ -2468,6 +3508,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1A7
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 297
@@ -2479,6 +3529,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x33
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 299
@@ -2490,6 +3550,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 301
@@ -2515,6 +3585,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 305
@@ -2526,6 +3606,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 307
@@ -2537,6 +3627,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 309
@@ -2548,6 +3648,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xEF
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 311
@@ -2559,6 +3669,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 313
@@ -2570,6 +3690,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 315
@@ -2581,6 +3711,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x64
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 317
@@ -2592,6 +3732,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 319
@@ -2617,6 +3767,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 323
@@ -2628,6 +3788,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 325
@@ -2639,6 +3809,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 327
@@ -2650,6 +3830,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 329
@@ -2682,6 +3872,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 333
@@ -2693,6 +3893,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 335
@@ -2704,6 +3914,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1E8
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 337
@@ -2715,6 +3935,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5F
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 339
@@ -2726,6 +3956,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 341
@@ -2737,6 +3977,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x64
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 343
@@ -2748,6 +3998,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 345
@@ -2791,6 +4051,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xF8
+        NumberOfRelocations: 11
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 351
@@ -2802,6 +4072,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 353
@@ -2813,6 +4093,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 355
@@ -2824,6 +4114,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x140
+        NumberOfRelocations: 7
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 357
@@ -2835,6 +4135,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 359
@@ -2846,6 +4156,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 361
@@ -2857,6 +4177,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x78
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 363
@@ -2868,6 +4198,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2CB
+        NumberOfRelocations: 13
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 365
@@ -2879,6 +4219,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xE1
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 367
@@ -2890,6 +4240,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10D
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 369
@@ -2901,6 +4261,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 371
@@ -2912,6 +4282,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x11B
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 373
@@ -2923,6 +4303,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 375
@@ -2934,6 +4324,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 377
@@ -2988,6 +4388,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 384
@@ -2999,6 +4409,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 386
@@ -3010,6 +4430,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 388
@@ -3021,6 +4451,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 390
@@ -3032,6 +4472,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 392
@@ -3043,6 +4493,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 394
@@ -3054,6 +4514,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xFC
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 396
@@ -3065,6 +4535,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 398
@@ -3076,6 +4556,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 400
@@ -3087,6 +4577,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x82
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 402
@@ -3098,6 +4598,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 404
@@ -3123,6 +4633,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 408
@@ -3134,6 +4654,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 410
@@ -3145,6 +4675,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 412
@@ -3156,6 +4696,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xFC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 414
@@ -3167,6 +4717,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 416
@@ -3178,6 +4738,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 418
@@ -3189,6 +4759,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x69
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 420
@@ -3200,6 +4780,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 422
@@ -3298,6 +4888,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 433
@@ -3309,6 +4909,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 435
@@ -3320,6 +4930,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x45E
+        NumberOfRelocations: 37
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 437
@@ -3331,6 +4951,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 439
@@ -3342,6 +4972,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 441
@@ -3353,6 +4993,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x102
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 443
@@ -3364,6 +5014,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 445
@@ -3375,6 +5035,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x24
+        NumberOfRelocations: 9
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 447
@@ -3386,6 +5056,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x160
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 449
@@ -3397,6 +5077,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x12A9
+        NumberOfRelocations: 170
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 451
@@ -3408,6 +5098,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x36D
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 453
@@ -3419,6 +5119,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xBD1
+        NumberOfRelocations: 10
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 455
@@ -3430,6 +5140,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 457
@@ -3441,6 +5161,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x300
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 459
@@ -3452,6 +5182,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x542
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 461
@@ -3463,6 +5203,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x90
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 463
@@ -3474,6 +5224,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 465
@@ -3539,6 +5299,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5C
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 473
@@ -3550,6 +5320,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 475
@@ -3561,6 +5341,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 477
@@ -3572,6 +5362,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 479
@@ -3583,6 +5383,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 481
@@ -3594,6 +5404,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x58
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 483
@@ -3605,6 +5425,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x35F
+        NumberOfRelocations: 20
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 485
@@ -3616,6 +5446,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xFA
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 487
@@ -3627,6 +5467,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x137
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 489
@@ -3638,6 +5488,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 491
@@ -3649,6 +5509,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x11E
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 493
@@ -3660,6 +5530,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x11
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 495
@@ -3671,6 +5551,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 497
@@ -3696,6 +5586,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 501
@@ -3707,6 +5607,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 503
@@ -3718,6 +5628,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 505
@@ -3729,6 +5649,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xED
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 507
@@ -3740,6 +5670,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 509
@@ -3751,6 +5691,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 511
@@ -3762,6 +5712,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x64
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 513
@@ -3773,6 +5733,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 515
@@ -3816,6 +5786,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1BA
+        NumberOfRelocations: 11
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 521
@@ -3827,6 +5807,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 523
@@ -3838,6 +5828,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 525
@@ -3849,6 +5849,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 527
@@ -3860,6 +5870,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x28
+        NumberOfRelocations: 10
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 529
@@ -3871,6 +5891,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 531
@@ -3882,6 +5912,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x88
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 533
@@ -3893,6 +5933,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xFE8
+        NumberOfRelocations: 30
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 535
@@ -3904,6 +5954,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x27B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 537
@@ -3915,6 +5975,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x356
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 539
@@ -3926,6 +5996,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 541
@@ -3937,6 +6017,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x25B
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 543
@@ -3948,6 +6038,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x19
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 545
@@ -3959,6 +6059,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 547
@@ -4068,6 +6178,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x262
+        NumberOfRelocations: 37
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 559
@@ -4079,6 +6199,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 561
@@ -4090,6 +6220,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x48
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 563
@@ -4101,6 +6241,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 565
@@ -4112,6 +6262,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 12
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 567
@@ -4123,6 +6283,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1C0
+        NumberOfRelocations: 8
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 569
@@ -4134,6 +6304,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x9DC
+        NumberOfRelocations: 82
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 571
@@ -4145,6 +6325,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x204
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 573
@@ -4156,6 +6346,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x728
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 575
@@ -4167,6 +6367,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 577
@@ -4178,6 +6388,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 579
@@ -4189,6 +6409,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x325
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 581
@@ -4200,6 +6430,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x7C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 583
@@ -4211,6 +6451,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 585
@@ -4236,6 +6486,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 589
@@ -4247,6 +6507,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 591
@@ -4258,6 +6528,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 593
@@ -4269,6 +6549,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xED
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 595
@@ -4280,6 +6570,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 597
@@ -4291,6 +6591,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 599
@@ -4302,6 +6612,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x63
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 601
@@ -4313,6 +6633,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 603
@@ -4338,6 +6668,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 607
@@ -4349,6 +6689,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 609
@@ -4360,6 +6710,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 611
@@ -4371,6 +6731,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x142
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 613
@@ -4382,6 +6752,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 615
@@ -4393,6 +6773,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 617
@@ -4404,6 +6794,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x6D
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 619
@@ -4415,6 +6815,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 621
@@ -4546,6 +6956,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3DE
+        NumberOfRelocations: 9
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 635
@@ -4557,6 +6977,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 637
@@ -4568,6 +6998,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 639
@@ -4579,6 +7019,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 641
@@ -4590,6 +7040,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x6C
+        NumberOfRelocations: 27
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 643
@@ -4601,6 +7061,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x158
+        NumberOfRelocations: 18
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 645
@@ -4612,6 +7082,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x15D9
+        NumberOfRelocations: 203
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 647
@@ -4623,6 +7103,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x256
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 649
@@ -4634,6 +7124,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xBE1
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 651
@@ -4645,6 +7145,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 653
@@ -4656,6 +7166,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x330
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 655
@@ -4667,6 +7187,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5ED
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 657
@@ -4678,6 +7208,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x54
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 659
@@ -4689,6 +7229,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 661
@@ -4714,6 +7264,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 7
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 665
@@ -4725,6 +7285,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x14
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 667
@@ -4736,6 +7306,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x72
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 669
@@ -4747,6 +7327,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x32
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 671
@@ -4758,6 +7348,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 673
@@ -4769,6 +7369,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 675
@@ -4780,6 +7390,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 677
@@ -4791,6 +7411,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8A
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 679
@@ -4816,6 +7446,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 683
@@ -4827,6 +7467,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 685
@@ -4838,6 +7488,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 687
@@ -4849,6 +7509,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xDDC
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 689
@@ -4860,6 +7530,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x93
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 691
@@ -4871,6 +7551,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 693
@@ -4882,6 +7572,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 695
@@ -4893,6 +7593,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 697
@@ -4918,6 +7628,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 701
@@ -4929,6 +7649,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 703
@@ -4940,6 +7670,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 705
@@ -4951,6 +7691,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x109
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 707
@@ -4962,6 +7712,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2E
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 709
@@ -4973,6 +7733,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x20
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 711
@@ -4984,6 +7754,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x6A
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 713
@@ -4995,6 +7775,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 715
@@ -5038,6 +7828,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x47
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 721
@@ -5049,6 +7849,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 723
@@ -5060,6 +7870,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 725
@@ -5071,6 +7891,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 727
@@ -5082,6 +7912,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 729
@@ -5093,6 +7933,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x78
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 731
@@ -5104,6 +7954,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x374
+        NumberOfRelocations: 21
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 733
@@ -5115,6 +7975,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xFB
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 735
@@ -5126,6 +7996,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x145
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 737
@@ -5137,6 +8017,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 739
@@ -5148,6 +8038,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10C
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 741
@@ -5159,6 +8059,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x28
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 743
@@ -5170,6 +8080,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 745
@@ -5389,6 +8309,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x25DF
+        NumberOfRelocations: 47
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 767
@@ -5400,6 +8330,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 769
@@ -5411,6 +8351,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 771
@@ -5422,6 +8372,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xF4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 773
@@ -5433,6 +8393,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC0
+        NumberOfRelocations: 48
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 775
@@ -5444,6 +8414,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18C
+        NumberOfRelocations: 91
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 777
@@ -5455,6 +8435,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x7D8
+        NumberOfRelocations: 32
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 779
@@ -5466,6 +8456,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B8A
+        NumberOfRelocations: 508
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 781
@@ -5477,6 +8477,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x47D
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 783
@@ -5488,6 +8498,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4CEE
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 785
@@ -5499,6 +8519,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 787
@@ -5510,6 +8540,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x850
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 789
@@ -5521,6 +8561,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2212
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 791
@@ -5532,6 +8582,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x83
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 793
@@ -5543,6 +8603,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 795
@@ -5619,6 +8689,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x256
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 804
@@ -5630,6 +8710,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 806
@@ -5641,6 +8731,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 808
@@ -5652,6 +8752,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 810
@@ -5663,6 +8773,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 12
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 812
@@ -5674,6 +8794,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x180
+        NumberOfRelocations: 8
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 814
@@ -5685,6 +8815,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5B0
+        NumberOfRelocations: 77
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 816
@@ -5696,6 +8836,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x19B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 818
@@ -5707,6 +8857,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xA59
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 820
@@ -5718,6 +8878,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 822
@@ -5729,6 +8899,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x60
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 824
@@ -5740,6 +8920,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3ED
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 826
@@ -5751,6 +8941,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 828
@@ -5762,6 +8962,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 830
@@ -5805,6 +9015,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 836
@@ -5816,6 +9036,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1707
+        NumberOfRelocations: 81
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 838
@@ -5827,6 +9057,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 840
@@ -5838,6 +9078,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 842
@@ -5849,6 +9099,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x88
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 844
@@ -5860,6 +9120,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 846
@@ -5871,6 +9141,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 848
@@ -5882,6 +9162,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x128
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 850
@@ -5893,6 +9183,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x116B
+        NumberOfRelocations: 221
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 852
@@ -5904,6 +9204,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x29D
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 854
@@ -5915,6 +9225,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5537
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 856
@@ -5926,6 +9246,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 858
@@ -5937,6 +9267,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xA0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 860
@@ -5948,6 +9288,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x11DC
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 862
@@ -5959,6 +9309,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC6
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 864
@@ -5970,6 +9330,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 866
@@ -6024,6 +9394,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x143
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 873
@@ -6035,6 +9415,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 875
@@ -6046,6 +9436,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 877
@@ -6057,6 +9457,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x14
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 879
@@ -6068,6 +9478,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 881
@@ -6079,6 +9499,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xD8
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 883
@@ -6090,6 +9520,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3CD
+        NumberOfRelocations: 37
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 885
@@ -6101,6 +9541,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x13B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 887
@@ -6112,6 +9562,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x55E
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 889
@@ -6123,6 +9583,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 891
@@ -6134,6 +9604,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x21D
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 893
@@ -6145,6 +9625,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x9
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 895
@@ -6156,6 +9646,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 897
@@ -6419,6 +9919,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xCFA
+        NumberOfRelocations: 59
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 923
@@ -6430,6 +9940,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 925
@@ -6441,6 +9961,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x9D0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 927
@@ -6452,6 +9982,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xAC
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 929
@@ -6463,6 +10003,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xA8
+        NumberOfRelocations: 42
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 931
@@ -6474,6 +10024,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x148
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 933
@@ -6485,6 +10045,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x620
+        NumberOfRelocations: 28
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 935
@@ -6496,6 +10066,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1AD5
+        NumberOfRelocations: 393
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 937
@@ -6507,6 +10087,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x43A
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 939
@@ -6518,6 +10108,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2D2F
+        NumberOfRelocations: 7
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 941
@@ -6529,6 +10129,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 943
@@ -6540,6 +10150,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3B0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 945
@@ -6551,6 +10171,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x103C
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 947
@@ -6562,6 +10192,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x70
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 949
@@ -6573,6 +10213,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 951
@@ -6616,6 +10266,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x28
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 957
@@ -6627,6 +10287,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 959
@@ -6638,6 +10308,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 961
@@ -6649,6 +10329,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 963
@@ -6660,6 +10350,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 965
@@ -6671,6 +10371,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 967
@@ -6682,6 +10392,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1E0
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 969
@@ -6693,6 +10413,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x81
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 971
@@ -6704,6 +10434,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3A
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 973
@@ -6715,6 +10455,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 975
@@ -6726,6 +10476,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xF7
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 977
@@ -6737,6 +10497,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 979
@@ -6780,6 +10550,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x27
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 985
@@ -6791,6 +10571,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 987
@@ -6802,6 +10592,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 989
@@ -6813,6 +10613,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 991
@@ -6824,6 +10634,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 993
@@ -6835,6 +10655,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 995
@@ -6846,6 +10676,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1F3
+        NumberOfRelocations: 8
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 997
@@ -6857,6 +10697,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x95
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 999
@@ -6868,6 +10718,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x7C
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1001
@@ -6879,6 +10739,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1003
@@ -6890,6 +10760,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x112
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1005
@@ -6901,6 +10781,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1007
@@ -9089,6 +12979,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x35A
+        NumberOfRelocations: 13
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1208
@@ -9100,6 +13000,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1210
@@ -9111,6 +13021,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1212
@@ -9122,6 +13042,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x40
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1214
@@ -9133,6 +13063,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 12
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1216
@@ -9144,6 +13084,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x260
+        NumberOfRelocations: 8
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1218
@@ -9155,6 +13105,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x723
+        NumberOfRelocations: 85
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1220
@@ -9166,6 +13126,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x179
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1222
@@ -9177,6 +13147,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xA4F
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1224
@@ -9188,6 +13168,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1226
@@ -9199,6 +13189,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1228
@@ -9210,6 +13210,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x35B
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1230
@@ -9221,6 +13231,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x69
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1232
@@ -9232,6 +13252,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1234
@@ -9297,6 +13327,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1D6
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1242
@@ -9308,6 +13348,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1244
@@ -9319,6 +13369,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1246
@@ -9330,6 +13390,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x28
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1248
@@ -9341,6 +13411,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x24
+        NumberOfRelocations: 9
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1250
@@ -9352,6 +13432,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x158
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1252
@@ -9363,6 +13453,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x567
+        NumberOfRelocations: 61
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1254
@@ -9374,6 +13474,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x14A
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1256
@@ -9385,6 +13495,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x6CB
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1258
@@ -9396,6 +13516,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1260
@@ -9407,6 +13537,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1262
@@ -9418,6 +13558,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x26F
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1264
@@ -9429,6 +13579,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x47
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1266
@@ -9440,6 +13600,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1268
@@ -9483,6 +13653,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1F
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1274
@@ -9494,6 +13674,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1276
@@ -9505,6 +13695,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1278
@@ -9516,6 +13716,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1280
@@ -9527,6 +13737,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1282
@@ -9538,6 +13758,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x50
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1284
@@ -9549,6 +13779,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2D4
+        NumberOfRelocations: 10
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1286
@@ -9560,6 +13800,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xCE
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1288
@@ -9571,6 +13821,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4F
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1290
@@ -9582,6 +13842,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1292
@@ -9593,6 +13863,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xDC
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1294
@@ -9604,6 +13884,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1296
@@ -9615,6 +13905,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1298
@@ -9702,6 +14002,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1B
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1308
@@ -9713,6 +14023,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1310
@@ -9724,6 +14044,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1312
@@ -9735,6 +14065,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1314
@@ -9746,6 +14086,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1316
@@ -9757,6 +14107,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x48
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1318
@@ -9768,6 +14128,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x6CA
+        NumberOfRelocations: 14
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1320
@@ -9779,6 +14149,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x15F
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1322
@@ -9790,6 +14170,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x53
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1324
@@ -9801,6 +14191,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1326
@@ -9812,6 +14212,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x17C
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1328
@@ -9823,6 +14233,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1330
@@ -9877,6 +14297,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xD0
+        NumberOfRelocations: 10
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1337
@@ -9888,6 +14318,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1339
@@ -9899,6 +14339,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1341
@@ -9910,6 +14360,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x10
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1343
@@ -9921,6 +14381,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x18
+        NumberOfRelocations: 6
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1345
@@ -9932,6 +14402,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB8
+        NumberOfRelocations: 4
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1347
@@ -9943,6 +14423,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xA51
+        NumberOfRelocations: 35
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1349
@@ -9954,6 +14444,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1C5
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1351
@@ -9965,6 +14465,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x1A6
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1353
@@ -9976,6 +14486,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1355
@@ -9987,6 +14507,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1357
@@ -9998,6 +14528,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x225
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1359
@@ -10009,6 +14549,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x3A
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1361
@@ -10020,6 +14570,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1363
@@ -10063,6 +14623,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1369
@@ -10074,6 +14644,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1371
@@ -10085,6 +14665,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1373
@@ -10096,6 +14686,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1375
@@ -10107,6 +14707,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1377
@@ -10118,6 +14728,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1379
@@ -10129,6 +14749,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1381
@@ -10140,6 +14770,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x176
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1383
@@ -10151,6 +14791,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x82
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1385
@@ -10162,6 +14812,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1387
@@ -10173,6 +14833,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x87
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1389
@@ -10184,6 +14854,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1391
@@ -10227,6 +14907,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1397
@@ -10238,6 +14928,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1399
@@ -10249,6 +14949,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1401
@@ -10260,6 +14970,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1403
@@ -10271,6 +14991,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1405
@@ -10282,6 +15012,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1407
@@ -10293,6 +15033,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1409
@@ -10304,6 +15054,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x165
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1411
@@ -10315,6 +15075,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x73
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1413
@@ -10326,6 +15096,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1415
@@ -10337,6 +15117,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x88
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1417
@@ -10348,6 +15138,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1419
@@ -10391,6 +15191,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: IMAGE_COMDAT_SELECT_ANY (0x2)
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1425
@@ -10402,6 +15212,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1427
@@ -10413,6 +15233,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1429
@@ -10424,6 +15254,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1431
@@ -10435,6 +15275,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1433
@@ -10446,6 +15296,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1435
@@ -10457,6 +15317,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1437
@@ -10468,6 +15338,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x15D
+        NumberOfRelocations: 5
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1439
@@ -10479,6 +15359,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x73
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1441
@@ -10490,6 +15380,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x30
+        NumberOfRelocations: 2
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1443
@@ -10501,6 +15401,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x86
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1445
@@ -10512,6 +15422,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1447
@@ -10559,6 +15479,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1453
@@ -10570,6 +15500,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1455
@@ -10581,6 +15521,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1457
@@ -10592,6 +15542,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x14
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1459
@@ -11101,6 +16061,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1507
@@ -11112,6 +16082,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1509
@@ -11123,6 +16103,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1511
@@ -11134,6 +16124,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1513
@@ -11145,6 +16145,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1515
@@ -11156,6 +16166,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xB
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1517
@@ -12281,6 +17301,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1621
@@ -12292,6 +17322,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1623
@@ -12303,6 +17343,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1625
@@ -12371,6 +17421,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1633
@@ -12382,6 +17442,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1635
@@ -12393,6 +17463,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1637
@@ -12404,6 +17484,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1639
@@ -12415,6 +17505,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1641
@@ -12426,6 +17526,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xD
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1643
@@ -12623,6 +17733,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1663
@@ -12634,6 +17754,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1665
@@ -12645,6 +17775,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x0
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1667
@@ -12656,6 +17796,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x5
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1669
@@ -12667,6 +17817,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x4
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1671
@@ -12678,6 +17838,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0xC
+        NumberOfRelocations: 3
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1673
@@ -12689,6 +17859,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x8
+        NumberOfRelocations: 1
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1675
@@ -12700,6 +17880,16 @@ ImageSymbol {
     DerivedType: IMAGE_SYM_DTYPE_NULL (0x0)
     StorageClass: IMAGE_SYM_CLASS_STATIC (0x3)
     NumberOfAuxSymbols: 0x1
+    ImageAuxSymbolSection {
+        Length: 0x2B
+        NumberOfRelocations: 0
+        NumberOfLinenumbers: 0
+        CheckSum: 0x0
+        Number: 0
+        Selection: 0x0
+        Reserved: 0x0
+        HighNumber: 0
+    }
 }
 ImageSymbol {
     Index: 1677

--- a/crates/examples/testfiles/pe/base.o.objdump
+++ b/crates/examples/testfiles/pe/base.o.objdump
@@ -21,7 +21,7 @@ Segment { name: ".rdata$zzz", address: 0, size: 0 }
 
 Symbols
 0: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
-2: Symbol { name: "printf", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
+2: Symbol { name: "printf", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: None }
 4: Symbol { name: "main", address: 51, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Linkage, weak: false, flags: None }
 5: Symbol { name: ".text", address: 0, size: 75, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
 7: Symbol { name: ".data", address: 0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: CoffSection { selection: 0, associative_section: None } }
@@ -51,4 +51,5 @@ Symbols
 Dynamic symbols
 
 Symbol map
+0x0 "printf"
 0x51 "main"

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -384,7 +384,7 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> ObjectSymbol<'data>
         };
         match self.symbol.storage_class() {
             pe::IMAGE_SYM_CLASS_STATIC => {
-                if self.symbol.value() == 0 && self.symbol.number_of_aux_symbols() > 0 {
+                if self.symbol.has_aux_section() {
                     SymbolKind::Section
                 } else {
                     derived_kind
@@ -547,10 +547,7 @@ pub trait ImageSymbol: Debug + Pod {
             return false;
         }
         match self.storage_class() {
-            pe::IMAGE_SYM_CLASS_STATIC => {
-                // Exclude section symbols.
-                !(self.value() == 0 && self.number_of_aux_symbols() > 0)
-            }
+            pe::IMAGE_SYM_CLASS_STATIC => !self.has_aux_section(),
             pe::IMAGE_SYM_CLASS_EXTERNAL | pe::IMAGE_SYM_CLASS_WEAK_EXTERNAL => true,
             _ => false,
         }
@@ -570,7 +567,7 @@ pub trait ImageSymbol: Debug + Pod {
     fn has_aux_section(&self) -> bool {
         self.number_of_aux_symbols() > 0
             && self.storage_class() == pe::IMAGE_SYM_CLASS_STATIC
-            && self.value() == 0
+            && self.typ() == 0
     }
 
     fn base_type(&self) -> u16 {


### PR DESCRIPTION
Previously we wrongly excluded section symbols with non-zero values, and wrongly included function symbols with zero values.

This also means that we give them correct symbol kind, and that we exclude them from the symbol map.

Note that we still don't give the correct symbol kind to section symbols that don't have an auxiliary symbol.