### PR TITLE
ci: update actions/checkout in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
             os: "macOS-latest"
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install rust channel
@@ -34,7 +34,7 @@ jobs:
   features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: cargo build --no-default-features --features read
@@ -57,7 +57,7 @@ jobs:
           - "powerpc64-unknown-linux-gnu"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install rust
@@ -71,7 +71,7 @@ jobs:
   msrv-read:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install rust
@@ -85,7 +85,7 @@ jobs:
   msrv-all:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install rust
@@ -96,7 +96,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install rust
         run: |
           rustup install stable
@@ -110,7 +110,7 @@ jobs:
       image: xd009642/tarpaulin
       options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install rust
@@ -128,7 +128,7 @@ jobs:
   doc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cargo rustdoc --no-default-features --features doc
         env:
           RUSTDOCFLAGS: "-D warnings"


### PR DESCRIPTION
Update [`actions/checkout`](https://github.com/actions/checkout) to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20