### PR TITLE
Avoid using reexports within the crate

### DIFF
--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -2,6 +2,7 @@ use alloc::fmt;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
+use crate::endian::{Endian, Endianness};
 #[cfg(feature = "coff")]
 use crate::read::coff;
 #[cfg(feature = "elf")]
@@ -18,11 +19,9 @@ use crate::read::{
     self, Architecture, BinaryFormat, CodeView, ComdatKind, CompressedData, CompressedFileRange,
     Error, Export, FileFlags, FileKind, Import, Object, ObjectComdat, ObjectKind, ObjectMap,
     ObjectSection, ObjectSegment, ObjectSymbol, ObjectSymbolTable, ReadRef, Relocation, Result,
-    SectionFlags, SectionIndex, SectionKind, SegmentFlags, SymbolFlags, SymbolIndex, SymbolKind,
-    SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
+    SectionFlags, SectionIndex, SectionKind, SegmentFlags, SubArchitecture, SymbolFlags,
+    SymbolIndex, SymbolKind, SymbolMap, SymbolMapName, SymbolScope, SymbolSection,
 };
-#[allow(unused_imports)]
-use crate::{AddressSize, Endian, Endianness, SubArchitecture};
 
 /// Evaluate an expression on the contents of a file format enum.
 ///
@@ -272,10 +271,10 @@ impl<'data, R: ReadRef<'data>> File<'data, R> {
         image: &macho::DyldCacheImage<'data, 'cache, E, R>,
     ) -> Result<Self> {
         Ok(match image.cache.architecture().address_size() {
-            Some(AddressSize::U64) => {
+            Some(read::AddressSize::U64) => {
                 File::MachO64(macho::MachOFile64::parse_dyld_cache_image(image)?)
             }
-            Some(AddressSize::U32) => {
+            Some(read::AddressSize::U32) => {
                 File::MachO32(macho::MachOFile32::parse_dyld_cache_image(image)?)
             }
             _ => return Err(Error("Unsupported file format")),

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -1,11 +1,13 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
+use crate::endian::LittleEndian as LE;
+use crate::pe;
+use crate::pod::Pod;
 use crate::read::{
     self, Architecture, Export, FileFlags, Import, NoDynamicRelocationIterator, Object, ObjectKind,
     ObjectSection, ReadError, ReadRef, Result, SectionIndex, SubArchitecture, SymbolIndex,
 };
-use crate::{pe, LittleEndian as LE, Pod};
 
 use super::{
     CoffComdat, CoffComdatIterator, CoffSection, CoffSectionIterator, CoffSegment,

--- a/src/read/coff/import.rs
+++ b/src/read/coff/import.rs
@@ -3,8 +3,11 @@
 //! These are used by some Windows linkers as a more compact way to describe
 //! dynamically imported symbols.
 
-use crate::read::{Architecture, Error, ReadError, ReadRef, Result};
-use crate::{pe, ByteString, Bytes, LittleEndian as LE, SubArchitecture};
+use crate::endian::LittleEndian as LE;
+use crate::pe;
+use crate::read::{
+    Architecture, ByteString, Bytes, Error, ReadError, ReadRef, Result, SubArchitecture,
+};
 
 /// A Windows short form description of a symbol to import.
 ///

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -3,11 +3,13 @@ use core::convert::TryInto;
 use core::fmt::Debug;
 use core::mem;
 
+use crate::elf;
+use crate::endian::{self, Endian, Endianness, U32};
+use crate::pod::Pod;
 use crate::read::{
     self, util, Architecture, ByteString, Bytes, Error, Export, FileFlags, Import, Object,
     ObjectKind, ReadError, ReadRef, SectionIndex, StringTable, SymbolIndex,
 };
-use crate::{elf, endian, Endian, Endianness, Pod, U32};
 
 use super::{
     CompressionHeader, Dyn, ElfComdat, ElfComdatIterator, ElfDynamicRelocationIterator, ElfSection,

--- a/src/read/elf/hash.rs
+++ b/src/read/elf/hash.rs
@@ -1,8 +1,8 @@
 use core::mem;
 
 use crate::elf;
+use crate::endian::{U32, U64};
 use crate::read::{ReadError, ReadRef, Result};
-use crate::{U32, U64};
 
 use super::{FileHeader, Sym, SymbolTable, Version, VersionTable};
 

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -4,14 +4,14 @@ use core::fmt::Debug;
 use core::slice;
 use core::str;
 
-use crate::endian::{self, Endianness};
+use crate::elf;
+use crate::endian::{self, Endianness, U32};
 use crate::pod::Pod;
 use crate::read::util::StringTable;
 use crate::read::{
     self, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, SectionIndex, SymbolFlags,
     SymbolIndex, SymbolKind, SymbolMap, SymbolMapEntry, SymbolScope, SymbolSection,
 };
-use crate::{elf, U32};
 
 use super::{FileHeader, SectionHeader, SectionTable};
 

--- a/src/read/macho/dyld_cache.rs
+++ b/src/read/macho/dyld_cache.rs
@@ -1,8 +1,9 @@
 use alloc::vec::Vec;
 use core::slice;
 
-use crate::read::{Error, File, ReadError, ReadRef, Result};
-use crate::{macho, Architecture, Endian, Endianness};
+use crate::endian::{Endian, Endianness};
+use crate::macho;
+use crate::read::{Architecture, Error, File, ReadError, ReadRef, Result};
 
 /// A parsed representation of the dyld shared cache.
 #[derive(Debug)]

--- a/src/read/macho/fat.rs
+++ b/src/read/macho/fat.rs
@@ -1,5 +1,7 @@
+use crate::endian::BigEndian;
+use crate::macho;
+use crate::pod::Pod;
 use crate::read::{Architecture, Error, ReadError, ReadRef, Result};
-use crate::{macho, BigEndian, Pod};
 
 pub use macho::{FatArch32, FatArch64, FatHeader};
 

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -2,12 +2,14 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::{mem, str};
 
+use crate::endian::{self, BigEndian, Endian, Endianness};
+use crate::macho;
+use crate::pod::Pod;
 use crate::read::{
-    self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
-    Object, ObjectComdat, ObjectKind, ObjectMap, ObjectSection, ReadError, ReadRef, Result,
-    SectionIndex, SubArchitecture, SymbolIndex,
+    self, Architecture, ByteString, ComdatKind, Error, Export, FileFlags, Import,
+    NoDynamicRelocationIterator, Object, ObjectComdat, ObjectKind, ObjectMap, ObjectSection,
+    ReadError, ReadRef, Result, SectionIndex, SubArchitecture, SymbolIndex,
 };
-use crate::{endian, macho, BigEndian, ByteString, Endian, Endianness, Pod};
 
 use super::{
     DyldCacheImage, LoadCommandIterator, MachOSection, MachOSectionInternal, MachOSectionIterator,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -45,7 +45,7 @@ use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::{fmt, result};
 
-use crate::common::*;
+pub use crate::common::*;
 
 mod read_ref;
 pub use read_ref::*;
@@ -151,7 +151,7 @@ impl<T> ReadError<T> for Option<T> {
     target_pointer_width = "32",
     feature = "elf"
 ))]
-pub type NativeFile<'data, R = &'data [u8]> = elf::ElfFile32<'data, crate::Endianness, R>;
+pub type NativeFile<'data, R = &'data [u8]> = elf::ElfFile32<'data, crate::endian::Endianness, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(
@@ -160,15 +160,17 @@ pub type NativeFile<'data, R = &'data [u8]> = elf::ElfFile32<'data, crate::Endia
     target_pointer_width = "64",
     feature = "elf"
 ))]
-pub type NativeFile<'data, R = &'data [u8]> = elf::ElfFile64<'data, crate::Endianness, R>;
+pub type NativeFile<'data, R = &'data [u8]> = elf::ElfFile64<'data, crate::endian::Endianness, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "macos", target_pointer_width = "32", feature = "macho"))]
-pub type NativeFile<'data, R = &'data [u8]> = macho::MachOFile32<'data, crate::Endianness, R>;
+pub type NativeFile<'data, R = &'data [u8]> =
+    macho::MachOFile32<'data, crate::endian::Endianness, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "macos", target_pointer_width = "64", feature = "macho"))]
-pub type NativeFile<'data, R = &'data [u8]> = macho::MachOFile64<'data, crate::Endianness, R>;
+pub type NativeFile<'data, R = &'data [u8]> =
+    macho::MachOFile64<'data, crate::endian::Endianness, R>;
 
 /// The native executable file for the target platform.
 #[cfg(all(target_os = "windows", target_pointer_width = "32", feature = "pe"))]

--- a/src/read/pe/data_directory.rs
+++ b/src/read/pe/data_directory.rs
@@ -1,7 +1,8 @@
 use core::slice;
 
+use crate::endian::LittleEndian as LE;
+use crate::pe;
 use crate::read::{Error, ReadError, ReadRef, Result};
-use crate::{pe, LittleEndian as LE};
 
 use super::{
     DelayLoadImportTable, ExportTable, ImportTable, RelocationBlockIterator, ResourceDirectory,

--- a/src/read/pe/export.rs
+++ b/src/read/pe/export.rs
@@ -1,8 +1,9 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
+use crate::endian::{LittleEndian as LE, U16Bytes, U32Bytes};
+use crate::pe;
 use crate::read::{ByteString, Bytes, Error, ReadError, ReadRef, Result};
-use crate::{pe, LittleEndian as LE, U16Bytes, U32Bytes};
 
 /// Where an export is pointing to.
 #[derive(Clone, Copy)]

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -4,12 +4,15 @@ use core::{mem, str};
 
 use core::convert::TryInto;
 
+use crate::endian::{LittleEndian as LE, U32};
+use crate::pe;
+use crate::pod::Pod;
 use crate::read::coff::{CoffCommon, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, SymbolTable};
 use crate::read::{
-    self, Architecture, ComdatKind, Error, Export, FileFlags, Import, NoDynamicRelocationIterator,
-    Object, ObjectComdat, ObjectKind, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
+    self, Architecture, ByteString, Bytes, CodeView, ComdatKind, Error, Export, FileFlags, Import,
+    NoDynamicRelocationIterator, Object, ObjectComdat, ObjectKind, ReadError, ReadRef, Result,
+    SectionIndex, SubArchitecture, SymbolIndex,
 };
-use crate::{pe, ByteString, Bytes, CodeView, LittleEndian as LE, Pod, SubArchitecture, U32};
 
 use super::{
     DataDirectories, ExportTable, ImageThunkData, ImportTable, PeSection, PeSectionIterator,

--- a/src/read/pe/import.rs
+++ b/src/read/pe/import.rs
@@ -1,8 +1,10 @@
 use core::fmt::Debug;
 use core::mem;
 
+use crate::endian::{LittleEndian as LE, U16Bytes};
+use crate::pe;
+use crate::pod::Pod;
 use crate::read::{Bytes, ReadError, Result};
-use crate::{pe, LittleEndian as LE, Pod, U16Bytes};
 
 use super::ImageNtHeaders;
 

--- a/src/read/pe/resource.rs
+++ b/src/read/pe/resource.rs
@@ -1,8 +1,9 @@
 use alloc::string::String;
 use core::char;
 
+use crate::endian::{LittleEndian as LE, U16Bytes};
+use crate::pe;
 use crate::read::{ReadError, ReadRef, Result};
-use crate::{pe, LittleEndian as LE, U16Bytes};
 
 /// The `.rsrc` section of a PE file.
 ///

--- a/src/read/pe/rich.rs
+++ b/src/read/pe/rich.rs
@@ -2,9 +2,10 @@
 
 use core::mem;
 
+use crate::endian::{LittleEndian as LE, U32};
+use crate::pe;
 use crate::pod::bytes_of_slice;
-use crate::read::Bytes;
-use crate::{pe, LittleEndian as LE, ReadRef, U32};
+use crate::read::{Bytes, ReadRef};
 
 /// Parsed information about a Rich Header.
 #[derive(Debug, Clone, Copy)]

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -1,13 +1,13 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
+use crate::endian::Endianness;
 use crate::read::{
     self, Architecture, CodeView, ComdatKind, CompressedData, CompressedFileRange, Export,
     FileFlags, Import, ObjectKind, ObjectMap, Relocation, Result, SectionFlags, SectionIndex,
     SectionKind, SegmentFlags, SubArchitecture, SymbolFlags, SymbolIndex, SymbolKind, SymbolMap,
     SymbolMapName, SymbolScope, SymbolSection,
 };
-use crate::Endianness;
 
 /// An object file.
 ///

--- a/src/read/util.rs
+++ b/src/read/util.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use core::marker::PhantomData;
 
 use crate::pod::{from_bytes, slice_from_bytes, Pod};
-use crate::ReadRef;
+use crate::read::ReadRef;
 
 /// A newtype for byte slices.
 ///

--- a/src/read/xcoff/comdat.rs
+++ b/src/read/xcoff/comdat.rs
@@ -2,9 +2,8 @@
 
 use core::fmt::Debug;
 
-use crate::xcoff;
-
 use crate::read::{self, ComdatKind, ObjectComdat, ReadRef, Result, SectionIndex, SymbolIndex};
+use crate::xcoff;
 
 use super::{FileHeader, XcoffFile};
 

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -3,12 +3,13 @@ use core::mem;
 
 use alloc::vec::Vec;
 
-use crate::read::{self, Error, NoDynamicRelocationIterator, Object, ReadError, ReadRef, Result};
-
-use crate::{
-    xcoff, Architecture, BigEndian as BE, FileFlags, ObjectKind, ObjectSection, Pod, SectionIndex,
-    SymbolIndex,
+use crate::endian::BigEndian as BE;
+use crate::pod::Pod;
+use crate::read::{
+    self, Architecture, Error, Export, FileFlags, Import, NoDynamicRelocationIterator, Object,
+    ObjectKind, ObjectSection, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
 };
+use crate::xcoff;
 
 use super::{
     CsectAux, FileAux, SectionHeader, SectionTable, Symbol, SymbolTable, XcoffComdat,
@@ -100,7 +101,7 @@ where
     type SymbolTable = XcoffSymbolTable<'data, 'file, Xcoff, R>;
     type DynamicRelocationIterator = NoDynamicRelocationIterator;
 
-    fn architecture(&self) -> crate::Architecture {
+    fn architecture(&self) -> Architecture {
         if self.is_64() {
             Architecture::PowerPc64
         } else {
@@ -211,12 +212,12 @@ where
         None
     }
 
-    fn imports(&self) -> Result<alloc::vec::Vec<crate::Import<'data>>> {
+    fn imports(&self) -> Result<alloc::vec::Vec<Import<'data>>> {
         // TODO: return the imports in the STYP_LOADER section.
         Ok(Vec::new())
     }
 
-    fn exports(&self) -> Result<alloc::vec::Vec<crate::Export<'data>>> {
+    fn exports(&self) -> Result<alloc::vec::Vec<Export<'data>>> {
         // TODO: return the exports in the STYP_LOADER section.
         Ok(Vec::new())
     }

--- a/src/read/xcoff/relocation.rs
+++ b/src/read/xcoff/relocation.rs
@@ -2,12 +2,13 @@ use alloc::fmt;
 use core::fmt::Debug;
 use core::slice;
 
+use crate::endian::BigEndian as BE;
 use crate::pod::Pod;
-use crate::{xcoff, BigEndian as BE, Relocation};
-
 use crate::read::{
-    ReadRef, RelocationEncoding, RelocationFlags, RelocationKind, RelocationTarget, SymbolIndex,
+    ReadRef, Relocation, RelocationEncoding, RelocationFlags, RelocationKind, RelocationTarget,
+    SymbolIndex,
 };
+use crate::xcoff;
 
 use super::{FileHeader, SectionHeader, XcoffFile};
 

--- a/src/read/xcoff/section.rs
+++ b/src/read/xcoff/section.rs
@@ -1,11 +1,13 @@
 use core::fmt::Debug;
 use core::{iter, result, slice, str};
 
-use crate::{
-    xcoff, BigEndian as BE, CompressedData, CompressedFileRange, Pod, SectionFlags, SectionKind,
+use crate::endian::BigEndian as BE;
+use crate::pod::Pod;
+use crate::read::{
+    self, CompressedData, CompressedFileRange, Error, ObjectSection, ReadError, ReadRef, Result,
+    SectionFlags, SectionIndex, SectionKind,
 };
-
-use crate::read::{self, Error, ObjectSection, ReadError, ReadRef, Result, SectionIndex};
+use crate::xcoff;
 
 use super::{AuxHeader, FileHeader, Rel, XcoffFile, XcoffRelocationIterator};
 

--- a/src/read/xcoff/segment.rs
+++ b/src/read/xcoff/segment.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 use core::str;
 
-use crate::read::{self, ObjectSegment, ReadRef, Result};
+use crate::read::{self, ObjectSegment, ReadRef, Result, SegmentFlags};
 use crate::xcoff;
 
 use super::{FileHeader, XcoffFile};
@@ -111,7 +111,7 @@ where
         unreachable!();
     }
 
-    fn flags(&self) -> crate::SegmentFlags {
+    fn flags(&self) -> SegmentFlags {
         unreachable!();
     }
 }

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -6,13 +6,11 @@ use core::str;
 
 use crate::endian::{BigEndian as BE, U32Bytes};
 use crate::pod::{bytes_of, Pod};
-use crate::read::util::StringTable;
-use crate::xcoff;
-
 use crate::read::{
     self, Bytes, Error, ObjectSymbol, ObjectSymbolTable, ReadError, ReadRef, Result, SectionIndex,
-    SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
+    StringTable, SymbolFlags, SymbolIndex, SymbolKind, SymbolScope, SymbolSection,
 };
+use crate::xcoff;
 
 use super::{FileHeader, XcoffFile};
 

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -3,7 +3,6 @@ use alloc::vec::Vec;
 use crate::write::elf::writer::*;
 use crate::write::string::StringId;
 use crate::write::*;
-use crate::AddressSize;
 use crate::{elf, pod};
 
 #[derive(Clone, Copy)]

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -5,7 +5,6 @@ use crate::macho;
 use crate::write::string::*;
 use crate::write::util::*;
 use crate::write::*;
-use crate::AddressSize;
 
 #[derive(Default, Clone, Copy)]
 struct SectionOffsets {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -10,11 +10,8 @@ use hashbrown::HashMap;
 use std::{boxed::Box, collections::HashMap, error, io};
 
 use crate::endian::{Endianness, U32, U64};
-use crate::{
-    Architecture, BinaryFormat, ComdatKind, FileFlags, RelocationEncoding, RelocationFlags,
-    RelocationKind, SectionFlags, SectionKind, SubArchitecture, SymbolFlags, SymbolKind,
-    SymbolScope,
-};
+
+pub use crate::common::*;
 
 #[cfg(feature = "coff")]
 pub mod coff;

--- a/src/write/xcoff.rs
+++ b/src/write/xcoff.rs
@@ -5,7 +5,7 @@ use crate::write::string::*;
 use crate::write::util::*;
 use crate::write::*;
 
-use crate::{xcoff, AddressSize};
+use crate::xcoff;
 
 #[derive(Default, Clone, Copy)]
 struct SectionOffsets {


### PR DESCRIPTION
The exception is reusing common definitions that are reexported in the read module (preexisting) and write module (newly added).

This is for consistency, and makes it easier to experiment with a restructure.