### PR TITLE
read: add Relocation::set_addend

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -705,6 +705,12 @@ impl Relocation {
         self.addend
     }
 
+    /// Set the addend to use in the relocation calculation.
+    #[inline]
+    pub fn set_addend(&mut self, addend: i64) {
+        self.addend = addend;
+    }
+
     /// Returns true if there is an implicit addend stored in the data at the offset
     /// to be relocated.
     #[inline]


### PR DESCRIPTION
This was removed in eb58357f for consistency (nowhere else in the read API allows mutation), but there are existing users so add it back in for convenience.