### PR TITLE
read: check that sizes are smaller than the file when reading

### DIFF
--- a/src/read/read_cache.rs
+++ b/src/read/read_cache.rs
@@ -27,6 +27,30 @@ struct ReadCacheInternal<R: Read + Seek> {
     read: R,
     bufs: HashMap<(u64, u64), Box<[u8]>>,
     strings: HashMap<(u64, u8), Box<[u8]>>,
+    len: Option<u64>,
+}
+
+impl<R: Read + Seek> ReadCacheInternal<R> {
+    /// Ensures this range is contained in the len of the file
+    fn range_in_bounds(&mut self, range: &Range<u64>) -> Result<(), ()> {
+        if range.start <= range.end && range.end <= self.len()? {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// The length of the underlying read, memoized
+    fn len(&mut self) -> Result<u64, ()> {
+        match self.len {
+            Some(len) => Ok(len),
+            None => {
+                let len = self.read.seek(SeekFrom::End(0)).map_err(|_| ())?;
+                self.len = Some(len);
+                Ok(len)
+            }
+        }
+    }
 }
 
 impl<R: Read + Seek> ReadCache<R> {
@@ -37,6 +61,7 @@ impl<R: Read + Seek> ReadCache<R> {
                 read,
                 bufs: HashMap::new(),
                 strings: HashMap::new(),
+                len: None,
             }),
         }
     }
@@ -64,8 +89,7 @@ impl<R: Read + Seek> ReadCache<R> {
 
 impl<'a, R: Read + Seek> ReadRef<'a> for &'a ReadCache<R> {
     fn len(self) -> Result<u64, ()> {
-        let cache = &mut *self.cache.borrow_mut();
-        cache.read.seek(SeekFrom::End(0)).map_err(|_| ())
+        self.cache.borrow_mut().len()
     }
 
     fn read_bytes_at(self, offset: u64, size: u64) -> Result<&'a [u8], ()> {
@@ -73,6 +97,7 @@ impl<'a, R: Read + Seek> ReadRef<'a> for &'a ReadCache<R> {
             return Ok(&[]);
         }
         let cache = &mut *self.cache.borrow_mut();
+        cache.range_in_bounds(&(offset..(offset.saturating_add(size))))?;
         let buf = match cache.bufs.entry((offset, size)) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
@@ -90,6 +115,7 @@ impl<'a, R: Read + Seek> ReadRef<'a> for &'a ReadCache<R> {
 
     fn read_bytes_at_until(self, range: Range<u64>, delimiter: u8) -> Result<&'a [u8], ()> {
         let cache = &mut *self.cache.borrow_mut();
+        cache.range_in_bounds(&range)?;
         let buf = match cache.strings.entry((range.start, delimiter)) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {

--- a/tests/read/elf.rs
+++ b/tests/read/elf.rs
@@ -1,0 +1,47 @@
+use object::Object;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[cfg(feature = "std")]
+fn get_buildid(path: &Path) -> Result<Option<Vec<u8>>, object::read::Error> {
+    let file = std::fs::File::open(path).unwrap();
+    let reader = object::read::ReadCache::new(file);
+    let object = object::read::File::parse(&reader)?;
+    object
+        .build_id()
+        .map(|option| option.map(ToOwned::to_owned))
+}
+
+#[cfg(feature = "std")]
+#[test]
+/// Regression test: used to attempt to allocate 5644418395173552131 bytes
+fn get_buildid_bad_elf() {
+    let path: PathBuf = [
+        "testfiles",
+        "elf",
+        "yara-fuzzing",
+        "crash-7dc27920ae1cb85333e7f2735a45014488134673",
+    ]
+    .iter()
+    .collect();
+    let _ = get_buildid(&path);
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn get_buildid_less_bad_elf() {
+    let path: PathBuf = [
+        "testfiles",
+        "elf",
+        "yara-fuzzing",
+        "crash-f1fd008da535b110853885221ebfaac3f262a1c1e280f10929f7b353c44996c8",
+    ]
+    .iter()
+    .collect();
+    let buildid = get_buildid(&path).unwrap().unwrap();
+    // ground truth obtained from GNU binutils's readelf
+    assert_eq!(
+        buildid,
+        b"\xf9\xc0\xc6\x05\xd3\x76\xbb\xa5\x7e\x02\xf5\x74\x50\x9d\x16\xcc\xe9\x9c\x1b\xf1"
+    );
+}

--- a/tests/read/mod.rs
+++ b/tests/read/mod.rs
@@ -1,3 +1,4 @@
 #![cfg(feature = "read")]
 
 mod coff;
+mod elf;


### PR DESCRIPTION
related to #204

added a regression test case which used to attempt to allocate 5 exabytes of memory.

test files added in https://github.com/gimli-rs/object-testfiles/pull/12