### PR TITLE
read: use Vec::try_reserve_exact for large allocations

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -835,7 +835,11 @@ impl<'data> CompressedData<'data> {
                     .try_into()
                     .ok()
                     .read_error("Uncompressed data size is too large.")?;
-                let mut decompressed = Vec::with_capacity(size);
+                let mut decompressed = Vec::new();
+                decompressed
+                    .try_reserve_exact(size)
+                    .ok()
+                    .read_error("Uncompressed data allocation failed")?;
                 let mut decompress = flate2::Decompress::new(true);
                 decompress
                     .decompress_vec(
@@ -856,7 +860,11 @@ impl<'data> CompressedData<'data> {
                     .try_into()
                     .ok()
                     .read_error("Uncompressed data size is too large.")?;
-                let mut decompressed = Vec::with_capacity(size);
+                let mut decompressed = Vec::new();
+                decompressed
+                    .try_reserve_exact(size)
+                    .ok()
+                    .read_error("Uncompressed data allocation failed")?;
                 let mut decoder = ruzstd::StreamingDecoder::new(self.data)
                     .ok()
                     .read_error("Invalid zstd compressed data")?;

--- a/src/read/read_cache.rs
+++ b/src/read/read_cache.rs
@@ -103,7 +103,10 @@ impl<'a, R: Read + Seek> ReadRef<'a> for &'a ReadCache<R> {
             Entry::Vacant(entry) => {
                 let size = size.try_into().map_err(|_| ())?;
                 cache.read.seek(SeekFrom::Start(offset)).map_err(|_| ())?;
-                let mut bytes = vec![0; size].into_boxed_slice();
+                let mut bytes = Vec::new();
+                bytes.try_reserve_exact(size).map_err(|_| ())?;
+                bytes.resize(size, 0);
+                let mut bytes = bytes.into_boxed_slice();
                 cache.read.read_exact(&mut bytes).map_err(|_| ())?;
                 entry.insert(bytes)
             }


### PR DESCRIPTION
This changes the buffers allocated in ReadCache and for decompression.

This would also cause the test added in #630 to pass (it's still better to have the fix in #630 though).

Closes #204 

