### PR TITLE
Correctly handle dyld caches on macOS 13 and above

### DIFF
--- a/crates/examples/src/bin/dyldcachedump.rs
+++ b/crates/examples/src/bin/dyldcachedump.rs
@@ -115,6 +115,10 @@ fn open_subcaches(path: &str, subcaches_info: DyldSubCacheSlice<Endianness>) -> 
                 })
                 .collect()
         }
+        _ => panic!(
+            "If this case is hit, it means that someone added a variant to the (non-exhaustive) \
+            DyldSubCacheSlice enum and forgot to update this example"
+        ),
     };
     let mut files = Vec::new();
     for suffix in subcache_suffixes {

--- a/crates/examples/src/bin/dyldcachedump.rs
+++ b/crates/examples/src/bin/dyldcachedump.rs
@@ -1,4 +1,5 @@
-use object::read::macho::DyldCache;
+use object::macho::DyldCacheHeader;
+use object::read::macho::{DyldCache, DyldSubCacheSlice};
 use object::Endianness;
 use std::{env, fs, process};
 
@@ -22,7 +23,6 @@ fn main() {
                 continue;
             }
         };
-        let subcache_files = open_subcaches_if_exist(&file_path);
         let file = match unsafe { memmap2::Mmap::map(&file) } {
             Ok(mmap) => mmap,
             Err(err) => {
@@ -30,13 +30,27 @@ fn main() {
                 continue;
             }
         };
+
+        let subcaches_info = match get_subcache_info(&file) {
+            Ok(subcaches_info) => subcaches_info,
+            Err(err) => {
+                println!(
+                    "Failed to parse Dyld shared cache file '{}': {}",
+                    file_path, err,
+                );
+                continue;
+            }
+        };
+        let subcache_files = subcaches_info
+            .map(|info| open_subcaches(&file_path, info))
+            .unwrap_or_default();
         let subcache_files: Option<Vec<_>> = subcache_files
             .into_iter()
             .map(
                 |subcache_file| match unsafe { memmap2::Mmap::map(&subcache_file) } {
                     Ok(mmap) => Some(mmap),
                     Err(err) => {
-                        eprintln!("Failed to map file '{}': {}", file_path, err);
+                        println!("Failed to map file '{}': {}", file_path, err);
                         None
                     }
                 },
@@ -69,27 +83,46 @@ fn main() {
     }
 }
 
+/// Gets the slice of subcache info structs from the header of the main cache.
+fn get_subcache_info(
+    main_cache_data: &[u8],
+) -> object::read::Result<Option<DyldSubCacheSlice<'_, Endianness>>> {
+    let header = DyldCacheHeader::<Endianness>::parse(main_cache_data)?;
+    let (_arch, endian) = header.parse_magic()?;
+    let subcaches_info = header.subcaches(endian, main_cache_data)?;
+    Ok(subcaches_info)
+}
+
 // If the file is a dyld shared cache, and we're on macOS 12 or later,
 // then there will be one or more "subcache" files next to this file,
 // with the names filename.1, filename.2, ..., filename.symbols
-// or filename.01, filename.02 on macOS 13
-fn open_subcaches_if_exist(path: &str) -> Vec<fs::File> {
+// or filename.01, filename.02, ..., filename.symbols on macOS 13
+fn open_subcaches(path: &str, subcaches_info: DyldSubCacheSlice<Endianness>) -> Vec<fs::File> {
+    let subcache_suffixes: Vec<String> = match subcaches_info {
+        DyldSubCacheSlice::V1(subcaches) => {
+            // macOS 12: Subcaches have the file suffixes .1, .2, .3 etc.
+            (1..subcaches.len() + 1).map(|i| format!(".{i}")).collect()
+        }
+        DyldSubCacheSlice::V2(subcaches) => {
+            // macOS 13+: The subcache file suffix is written down in the header of the main cache.
+            subcaches
+                .iter()
+                .map(|s| {
+                    // The suffix is a nul-terminated string in a fixed-size byte array.
+                    let suffix = s.file_suffix;
+                    let len = suffix.iter().position(|&c| c == 0).unwrap_or(suffix.len());
+                    String::from_utf8_lossy(&suffix[..len]).to_string()
+                })
+                .collect()
+        }
+    };
     let mut files = Vec::new();
-    for i in 1.. {
-        let subcache_path = format!("{}.{}", path, i);
+    for suffix in subcache_suffixes {
+        let subcache_path = format!("{path}{suffix}");
         match fs::File::open(subcache_path) {
             Ok(subcache_file) => files.push(subcache_file),
             Err(_) => break,
         };
-    }
-    if files.is_empty() {
-        for i in 1.. {
-            let subcache_path = format!("{}.{:02}", path, i);
-            match fs::File::open(subcache_path) {
-                Ok(subcache_file) => files.push(subcache_file),
-                Err(_) => break,
-            };
-        }
     }
     let symbols_subcache_path = format!("{}.symbols", path);
     if let Ok(subcache_file) = fs::File::open(symbols_subcache_path) {

--- a/crates/examples/src/bin/objdump.rs
+++ b/crates/examples/src/bin/objdump.rs
@@ -1,3 +1,4 @@
+use object::{macho::DyldCacheHeader, read::macho::DyldSubCacheSlice, Endianness};
 use object_examples::objdump;
 use std::{env, fs, io, process};
 
@@ -18,7 +19,6 @@ fn main() {
             process::exit(1);
         }
     };
-    let extra_files = open_subcaches_if_exist(&file_path);
     let file = match unsafe { memmap2::Mmap::map(&file) } {
         Ok(mmap) => mmap,
         Err(err) => {
@@ -26,6 +26,10 @@ fn main() {
             process::exit(1);
         }
     };
+    let subcaches_info = get_subcache_info_if_dyld_cache(&file).ok().flatten();
+    let extra_files = subcaches_info
+        .map(|info| open_subcaches(&file_path, info))
+        .unwrap_or_default();
     let extra_files: Vec<_> = extra_files
         .into_iter()
         .map(
@@ -52,17 +56,44 @@ fn main() {
     .unwrap();
 }
 
+/// Gets the slice of subcache info structs from the header of the main cache,
+/// if `main_cache_data` is the data of a Dyld shared cache.
+fn get_subcache_info_if_dyld_cache(
+    main_cache_data: &[u8],
+) -> object::read::Result<Option<DyldSubCacheSlice<'_, Endianness>>> {
+    let header = DyldCacheHeader::<Endianness>::parse(main_cache_data)?;
+    let (_arch, endian) = header.parse_magic()?;
+    let subcaches_info = header.subcaches(endian, main_cache_data)?;
+    Ok(subcaches_info)
+}
+
 // If the file is a dyld shared cache, and we're on macOS 12 or later,
 // then there will be one or more "subcache" files next to this file,
-// with the names filename.1, filename.2 etc.
-// Read those files now, if they exist, even if we don't know that
-// we're dealing with a dyld shared cache. By the time we know what
-// we're dealing with, it's too late to read more files.
-fn open_subcaches_if_exist(path: &str) -> Vec<fs::File> {
+// with the names filename.1, filename.2, ..., filename.symbols
+// or filename.01, filename.02, ..., filename.symbols on macOS 13
+fn open_subcaches(path: &str, subcaches_info: DyldSubCacheSlice<Endianness>) -> Vec<fs::File> {
+    let subcache_suffixes: Vec<String> = match subcaches_info {
+        DyldSubCacheSlice::V1(subcaches) => {
+            // macOS 12: Subcaches have the file suffixes .1, .2, .3 etc.
+            (1..subcaches.len() + 1).map(|i| format!(".{i}")).collect()
+        }
+        DyldSubCacheSlice::V2(subcaches) => {
+            // macOS 13+: The subcache file suffix is written down in the header of the main cache.
+            subcaches
+                .iter()
+                .map(|s| {
+                    // The suffix is a nul-terminated string in a fixed-size byte array.
+                    let suffix = s.file_suffix;
+                    let len = suffix.iter().position(|&c| c == 0).unwrap_or(suffix.len());
+                    String::from_utf8_lossy(&suffix[..len]).to_string()
+                })
+                .collect()
+        }
+    };
     let mut files = Vec::new();
-    for i in 1.. {
-        let subcache_path = format!("{}.{}", path, i);
-        match fs::File::open(&subcache_path) {
+    for suffix in subcache_suffixes {
+        let subcache_path = format!("{path}{suffix}");
+        match fs::File::open(subcache_path) {
             Ok(subcache_file) => files.push(subcache_file),
             Err(_) => break,
         };
@@ -71,5 +102,6 @@ fn open_subcaches_if_exist(path: &str) -> Vec<fs::File> {
     if let Ok(subcache_file) = fs::File::open(symbols_subcache_path) {
         files.push(subcache_file);
     };
+    println!("Found {} subcache files", files.len());
     files
 }

--- a/crates/examples/src/bin/objdump.rs
+++ b/crates/examples/src/bin/objdump.rs
@@ -89,6 +89,10 @@ fn open_subcaches(path: &str, subcaches_info: DyldSubCacheSlice<Endianness>) -> 
                 })
                 .collect()
         }
+        _ => panic!(
+            "If this case is hit, it means that someone added a variant to the (non-exhaustive) \
+            DyldSubCacheSlice enum and forgot to update this example"
+        ),
     };
     let mut files = Vec::new();
     for suffix in subcache_suffixes {

--- a/crates/examples/src/objdump.rs
+++ b/crates/examples/src/objdump.rs
@@ -60,7 +60,7 @@ pub fn print<W: Write, E: Write>(
             let path = match image.path() {
                 Ok(path) => path,
                 Err(err) => {
-                    writeln!(e, "Failed to parse dydld image name: {}", err)?;
+                    writeln!(e, "Failed to parse dyld image name: {}", err)?;
                     continue;
                 }
             };

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -379,15 +379,29 @@ pub struct DyldCacheImageInfo<E: Endian> {
     pub pad: U32<E>,
 }
 
-/// Corresponds to a struct whose source code has not been published as of Nov 2021.
-/// Added in the dyld cache version which shipped with macOS 12 / iOS 15.
+/// Added in dyld-940, which shipped with macOS 12 / iOS 15.
+/// Originally called `dyld_subcache_entry`, renamed to `dyld_subcache_entry_v1`
+/// in dyld-1042.1.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct DyldSubCacheInfo<E: Endian> {
+pub struct DyldSubCacheEntryV1<E: Endian> {
     /// The UUID of this subcache.
     pub uuid: [u8; 16],
-    /// The size of this subcache plus all previous subcaches.
-    pub cumulative_size: U64<E>,
+    /// The offset of this subcache from the main cache base address.
+    pub cache_vm_offset: U64<E>,
+}
+
+/// Added in dyld-1042.1, which shipped with macOS 13 / iOS 16.
+/// Called `dyld_subcache_entry` as of dyld-1042.1.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct DyldSubCacheEntryV2<E: Endian> {
+    /// The UUID of this subcache.
+    pub uuid: [u8; 16],
+    /// The offset of this subcache from the main cache base address.
+    pub cache_vm_offset: U64<E>,
+    /// The file name suffix of the subCache file, e.g. ".25.data" or ".03.development".
+    pub file_suffix: [u8; 32],
 }
 
 // Definitions from "/usr/include/mach-o/loader.h".
@@ -3253,7 +3267,8 @@ unsafe_impl_endian_pod!(
     DyldCacheHeader,
     DyldCacheMappingInfo,
     DyldCacheImageInfo,
-    DyldSubCacheInfo,
+    DyldSubCacheEntryV1,
+    DyldSubCacheEntryV2,
     MachHeader32,
     MachHeader64,
     LoadCommand,

--- a/src/read/macho/dyld_cache.rs
+++ b/src/read/macho/dyld_cache.rs
@@ -35,6 +35,7 @@ where
 /// an additional field (the file suffix) in dyld-1042.1 (macOS 13 / iOS 16),
 /// so this is an enum of the two possible slice types.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum DyldSubCacheSlice<'data, E: Endian> {
     /// V1, used between dyld-940 and dyld-1042.1.
     V1(&'data [macho::DyldSubCacheEntryV1<E>]),

--- a/src/read/macho/dyld_cache.rs
+++ b/src/read/macho/dyld_cache.rs
@@ -90,10 +90,11 @@ where
         // Read the regular SubCaches, if present.
         let mut subcaches = Vec::new();
         if let Some(subcaches_info) = subcaches_info {
-            let uuids: Vec<&[u8; 16]> = match subcaches_info {
-                DyldSubCacheSlice::V1(s) => s.iter().map(|e| &e.uuid).collect(),
-                DyldSubCacheSlice::V2(s) => s.iter().map(|e| &e.uuid).collect(),
+            let (v1, v2) = match subcaches_info {
+                DyldSubCacheSlice::V1(s) => (s, &[][..]),
+                DyldSubCacheSlice::V2(s) => (&[][..], s),
             };
+            let uuids = v1.iter().map(|e| &e.uuid).chain(v2.iter().map(|e| &e.uuid));
             for (&data, uuid) in subcache_data.iter().zip(uuids) {
                 let sc_header = macho::DyldCacheHeader::<E>::parse(data)?;
                 if &sc_header.uuid != uuid {


### PR DESCRIPTION
This allows successful parsing of dyld caches on macOS 13 and above on Intel Macs.

The main dyld cache file on macOS contains an array of subcache info structs, each of which specifies the UUID (and some other information) of each subcache.
`DyldCache::parse` checks that the subcache UUIDs match these expected UUIDs.

In macOS 13, the format of the subcache info struct changed: the struct gained an additional field after the UUID field. This means that as soon as you had more than one subcache, our UUID check would fail, because the second subcache UUID would be read from the wrong offset.

I didn't notice this on my Apple Silicon Mac, because the arm64e dyld cache only has one subcache:
`dyld_shared_cache_arm64e.01`.
But on Intel Macs, there are currently four subcaches: `dyld_shared_cache_x86_64.01`, `.02`, `.03`, and `.04`.

In practice this means that my software hasn't been able to symbolicate macOS system libraries on Intel Macs since the release of macOS 13.

This commit adds the new struct definition and makes the UUID check work correctly.

This is a breaking change to the public API. I added a `DyldSubCacheSlice` enum, but I'm not particularly fond of it.
I'm also not a big fan of the new allocation for the Vec of UUIDs, but it seemed better than the alternatives I tried, which all had a bunch of code duplication.

dyld source code:

 - [`dyld_cache_header` struct definition](https://github.com/apple-oss-distributions/dyld/blame/d1a0f6869ece370913a3f749617e457f3b4cd7c4/cache-builder/dyld_cache_format.h#L31)
 - [`dyld_subcache_entry_v1` and `dyld_subcache_entry` struct definitions](https://github.com/apple-oss-distributions/dyld/blame/d1a0f6869ece370913a3f749617e457f3b4cd7c4/cache-builder/dyld_cache_format.h#L502-L513)
 - [A check for whether subcache information is present](https://github.com/apple-oss-distributions/dyld/blob/d1a0f6869ece370913a3f749617e457f3b4cd7c4/common/DyldSharedCache.cpp#L1724)
 - [A check for whether V2 information is present](https://github.com/apple-oss-distributions/dyld/blob/d1a0f6869ece370913a3f749617e457f3b4cd7c4/common/DyldSharedCache.cpp#L1727)

I've changed `MIN_HEADER_SIZE_SUBCACHES_V1` to be `0x1c8` instead of `0x1c4` because we use a >= check on it. dyld uses a > check with the offset of the `subCacheArrayCount` field (called `images_across_all_subcaches_count` in our definition), so what dyld is doing is a equivalent to a `> 0x1c4` check. Rather than changing our check to be a > check, I've kept it as a >= because that fits better with the `MIN_HEADER_SIZE` name, and instead increased the offset to point to the *end* of the field instead of the beginning.

I didn't touch our definition of `DyldCacheHeader`. It's quite incomplete because the dyld source with the new header fields hadn't been released yet at the time I wrote the `object` code. Now that it's out, we could flesh out our type definition a bit, but I don't have an urgent need for that at the moment.