### PR TITLE
Skip the EC Symbol Map when parsing COFF archives

### DIFF
--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -144,6 +144,13 @@ impl<'data, R: ReadRef<'data>> ArchiveFile<'data, R> {
                                 members_offset = tail;
                             }
                         }
+                        if tail < len {
+                            let member = ArchiveMember::parse(data, &mut tail, &file.names, thin)?;
+                            if member.name == b"/<ECSYMBOLS>/" {
+                                // COFF EC Symbol Table.
+                                members_offset = tail;
+                            }
+                        }
                     } else if member.name == b"//" {
                         // GNU names table.
                         file.names = member.data(data)?;


### PR DESCRIPTION
Arm64EC introduced a new special member in COFF called `/<ECSYMBOL>/` which contains the symbol table for EC-specific symbols: <https://github.com/llvm/llvm-project/blob/1aceee7bb6c4423da73f71aff2004493bdf620d1/llvm/lib/Object/ArchiveWriter.cpp#L647>

When parsing an archive, `object` should skip over this member.