### PR TITLE
write/macho: ensure Mach-O subsections are not zero size

### DIFF
--- a/crates/examples/src/bin/simple_write.rs
+++ b/crates/examples/src/bin/simple_write.rs
@@ -66,8 +66,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     main_data.extend_from_slice(&[0xc3]);
 
     // Add the main function in its own subsection (equivalent to -ffunction-sections).
-    let (main_section, main_offset) =
-        obj.add_subsection(StandardSection::Text, b"main", &main_data, 1);
+    let main_section = obj.add_subsection(StandardSection::Text, b"main");
+    let main_offset = obj.append_section_data(main_section, &main_data, 1);
     // Add a globally visible symbol for the main function.
     obj.add_symbol(Symbol {
         name: b"main".into(),

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -66,16 +66,6 @@ impl<'a> Object<'a> {
 
 // Private methods.
 impl<'a> Object<'a> {
-    pub(crate) fn macho_set_subsections_via_symbols(&mut self) {
-        let flags = match self.flags {
-            FileFlags::MachO { flags } => flags,
-            _ => 0,
-        };
-        self.flags = FileFlags::MachO {
-            flags: flags | macho::MH_SUBSECTIONS_VIA_SYMBOLS,
-        };
-    }
-
     pub(crate) fn macho_segment_name(&self, segment: StandardSegment) -> &'static [u8] {
         match segment {
             StandardSegment::Text => &b"__TEXT"[..],
@@ -570,10 +560,13 @@ impl<'a> Object<'a> {
             cpusubtype = cpu_subtype;
         }
 
-        let flags = match self.flags {
+        let mut flags = match self.flags {
             FileFlags::MachO { flags } => flags,
             _ => 0,
         };
+        if self.macho_subsections_via_symbols {
+            flags |= macho::MH_SUBSECTIONS_VIA_SYMBOLS;
+        }
         macho.write_mach_header(
             buffer,
             MachHeader {

--- a/tests/round_trip/comdat.rs
+++ b/tests/round_trip/comdat.rs
@@ -13,11 +13,11 @@ fn coff_x86_64_comdat() {
     let mut object =
         write::Object::new(BinaryFormat::Coff, Architecture::X86_64, Endianness::Little);
 
-    let (section1, offset) =
-        object.add_subsection(write::StandardSection::Text, b"s1", &[0, 1, 2, 3], 4);
+    let section1 = object.add_subsection(write::StandardSection::Text, b"s1");
+    let offset = object.append_section_data(section1, &[0, 1, 2, 3], 4);
     object.section_symbol(section1);
-    let (section2, _) =
-        object.add_subsection(write::StandardSection::Data, b"s1", &[0, 1, 2, 3], 4);
+    let section2 = object.add_subsection(write::StandardSection::Data, b"s1");
+    object.append_section_data(section2, &[0, 1, 2, 3], 4);
     object.section_symbol(section2);
 
     let symbol = object.add_symbol(write::Symbol {
@@ -132,10 +132,10 @@ fn elf_x86_64_comdat() {
     let mut object =
         write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
 
-    let (section1, offset) =
-        object.add_subsection(write::StandardSection::Text, b"s1", &[0, 1, 2, 3], 4);
-    let (section2, _) =
-        object.add_subsection(write::StandardSection::Data, b"s1", &[0, 1, 2, 3], 4);
+    let section1 = object.add_subsection(write::StandardSection::Text, b"s1");
+    let offset = object.append_section_data(section1, &[0, 1, 2, 3], 4);
+    let section2 = object.add_subsection(write::StandardSection::Data, b"s1");
+    object.append_section_data(section2, &[0, 1, 2, 3], 4);
 
     let symbol = object.add_symbol(write::Symbol {
         name: b"s1".to_vec(),

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -13,8 +13,8 @@ fn symtab_shndx() {
 
     for i in 0..0x10000 {
         let name = format!("func{}", i).into_bytes();
-        let (section, offset) =
-            object.add_subsection(write::StandardSection::Text, &name, &[0xcc], 1);
+        let section = object.add_subsection(write::StandardSection::Text, &name);
+        let offset = object.append_section_data(section, &[0xcc], 1);
         object.add_symbol(write::Symbol {
             name,
             value: offset,


### PR DESCRIPTION
For Mach-O, `add_symbol_data` now ensures that the symbol size is at least 1 when subsections via symbols are enabled. This change was made to support linking with ld-prime. It is also unclear how this previously managed to work with ld64.

`write::Object::add_subsection` no longer enables subsections via symbols for Mach-O. Use `set_subsections_via_symbols` instead. This change was made because Mach-O subsections are all or nothing, so this decision must be made before any symbols are added.

`write::Object::add_subsection` no longer adds data to the subsection. This change was made because it was done with `append_section_data`, but this is often not the correct way to add data to the subsection. Usually `add_symbol_data` is a better choice.