### PR TITLE
read: do not return null sections or symbols in unified API

### DIFF
--- a/crates/examples/src/objcopy.rs
+++ b/crates/examples/src/objcopy.rs
@@ -63,9 +63,6 @@ pub fn copy(in_data: &[u8]) -> Vec<u8> {
 
     let mut out_symbols = HashMap::new();
     for in_symbol in in_object.symbols() {
-        if in_symbol.kind() == SymbolKind::Null {
-            continue;
-        }
         let (section, value) = match in_symbol.section() {
             SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
             SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),

--- a/crates/examples/testfiles/elf/base-aarch64.o.objdump
+++ b/crates/examples/testfiles/elf/base-aarch64.o.objdump
@@ -4,7 +4,6 @@ Architecture: Aarch64
 Flags: Elf { os_abi: 0, abi_version: 0, e_flags: 0 }
 Relative Address Base: 0
 Entry Address: 0
-0: Section { name: "", address: 0, size: 0, align: 0, kind: Metadata, flags: Elf { sh_flags: 0 } }
 1: Section { name: ".text", address: 0, size: 20, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
 2: Section { name: ".rela.text", address: 0, size: 48, align: 8, kind: Metadata, flags: Elf { sh_flags: 40 } }
 3: Section { name: ".data", address: 0, size: 0, align: 1, kind: Data, flags: Elf { sh_flags: 3 } }
@@ -17,7 +16,6 @@ Entry Address: 0
 10: Section { name: ".shstrtab", address: 0, size: 52, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
 
 Symbols
-0: Symbol { name: "", address: 0, size: 0, kind: Null, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
 1: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
 2: Symbol { name: "", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 3: Symbol { name: "", address: 0, size: 0, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }

--- a/crates/examples/testfiles/elf/base-aarch64.objdump
+++ b/crates/examples/testfiles/elf/base-aarch64.objdump
@@ -7,7 +7,6 @@ Entry Address: 620
 Build ID: [f7, 5e, 1f, d9, 4, 9a, 3f, cb, 21, dc, 15, f2, 7b, 5, 32, d8, 61, cf, 16, 2]
 Segment { address: 0, size: 7fc }
 Segment { address: 10d80, size: 298 }
-0: Section { name: "", address: 0, size: 0, align: 0, kind: Metadata, flags: Elf { sh_flags: 0 } }
 1: Section { name: ".interp", address: 200, size: 1b, align: 1, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
 2: Section { name: ".note.ABI-tag", address: 21c, size: 20, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
 3: Section { name: ".note.gnu.build-id", address: 23c, size: 24, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
@@ -36,7 +35,6 @@ Segment { address: 10d80, size: 298 }
 26: Section { name: ".shstrtab", address: 0, size: ec, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
 
 Symbols
-0: Symbol { name: "", address: 0, size: 0, kind: Null, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
 1: Symbol { name: "", address: 200, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 2: Symbol { name: "", address: 21c, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 3: Symbol { name: "", address: 23c, size: 0, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
@@ -126,7 +124,6 @@ Symbols
 87: Symbol { name: "_init", address: 598, size: 0, kind: Text, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
 
 Dynamic symbols
-0: Symbol { name: "", address: 0, size: 0, kind: Null, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
 1: Symbol { name: "", address: 598, size: 0, kind: Section, section: Section(SectionIndex(b)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 2: Symbol { name: "", address: 11000, size: 0, kind: Section, section: Section(SectionIndex(15)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 3: Symbol { name: "_ITM_deregisterTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }

--- a/crates/examples/testfiles/elf/base.o.objdump
+++ b/crates/examples/testfiles/elf/base.o.objdump
@@ -4,7 +4,6 @@ Architecture: X86_64
 Flags: Elf { os_abi: 0, abi_version: 0, e_flags: 0 }
 Relative Address Base: 0
 Entry Address: 0
-0: Section { name: "", address: 0, size: 0, align: 0, kind: Metadata, flags: Elf { sh_flags: 0 } }
 1: Section { name: ".text", address: 0, size: 1c, align: 1, kind: Text, flags: Elf { sh_flags: 6 } }
 2: Section { name: ".rela.text", address: 0, size: 30, align: 8, kind: Metadata, flags: Elf { sh_flags: 40 } }
 3: Section { name: ".data", address: 0, size: 0, align: 1, kind: Data, flags: Elf { sh_flags: 3 } }
@@ -19,7 +18,6 @@ Entry Address: 0
 12: Section { name: ".shstrtab", address: 0, size: 61, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
 
 Symbols
-0: Symbol { name: "", address: 0, size: 0, kind: Null, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
 1: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
 2: Symbol { name: "", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 3: Symbol { name: "", address: 0, size: 0, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }

--- a/crates/examples/testfiles/elf/base.objdump
+++ b/crates/examples/testfiles/elf/base.objdump
@@ -7,7 +7,6 @@ Entry Address: 570
 Build ID: [d4, 46, a0, 61, bb, 9a, c2, 7a, b4, 3b, 11, 71, 8f, de, df, 5b, 7f, 3a, f6, f4]
 Segment { address: 0, size: 878 }
 Segment { address: 200da8, size: 270 }
-0: Section { name: "", address: 0, size: 0, align: 0, kind: Metadata, flags: Elf { sh_flags: 0 } }
 1: Section { name: ".interp", address: 238, size: 1c, align: 1, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
 2: Section { name: ".note.ABI-tag", address: 254, size: 20, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
 3: Section { name: ".note.gnu.build-id", address: 274, size: 24, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
@@ -39,7 +38,6 @@ Segment { address: 200da8, size: 270 }
 29: Section { name: ".shstrtab", address: 0, size: fe, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
 
 Symbols
-0: Symbol { name: "", address: 0, size: 0, kind: Null, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
 1: Symbol { name: "", address: 238, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 2: Symbol { name: "", address: 254, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
 3: Symbol { name: "", address: 274, size: 0, kind: Section, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
@@ -105,7 +103,6 @@ Symbols
 63: Symbol { name: "_init", address: 520, size: 0, kind: Text, section: Section(SectionIndex(c)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
 
 Dynamic symbols
-0: Symbol { name: "", address: 0, size: 0, kind: Null, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
 1: Symbol { name: "_ITM_deregisterTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
 2: Symbol { name: "printf", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
 3: Symbol { name: "__libc_start_main", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }

--- a/src/common.rs
+++ b/src/common.rs
@@ -270,8 +270,6 @@ pub enum ComdatKind {
 pub enum SymbolKind {
     /// The symbol kind is unknown.
     Unknown,
-    /// The symbol is a null placeholder.
-    Null,
     /// The symbol is for executable code.
     Text,
     /// The symbol is for a data object.

--- a/src/read/elf/comdat.rs
+++ b/src/read/elf/comdat.rs
@@ -21,8 +21,22 @@ where
     Elf: FileHeader,
     R: ReadRef<'data>,
 {
-    pub(super) file: &'file ElfFile<'data, Elf, R>,
-    pub(super) iter: iter::Enumerate<slice::Iter<'data, Elf::SectionHeader>>,
+    file: &'file ElfFile<'data, Elf, R>,
+    iter: iter::Enumerate<slice::Iter<'data, Elf::SectionHeader>>,
+}
+
+impl<'data, 'file, Elf, R> ElfComdatIterator<'data, 'file, Elf, R>
+where
+    Elf: FileHeader,
+    R: ReadRef<'data>,
+{
+    pub(super) fn new(
+        file: &'file ElfFile<'data, Elf, R>,
+    ) -> ElfComdatIterator<'data, 'file, Elf, R> {
+        let mut iter = file.sections.iter().enumerate();
+        iter.next(); // Skip null section.
+        ElfComdatIterator { file, iter }
+    }
 }
 
 impl<'data, 'file, Elf, R> Iterator for ElfComdatIterator<'data, 'file, Elf, R>

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -278,17 +278,11 @@ where
     }
 
     fn sections(&self) -> ElfSectionIterator<'data, '_, Elf, R> {
-        ElfSectionIterator {
-            file: self,
-            iter: self.sections.iter().enumerate(),
-        }
+        ElfSectionIterator::new(self)
     }
 
     fn comdats(&self) -> ElfComdatIterator<'data, '_, Elf, R> {
-        ElfComdatIterator {
-            file: self,
-            iter: self.sections.iter().enumerate(),
-        }
+        ElfComdatIterator::new(self)
     }
 
     fn symbol_by_index(&self, index: SymbolIndex) -> read::Result<ElfSymbol<'data, '_, Elf, R>> {
@@ -302,11 +296,7 @@ where
     }
 
     fn symbols(&self) -> ElfSymbolIterator<'data, '_, Elf, R> {
-        ElfSymbolIterator {
-            endian: self.endian,
-            symbols: &self.symbols,
-            index: 0,
-        }
+        ElfSymbolIterator::new(self.endian, &self.symbols)
     }
 
     fn symbol_table(&self) -> Option<ElfSymbolTable<'data, '_, Elf, R>> {
@@ -320,11 +310,7 @@ where
     }
 
     fn dynamic_symbols(&self) -> ElfSymbolIterator<'data, '_, Elf, R> {
-        ElfSymbolIterator {
-            endian: self.endian,
-            symbols: &self.dynamic_symbols,
-            index: 0,
-        }
+        ElfSymbolIterator::new(self.endian, &self.dynamic_symbols)
     }
 
     fn dynamic_symbol_table(&self) -> Option<ElfSymbolTable<'data, '_, Elf, R>> {

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -615,7 +615,7 @@ impl<'a> Object<'a> {
                         }
                     }
                 }
-                SymbolKind::Unknown | SymbolKind::Null => {
+                SymbolKind::Unknown => {
                     return Err(Error(format!(
                         "unimplemented symbol `{}` kind {:?}",
                         symbol.name().unwrap_or(""),

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -679,7 +679,6 @@ impl<'a> Object<'a> {
                 st_info
             } else {
                 let st_type = match symbol.kind {
-                    SymbolKind::Null => elf::STT_NOTYPE,
                     SymbolKind::Text => {
                         if symbol.is_undefined() {
                             elf::STT_NOTYPE

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -460,7 +460,7 @@ impl<'a> Object<'a> {
             match symbol.kind {
                 SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls | SymbolKind::Unknown => {}
                 SymbolKind::File | SymbolKind::Section => continue,
-                SymbolKind::Null | SymbolKind::Label => {
+                SymbolKind::Label => {
                     return Err(Error(format!(
                         "unimplemented symbol `{}` kind {:?}",
                         symbol.name().unwrap_or(""),

--- a/src/write/xcoff.rs
+++ b/src/write/xcoff.rs
@@ -194,7 +194,6 @@ impl<'a> Object<'a> {
                 n_sclass
             } else {
                 match symbol.kind {
-                    SymbolKind::Null => xcoff::C_NULL,
                     SymbolKind::File => xcoff::C_FILE,
                     SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {
                         if symbol.is_local() {

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -125,13 +125,6 @@ fn elf_x86_64_bss() {
 
     let mut sections = object.sections();
 
-    let section = sections.next().unwrap();
-    println!("{:?}", section);
-    assert_eq!(section.name(), Ok(""));
-    assert_eq!(section.kind(), SectionKind::Metadata);
-    assert_eq!(section.address(), 0);
-    assert_eq!(section.size(), 0);
-
     let bss = sections.next().unwrap();
     println!("{:?}", bss);
     let bss_index = bss.index();
@@ -141,10 +134,6 @@ fn elf_x86_64_bss() {
     assert_eq!(bss.data(), Ok(&[][..]));
 
     let mut symbols = object.symbols();
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok(""));
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);

--- a/tests/round_trip/comdat.rs
+++ b/tests/round_trip/comdat.rs
@@ -166,10 +166,6 @@ fn elf_x86_64_comdat() {
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
-    assert_eq!(section.name(), Ok(""));
-
-    let section = sections.next().unwrap();
-    println!("{:?}", section);
     assert_eq!(section.name(), Ok(".group"));
 
     let section1 = sections.next().unwrap();
@@ -189,10 +185,6 @@ fn elf_x86_64_comdat() {
     assert_eq!(section2.size(), 4);
 
     let mut symbols = object.symbols();
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok(""));
 
     let symbol = symbols.next().unwrap();
     let symbol_index = symbol.index();

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -136,10 +136,6 @@ fn elf_x86_64_common() {
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok(""));
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
     assert_eq!(symbol.name(), Ok("v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
     assert_eq!(symbol.section(), read::SymbolSection::Common);

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -34,7 +34,7 @@ fn symtab_shndx() {
     assert_eq!(object.format(), BinaryFormat::Elf);
     assert_eq!(object.architecture(), Architecture::X86_64);
 
-    for symbol in object.symbols().skip(1) {
+    for symbol in object.symbols() {
         assert_eq!(
             symbol.section(),
             SymbolSection::Section(SectionIndex(symbol.index().0))
@@ -62,7 +62,6 @@ fn aligned_sections() {
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut sections = object.sections();
-    let _ = sections.next().unwrap();
 
     let section = sections.next().unwrap();
     assert_eq!(section.name(), Ok(".text"));

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -203,13 +203,6 @@ fn elf_x86_64() {
 
     let mut sections = object.sections();
 
-    let section = sections.next().unwrap();
-    println!("{:?}", section);
-    assert_eq!(section.name(), Ok(""));
-    assert_eq!(section.kind(), SectionKind::Metadata);
-    assert_eq!(section.address(), 0);
-    assert_eq!(section.size(), 0);
-
     let text = sections.next().unwrap();
     println!("{:?}", text);
     let text_index = text.index();
@@ -221,16 +214,6 @@ fn elf_x86_64() {
     assert_eq!(&text.data().unwrap()[32..62], &[1; 30]);
 
     let mut symbols = object.symbols();
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok(""));
-    assert_eq!(symbol.address(), 0);
-    assert_eq!(symbol.kind(), SymbolKind::Null);
-    assert_eq!(symbol.section_index(), None);
-    assert_eq!(symbol.scope(), SymbolScope::Unknown);
-    assert!(!symbol.is_weak());
-    assert!(symbol.is_undefined());
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
@@ -349,13 +332,6 @@ fn elf_any() {
         assert_eq!(object.endianness(), endian);
 
         let mut sections = object.sections();
-
-        let section = sections.next().unwrap();
-        println!("{:?}", section);
-        assert_eq!(section.name(), Ok(""));
-        assert_eq!(section.kind(), SectionKind::Metadata);
-        assert_eq!(section.address(), 0);
-        assert_eq!(section.size(), 0);
 
         let data = sections.next().unwrap();
         println!("{:?}", data);

--- a/tests/round_trip/section_flags.rs
+++ b/tests/round_trip/section_flags.rs
@@ -48,7 +48,6 @@ fn elf_x86_64_section_flags() {
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut sections = object.sections();
-    sections.next().unwrap();
     let section = sections.next().unwrap();
     assert_eq!(section.name(), Ok(".text"));
     assert_eq!(

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -98,10 +98,6 @@ fn elf_x86_64_tls() {
 
     let section = sections.next().unwrap();
     println!("{:?}", section);
-    assert_eq!(section.name(), Ok(""));
-
-    let section = sections.next().unwrap();
-    println!("{:?}", section);
     let tdata_index = section.index();
     assert_eq!(section.name(), Ok(".tdata"));
     assert_eq!(section.kind(), SectionKind::Tls);
@@ -117,10 +113,6 @@ fn elf_x86_64_tls() {
     assert_eq!(section.data().unwrap(), &[]);
 
     let mut symbols = object.symbols();
-
-    let symbol = symbols.next().unwrap();
-    println!("{:?}", symbol);
-    assert_eq!(symbol.name(), Ok(""));
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);


### PR DESCRIPTION
This affects ELF and XCOFF, including some of the lower level APIs too.