### PR TITLE
read/elf: remove unneeded lifetimes

### DIFF
--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -84,7 +84,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SectionTable<'data, Elf, R> {
     pub fn section_name(
         &self,
         endian: Elf::Endian,
-        section: &'data Elf::SectionHeader,
+        section: &Elf::SectionHeader,
     ) -> read::Result<&'data [u8]> {
         section.name(endian, self.strings)
     }

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -162,7 +162,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SymbolTable<'data, Elf, R> {
     pub fn symbol_section(
         &self,
         endian: Elf::Endian,
-        symbol: &'data Elf::Sym,
+        symbol: &Elf::Sym,
         index: usize,
     ) -> read::Result<Option<SectionIndex>> {
         match symbol.st_shndx(endian) {
@@ -177,11 +177,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SymbolTable<'data, Elf, R> {
     }
 
     /// Return the symbol name for the given symbol.
-    pub fn symbol_name(
-        &self,
-        endian: Elf::Endian,
-        symbol: &'data Elf::Sym,
-    ) -> read::Result<&'data [u8]> {
+    pub fn symbol_name(&self, endian: Elf::Endian, symbol: &Elf::Sym) -> read::Result<&'data [u8]> {
         symbol.name(endian, self.strings)
     }
 


### PR DESCRIPTION
While these should be true in practice, they aren't needed, and their presence may require callers to annotate them too.