### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,17 +142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "env_filter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,9 +287,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -328,12 +317,11 @@ checksum = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
 
 [[package]]
 name = "ruzstd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
+checksum = "5022b253619b1ba797f243056276bed8ed1a73b0f5a7ce7225d524067644bf8f"
 dependencies = [
  "byteorder",
- "derive_more",
  "twox-hash",
 ]
 
@@ -348,17 +336,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -401,9 +378,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasmparser"
-version = "0.208.1"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd921789c9dcc495f589cb37d200155dee65b4a4beeb853323b5e24e0a5f9c58"
+checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
 dependencies = [
  "bitflags",
 ]
@@ -498,5 +475,5 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ features = ['doc']
 crc32fast = { version = "1.2", default-features = false, optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "2.0", default-features = false, optional = true }
-wasmparser = { version = "0.208.1", default-features = false, optional = true }
+wasmparser = { version = "0.209.1", default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
 hashbrown = { version = "0.14.0", features = ["ahash"], default-features = false, optional = true }
-ruzstd = { version = "0.6.0", optional = true }
+ruzstd = { version = "0.7.0", optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -188,13 +188,13 @@ fn cmd_msrv() -> Result<(), DynError> {
     cargo(&["update", "-p", "ahash", "--precise", "0.8.7"])?;
     cmd_with(
         "cargo",
-        &["+1.65.0", "test", "-p", "object", "--features", "read,write,build,std"],
+        &["+1.65.0", "test", "-p", "object", "--no-default-features", "--features", "read,write,build,std"],
         |cmd| {
             cmd.env("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
         },
     )?;
     cargo(&["update", "-p", "ahash"])?;
-    // wasmparser needs 1.76.0
+    // wasmparser needs 1.76.0 and ruzstd needs 1.73
     cmd_with(
         "cargo",
         &["+1.76.0", "test", "-p", "object", "--features", "all"],

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -188,7 +188,7 @@ fn cmd_msrv() -> Result<(), DynError> {
     cargo(&["update", "-p", "ahash", "--precise", "0.8.7"])?;
     cmd_with(
         "cargo",
-        &["+1.65.0", "test", "-p", "object", "--features", "read,write,build,std,compression"],
+        &["+1.65.0", "test", "-p", "object", "--features", "read,write,build,std"],
         |cmd| {
             cmd.env("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
         },


### PR DESCRIPTION
This PR updates some dependencies, my main motivation in this is ruzstd removes syn from it's dependency tree and a bunch of proc-macro code generation speeding up compile times and making it so my project will only have syn 2 in it's dependencies and not syn 1 + 2 (once object updates and releases a new version).