### PR TITLE
elf: parse library from symbol versioning table

### DIFF
--- a/crates/examples/testfiles/elf/base-aarch64.objdump
+++ b/crates/examples/testfiles/elf/base-aarch64.objdump
@@ -152,12 +152,12 @@ Dynamic relocations
 (10fb8, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(9)), addend: 0, implicit_addend: false, flags: Elf { r_type: 402 } })
 
 Import { library: "", name: "_ITM_deregisterTMCloneTable" }
-Import { library: "", name: "__cxa_finalize" }
-Import { library: "", name: "__libc_start_main" }
+Import { library: "GLIBC_2.17", name: "__cxa_finalize" }
+Import { library: "GLIBC_2.17", name: "__libc_start_main" }
 Import { library: "", name: "__gmon_start__" }
-Import { library: "", name: "abort" }
+Import { library: "GLIBC_2.17", name: "abort" }
 Import { library: "", name: "_ITM_registerTMCloneTable" }
-Import { library: "", name: "printf" }
+Import { library: "GLIBC_2.17", name: "printf" }
 
 Symbol map
 0x598 "_init"

--- a/crates/examples/testfiles/elf/base-aarch64.objdump
+++ b/crates/examples/testfiles/elf/base-aarch64.objdump
@@ -152,12 +152,12 @@ Dynamic relocations
 (10fb8, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(9)), addend: 0, implicit_addend: false, flags: Elf { r_type: 402 } })
 
 Import { library: "", name: "_ITM_deregisterTMCloneTable" }
-Import { library: "GLIBC_2.17", name: "__cxa_finalize" }
-Import { library: "GLIBC_2.17", name: "__libc_start_main" }
+Import { library: "libc.so.6", name: "__cxa_finalize" }
+Import { library: "libc.so.6", name: "__libc_start_main" }
 Import { library: "", name: "__gmon_start__" }
-Import { library: "GLIBC_2.17", name: "abort" }
+Import { library: "libc.so.6", name: "abort" }
 Import { library: "", name: "_ITM_registerTMCloneTable" }
-Import { library: "GLIBC_2.17", name: "printf" }
+Import { library: "libc.so.6", name: "printf" }
 
 Symbol map
 0x598 "_init"

--- a/crates/examples/testfiles/elf/base.objdump
+++ b/crates/examples/testfiles/elf/base.objdump
@@ -122,11 +122,11 @@ Dynamic relocations
 (200fd0, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(2)), addend: 0, implicit_addend: false, flags: Elf { r_type: 7 } })
 
 Import { library: "", name: "_ITM_deregisterTMCloneTable" }
-Import { library: "", name: "printf" }
-Import { library: "", name: "__libc_start_main" }
+Import { library: "GLIBC_2.2.5", name: "printf" }
+Import { library: "GLIBC_2.2.5", name: "__libc_start_main" }
 Import { library: "", name: "__gmon_start__" }
 Import { library: "", name: "_ITM_registerTMCloneTable" }
-Import { library: "", name: "__cxa_finalize" }
+Import { library: "GLIBC_2.2.5", name: "__cxa_finalize" }
 
 Symbol map
 0x520 "_init"

--- a/crates/examples/testfiles/elf/base.objdump
+++ b/crates/examples/testfiles/elf/base.objdump
@@ -122,11 +122,11 @@ Dynamic relocations
 (200fd0, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(2)), addend: 0, implicit_addend: false, flags: Elf { r_type: 7 } })
 
 Import { library: "", name: "_ITM_deregisterTMCloneTable" }
-Import { library: "GLIBC_2.2.5", name: "printf" }
-Import { library: "GLIBC_2.2.5", name: "__libc_start_main" }
+Import { library: "libc.so.6", name: "printf" }
+Import { library: "libc.so.6", name: "__libc_start_main" }
 Import { library: "", name: "__gmon_start__" }
 Import { library: "", name: "_ITM_registerTMCloneTable" }
-Import { library: "GLIBC_2.2.5", name: "__cxa_finalize" }
+Import { library: "libc.so.6", name: "__cxa_finalize" }
 
 Symbol map
 0x520 "_init"

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -334,18 +334,17 @@ where
     }
 
     fn imports(&self) -> read::Result<Vec<Import<'data>>> {
-        let svt = self.sections.versions(self.endian, self.data)?;
+        let versions = self.sections.versions(self.endian, self.data)?;
 
         let mut imports = Vec::new();
         for (index, symbol) in self.dynamic_symbols.enumerate() {
             if symbol.is_undefined(self.endian) {
                 let name = symbol.name(self.endian, self.dynamic_symbols.strings())?;
                 if !name.is_empty() {
-                    let library = if let Some(svt) = svt.as_ref() {
+                    let library = if let Some(svt) = versions.as_ref() {
                         let vi = svt.version_index(self.endian, index);
                         svt.version(vi)?
-                            .map(|v| v.vn_file())
-                            .flatten()
+                            .and_then(|v| v.file())
                     } else {
                         None
                     }.unwrap_or(&[]);

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -343,11 +343,11 @@ where
                 if !name.is_empty() {
                     let library = if let Some(svt) = versions.as_ref() {
                         let vi = svt.version_index(self.endian, index);
-                        svt.version(vi)?
-                            .and_then(|v| v.file())
+                        svt.version(vi)?.and_then(|v| v.file())
                     } else {
                         None
-                    }.unwrap_or(&[]);
+                    }
+                    .unwrap_or(&[]);
                     imports.push(Import {
                         name: ByteString(name),
                         library: ByteString(library),

--- a/src/read/elf/version.rs
+++ b/src/read/elf/version.rs
@@ -40,6 +40,7 @@ pub struct Version<'data> {
     hash: u32,
     // Used to keep track of valid indices in `VersionTable`.
     valid: bool,
+    vn_file: Option<&'data [u8]>,
 }
 
 impl<'data> Version<'data> {
@@ -51,6 +52,12 @@ impl<'data> Version<'data> {
     /// Return hash of the version name.
     pub fn hash(&self) -> u32 {
         self.hash
+    }
+
+    /// Return the `vn_file` field of the associated entry in [`elf::SHT_GNU_VERNEED`].
+    /// Returns `None` if the version info was parsed from a [`elf::SHT_GNU_VERDEF`] section.
+    pub fn vn_file(&self) -> Option<&'data [u8]> {
+        self.vn_file
     }
 }
 
@@ -128,12 +135,13 @@ impl<'data, Elf: FileHeader> VersionTable<'data, Elf> {
                         name: verdaux.name(endian, strings)?,
                         hash: verdef.vd_hash.get(endian),
                         valid: true,
+                        vn_file: None,
                     };
                 }
             }
         }
         if let Some(mut verneeds) = verneeds {
-            while let Some((_, mut vernauxs)) = verneeds.next()? {
+            while let Some((verneed, mut vernauxs)) = verneeds.next()? {
                 while let Some(vernaux) = vernauxs.next()? {
                     let index = vernaux.vna_other.get(endian) & elf::VERSYM_VERSION;
                     if index <= elf::VER_NDX_GLOBAL {
@@ -144,6 +152,7 @@ impl<'data, Elf: FileHeader> VersionTable<'data, Elf> {
                         name: vernaux.name(endian, strings)?,
                         hash: vernaux.vna_hash.get(endian),
                         valid: true,
+                        vn_file: Some(verneed.file(endian, strings)?),
                     };
                 }
             }

--- a/src/read/elf/version.rs
+++ b/src/read/elf/version.rs
@@ -40,7 +40,7 @@ pub struct Version<'data> {
     hash: u32,
     // Used to keep track of valid indices in `VersionTable`.
     valid: bool,
-    vn_file: Option<&'data [u8]>,
+    file: Option<&'data [u8]>,
 }
 
 impl<'data> Version<'data> {
@@ -54,10 +54,12 @@ impl<'data> Version<'data> {
         self.hash
     }
 
-    /// Return the `vn_file` field of the associated entry in [`elf::SHT_GNU_VERNEED`].
-    /// Returns `None` if the version info was parsed from a [`elf::SHT_GNU_VERDEF`] section.
-    pub fn vn_file(&self) -> Option<&'data [u8]> {
-        self.vn_file
+    /// Return the filename of the library containing this version.
+    ///
+    /// This is the `vn_file` field of the associated entry in [`elf::SHT_GNU_VERNEED`].
+    /// or `None` if the version info was parsed from a [`elf::SHT_GNU_VERDEF`] section.
+    pub fn file(&self) -> Option<&'data [u8]> {
+        self.file
     }
 }
 
@@ -135,7 +137,7 @@ impl<'data, Elf: FileHeader> VersionTable<'data, Elf> {
                         name: verdaux.name(endian, strings)?,
                         hash: verdef.vd_hash.get(endian),
                         valid: true,
-                        vn_file: None,
+                        file: None,
                     };
                 }
             }
@@ -152,7 +154,7 @@ impl<'data, Elf: FileHeader> VersionTable<'data, Elf> {
                         name: vernaux.name(endian, strings)?,
                         hash: vernaux.vna_hash.get(endian),
                         valid: true,
-                        vn_file: Some(verneed.file(endian, strings)?),
+                        file: Some(verneed.file(endian, strings)?),
                     };
                 }
             }


### PR DESCRIPTION
This change parses the library name for a dynamic symbol from the ELF symbol versioning table and removes a // TODO