### PR TITLE
read/macho: support Go's compression format

### DIFF
--- a/src/read/gnu_compression.rs
+++ b/src/read/gnu_compression.rs
@@ -1,0 +1,36 @@
+use crate::read::{self, Error, ReadError as _};
+use crate::{endian, CompressedFileRange, CompressionFormat, ReadRef, U32Bytes};
+
+// Attempt to parse the the CompressedFileRange for a section using the GNU-style
+// inline compression header format. This is used by the Go compiler in Mach-O files
+// as well as by the GNU linker in some ELF files.
+pub(super) fn compressed_file_range<'data, R: ReadRef<'data>>(
+    file_data: R,
+    section_offset: u64,
+    section_size: u64,
+) -> read::Result<CompressedFileRange> {
+    let mut offset = section_offset;
+    // Assume ZLIB-style uncompressed data is no more than 4GB to avoid accidentally
+    // huge allocations. This also reduces the chance of accidentally matching on a
+    // .debug_str that happens to start with "ZLIB".
+    let header = file_data
+        .read_bytes(&mut offset, 8)
+        .read_error("GNU compressed section is too short")?;
+    if header != b"ZLIB\0\0\0\0" {
+        return Err(Error("Invalid GNU compressed section header"));
+    }
+    let uncompressed_size = file_data
+        .read::<U32Bytes<_>>(&mut offset)
+        .read_error("GNU compressed section is too short")?
+        .get(endian::BigEndian)
+        .into();
+    let compressed_size = section_size
+        .checked_sub(offset - section_offset)
+        .read_error("GNU compressed section is too short")?;
+    Ok(CompressedFileRange {
+        format: CompressionFormat::Zlib,
+        offset,
+        compressed_size,
+        uncompressed_size,
+    })
+}

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -61,6 +61,9 @@ pub use read_cache::*;
 mod util;
 pub use util::*;
 
+#[cfg(any(feature = "elf", feature = "macho"))]
+mod gnu_compression;
+
 #[cfg(any(
     feature = "coff",
     feature = "elf",

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -121,16 +121,18 @@ pub trait Object<'data>: read::private::Sealed {
 
     /// Get the section named `section_name`, if such a section exists.
     ///
-    /// If `section_name` starts with a '.' then it is treated as a system section name,
-    /// and is compared using the conventions specific to the object file format. This
-    /// includes:
-    /// - if ".debug_str_offsets" is requested for a Mach-O object file, then the actual
-    /// section name that is searched for is "__debug_str_offs".
+    /// If `section_name` starts with a '.' then it is treated as a system
+    /// section name, and is compared using the conventions specific to the
+    /// object file format. This includes:
+    /// - if ".debug_str_offsets" is requested for a Mach-O object file, then
+    ///   the actual section name that is searched for is "__debug_str_offs".
     /// - if ".debug_info" is requested for an ELF object file, then
-    /// ".zdebug_info" may be returned (and similarly for other debug sections).
+    ///   ".zdebug_info" may be returned (and similarly for other debug
+    ///   sections). Similarly, if ".debug_info" is requested for a Mach-O
+    ///   object file, then "__zdebug_info" may be returned.
     ///
-    /// For some object files, multiple segments may contain sections with the same
-    /// name. In this case, the first matching section will be used.
+    /// For some object files, multiple segments may contain sections with the
+    /// same name. In this case, the first matching section will be used.
     ///
     /// This method skips over sections with invalid names.
     fn section_by_name(&self, section_name: &str) -> Option<Self::Section<'_>> {

--- a/tests/read/macho.rs
+++ b/tests/read/macho.rs
@@ -1,0 +1,49 @@
+#[cfg(feature = "std")]
+use object::{Object, ObjectSection as _};
+
+// Test that we can read compressed sections in Mach-O files as produced
+// by the Go compiler.
+#[cfg(feature = "std")]
+#[test]
+fn test_go_macho() {
+    let macho_testfiles = std::path::Path::new("testfiles/macho");
+
+    // Section names we expect to find, whether they should be
+    // compressed, and the actual name of the section in the file.
+    const EXPECTED: &[(&str, bool, &str)] = &[
+        (".debug_abbrev", true, "__zdebug_abbrev"),
+        (".debug_gdb_scripts", false, "__debug_gdb_scri"),
+        (".debug_ranges", true, "__zdebug_ranges"),
+        ("__data", false, "__data"),
+    ];
+
+    for file in &["go-aarch64", "go-x86_64"] {
+        let path = macho_testfiles.join(file);
+        let file = std::fs::File::open(path).unwrap();
+        let reader = object::read::ReadCache::new(file);
+        let object = object::read::File::parse(&reader).unwrap();
+        for &(name, compressed, actual_name) in EXPECTED {
+            let section = object.section_by_name(name).unwrap();
+            assert_eq!(section.name(), Ok(actual_name));
+            let compressed_file_range = section.compressed_file_range().unwrap();
+            let size = section.size();
+            if compressed {
+                assert_eq!(
+                    compressed_file_range.format,
+                    object::CompressionFormat::Zlib
+                );
+                assert_eq!(compressed_file_range.compressed_size, size - 12);
+                assert!(
+                    compressed_file_range.uncompressed_size > compressed_file_range.compressed_size,
+                    "decompressed size is greater than compressed size"
+                );
+            } else {
+                assert_eq!(
+                    compressed_file_range.format,
+                    object::CompressionFormat::None
+                );
+                assert_eq!(compressed_file_range.compressed_size, size);
+            }
+        }
+    }
+}

--- a/tests/read/mod.rs
+++ b/tests/read/mod.rs
@@ -2,3 +2,4 @@
 
 mod coff;
 mod elf;
+mod macho;


### PR DESCRIPTION
This PR adds support in the object crate for Go's format to compress Mach-O debug info sections. It contains two changes:

* The MachOFile now can match section names which contain both the `__` and `__z` prefix instead of a `.`.
* The MachOSection now detects the presence of the `__z` prefix and attempts to offer decompression when it detects the section is compressed using the Go compression scheme.

A third commit adds testing. This third commit will need to be rebased to update the testfiles commit once https://github.com/gimli-rs/object-testfiles/pull/14 is merged into the upstream.

Fixes https://github.com/gimli-rs/object/issues/696.