### PR TITLE
Reverse the order of emitting relocations on MachO

### DIFF
--- a/crates/examples/src/objcopy.rs
+++ b/crates/examples/src/objcopy.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::process;
 
 use object::{
-    write, Object, ObjectComdat, ObjectKind, ObjectSection, ObjectSymbol, RelocationTarget,
-    SectionKind, SymbolFlags, SymbolKind, SymbolSection,
+    write, BinaryFormat, Object, ObjectComdat, ObjectKind, ObjectSection, ObjectSymbol,
+    RelocationTarget, SectionKind, SymbolFlags, SymbolKind, SymbolSection,
 };
 
 /// An example of how to use the read and write APIs of the `object` crate
@@ -133,7 +133,11 @@ pub fn copy(in_data: &[u8]) -> Vec<u8> {
             continue;
         }
         let out_section = *out_sections.get(&in_section.index()).unwrap();
-        for (offset, in_relocation) in in_section.relocations() {
+        let mut relocations = in_section.relocations().collect::<Vec<_>>();
+        if in_object.format() == BinaryFormat::MachO {
+            relocations.reverse();
+        }
+        for (offset, in_relocation) in relocations {
             let symbol = match in_relocation.target() {
                 RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
                 RelocationTarget::Section(section) => {

--- a/crates/examples/src/objcopy.rs
+++ b/crates/examples/src/objcopy.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::process;
 
 use object::{
-    write, BinaryFormat, Object, ObjectComdat, ObjectKind, ObjectSection, ObjectSymbol,
-    RelocationTarget, SectionKind, SymbolFlags, SymbolKind, SymbolSection,
+    write, Object, ObjectComdat, ObjectKind, ObjectSection, ObjectSymbol, RelocationTarget,
+    SectionKind, SymbolFlags, SymbolKind, SymbolSection,
 };
 
 /// An example of how to use the read and write APIs of the `object` crate
@@ -133,11 +133,7 @@ pub fn copy(in_data: &[u8]) -> Vec<u8> {
             continue;
         }
         let out_section = *out_sections.get(&in_section.index()).unwrap();
-        let mut relocations = in_section.relocations().collect::<Vec<_>>();
-        if in_object.format() == BinaryFormat::MachO {
-            relocations.reverse();
-        }
-        for (offset, in_relocation) in relocations {
+        for (offset, in_relocation) in in_section.relocations() {
             let symbol = match in_relocation.target() {
                 RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
                 RelocationTarget::Section(section) => {

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -729,7 +729,10 @@ impl<'a> Object<'a> {
             if !section.relocations.is_empty() {
                 write_align(buffer, pointer_align);
                 debug_assert_eq!(section_offsets[index].reloc_offset, buffer.len());
-                for reloc in &section.relocations {
+                // Relocations are emitted in reverse order add_relocation is called as
+                // otherwise Apple's new linker crashes. This matches LLVM's behavior too:
+                // https://github.com/llvm/llvm-project/blob/e9b8cd0c8/llvm/lib/MC/MachObjectWriter.cpp#L1001-L1002
+                for reloc in section.relocations.iter().rev() {
                     let (r_type, r_pcrel, r_length) = if let RelocationFlags::MachO {
                         r_type,
                         r_pcrel,

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -729,10 +729,8 @@ impl<'a> Object<'a> {
             if !section.relocations.is_empty() {
                 write_align(buffer, pointer_align);
                 debug_assert_eq!(section_offsets[index].reloc_offset, buffer.len());
-                // Relocations are emitted in reverse order add_relocation is called as
-                // otherwise Apple's new linker crashes. This matches LLVM's behavior too:
-                // https://github.com/llvm/llvm-project/blob/e9b8cd0c8/llvm/lib/MC/MachObjectWriter.cpp#L1001-L1002
-                for reloc in section.relocations.iter().rev() {
+
+                let mut write_reloc = |reloc: &Relocation| {
                     let (r_type, r_pcrel, r_length) = if let RelocationFlags::MachO {
                         r_type,
                         r_pcrel,
@@ -786,6 +784,29 @@ impl<'a> Object<'a> {
                         r_type,
                     };
                     buffer.write(&reloc_info.relocation(endian));
+                    Ok(())
+                };
+
+                // Relocations are emitted in descending order as otherwise Apple's
+                // new linker crashes. This matches LLVM's behavior too:
+                // https://github.com/llvm/llvm-project/blob/e9b8cd0c8/llvm/lib/MC/MachObjectWriter.cpp#L1001-L1002
+                let need_reverse = |relocs: &[Relocation]| {
+                    let Some(first) = relocs.first() else {
+                        return false;
+                    };
+                    let Some(last) = relocs.last() else {
+                        return false;
+                    };
+                    first.offset < last.offset
+                };
+                if need_reverse(&section.relocations) {
+                    for reloc in section.relocations.iter().rev() {
+                        write_reloc(reloc)?;
+                    }
+                } else {
+                    for reloc in &section.relocations {
+                        write_reloc(reloc)?;
+                    }
                 }
             }
         }

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -454,18 +454,6 @@ fn macho_x86_64() {
 
     let (offset, relocation) = relocations.next().unwrap();
     println!("{:?}", relocation);
-    assert_eq!(offset, 8);
-    assert_eq!(relocation.kind(), RelocationKind::Absolute);
-    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
-    assert_eq!(relocation.size(), 64);
-    assert_eq!(
-        relocation.target(),
-        read::RelocationTarget::Symbol(func1_symbol)
-    );
-    assert_eq!(relocation.addend(), 0);
-
-    let (offset, relocation) = relocations.next().unwrap();
-    println!("{:?}", relocation);
     assert_eq!(offset, 16);
     assert_eq!(relocation.kind(), RelocationKind::Relative);
     assert_eq!(relocation.encoding(), RelocationEncoding::X86RipRelative);
@@ -475,6 +463,18 @@ fn macho_x86_64() {
         read::RelocationTarget::Symbol(func1_symbol)
     );
     assert_eq!(relocation.addend(), -4);
+
+    let (offset, relocation) = relocations.next().unwrap();
+    println!("{:?}", relocation);
+    assert_eq!(offset, 8);
+    assert_eq!(relocation.kind(), RelocationKind::Absolute);
+    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+    assert_eq!(relocation.size(), 64);
+    assert_eq!(
+        relocation.target(),
+        read::RelocationTarget::Symbol(func1_symbol)
+    );
+    assert_eq!(relocation.addend(), 0);
 
     let map = object.symbol_map();
     let symbol = map.get(func1_offset + 1).unwrap();
@@ -564,14 +564,6 @@ fn macho_any() {
 
         let mut relocations = data.relocations();
 
-        let (offset, relocation) = relocations.next().unwrap();
-        println!("{:?}", relocation);
-        assert_eq!(offset, 8);
-        assert_eq!(relocation.kind(), RelocationKind::Absolute);
-        assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
-        assert_eq!(relocation.size(), 32);
-        assert_eq!(relocation.addend(), 0);
-
         if arch.address_size().unwrap().bytes() >= 8 {
             let (offset, relocation) = relocations.next().unwrap();
             println!("{:?}", relocation);
@@ -581,6 +573,14 @@ fn macho_any() {
             assert_eq!(relocation.size(), 64);
             assert_eq!(relocation.addend(), 0);
         }
+
+        let (offset, relocation) = relocations.next().unwrap();
+        println!("{:?}", relocation);
+        assert_eq!(offset, 8);
+        assert_eq!(relocation.kind(), RelocationKind::Absolute);
+        assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+        assert_eq!(relocation.size(), 32);
+        assert_eq!(relocation.addend(), 0);
     }
 }
 

--- a/tests/round_trip/tls.rs
+++ b/tests/round_trip/tls.rs
@@ -260,7 +260,19 @@ fn macho_x86_64_tls() {
 
     let (offset, relocation) = relocations.next().unwrap();
     println!("{:?}", relocation);
-    assert_eq!(offset, 0);
+    assert_eq!(offset, 40);
+    assert_eq!(relocation.kind(), RelocationKind::Absolute);
+    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+    assert_eq!(relocation.size(), 64);
+    assert_eq!(
+        relocation.target(),
+        read::RelocationTarget::Symbol(tls2_init_symbol)
+    );
+    assert_eq!(relocation.addend(), 0);
+
+    let (offset, relocation) = relocations.next().unwrap();
+    println!("{:?}", relocation);
+    assert_eq!(offset, 24);
     assert_eq!(relocation.kind(), RelocationKind::Absolute);
     assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
     assert_eq!(relocation.size(), 64);
@@ -284,25 +296,13 @@ fn macho_x86_64_tls() {
 
     let (offset, relocation) = relocations.next().unwrap();
     println!("{:?}", relocation);
-    assert_eq!(offset, 24);
+    assert_eq!(offset, 0);
     assert_eq!(relocation.kind(), RelocationKind::Absolute);
     assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
     assert_eq!(relocation.size(), 64);
     assert_eq!(
         relocation.target(),
         read::RelocationTarget::Symbol(tlv_bootstrap_symbol)
-    );
-    assert_eq!(relocation.addend(), 0);
-
-    let (offset, relocation) = relocations.next().unwrap();
-    println!("{:?}", relocation);
-    assert_eq!(offset, 40);
-    assert_eq!(relocation.kind(), RelocationKind::Absolute);
-    assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
-    assert_eq!(relocation.size(), 64);
-    assert_eq!(
-        relocation.target(),
-        read::RelocationTarget::Symbol(tls2_init_symbol)
     );
     assert_eq!(relocation.addend(), 0);
 }


### PR DESCRIPTION
This prevents a crash of Apple's new linker.