### PR TITLE
read: implement Iterator for more types

### DIFF
--- a/src/read/elf/attributes.rs
+++ b/src/read/elf/attributes.rs
@@ -70,14 +70,14 @@ impl<'data, Elf: FileHeader> AttributesSubsectionIterator<'data, Elf> {
             return Ok(None);
         }
 
-        let result = self.parse();
+        let result = self.parse().map(Some);
         if result.is_err() {
             self.data = Bytes(&[]);
         }
         result
     }
 
-    fn parse(&mut self) -> Result<Option<AttributesSubsection<'data, Elf>>> {
+    fn parse(&mut self) -> Result<AttributesSubsection<'data, Elf>> {
         // First read the subsection length.
         let mut data = self.data;
         let length = data
@@ -94,16 +94,25 @@ impl<'data, Elf: FileHeader> AttributesSubsectionIterator<'data, Elf> {
         data.skip(4)
             .read_error("Invalid ELF attributes subsection length")?;
 
+        // TODO: errors here should not prevent reading the next subsection.
         let vendor = data
             .read_string()
             .read_error("Invalid ELF attributes vendor")?;
 
-        Ok(Some(AttributesSubsection {
+        Ok(AttributesSubsection {
             endian: self.endian,
             length,
             vendor,
             data,
-        }))
+        })
+    }
+}
+
+impl<'data, Elf: FileHeader> Iterator for AttributesSubsectionIterator<'data, Elf> {
+    type Item = Result<AttributesSubsection<'data, Elf>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
     }
 }
 
@@ -153,14 +162,14 @@ impl<'data, Elf: FileHeader> AttributesSubsubsectionIterator<'data, Elf> {
             return Ok(None);
         }
 
-        let result = self.parse();
+        let result = self.parse().map(Some);
         if result.is_err() {
             self.data = Bytes(&[]);
         }
         result
     }
 
-    fn parse(&mut self) -> Result<Option<AttributesSubsubsection<'data>>> {
+    fn parse(&mut self) -> Result<AttributesSubsubsection<'data>> {
         // The format of a sub-section looks like this:
         //
         // <file-tag> <size> <attribute>*
@@ -184,6 +193,7 @@ impl<'data, Elf: FileHeader> AttributesSubsubsectionIterator<'data, Elf> {
         data.skip(1 + 4)
             .read_error("Invalid ELF attributes sub-subsection length")?;
 
+        // TODO: errors here should not prevent reading the next sub-subsection.
         let indices = if tag == elf::Tag_Section || tag == elf::Tag_Symbol {
             data.read_string()
                 .map(Bytes)
@@ -194,12 +204,20 @@ impl<'data, Elf: FileHeader> AttributesSubsubsectionIterator<'data, Elf> {
             return Err(Error("Unimplemented ELF attributes sub-subsection tag"));
         };
 
-        Ok(Some(AttributesSubsubsection {
+        Ok(AttributesSubsubsection {
             tag,
             length,
             indices,
             data,
-        }))
+        })
+    }
+}
+
+impl<'data, Elf: FileHeader> Iterator for AttributesSubsubsectionIterator<'data, Elf> {
+    type Item = Result<AttributesSubsubsection<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
     }
 }
 
@@ -263,6 +281,15 @@ impl<'data> AttributeIndexIterator<'data> {
         if self.data.is_empty() {
             return Ok(None);
         }
+
+        let result = self.parse().map(Some);
+        if result.is_err() {
+            self.data = Bytes(&[]);
+        }
+        result
+    }
+
+    fn parse(&mut self) -> Result<u32> {
         let err = "Invalid ELF attribute index";
         self.data
             .read_uleb128()
@@ -270,7 +297,14 @@ impl<'data> AttributeIndexIterator<'data> {
             .try_into()
             .map_err(|_| ())
             .read_error(err)
-            .map(Some)
+    }
+}
+
+impl<'data> Iterator for AttributeIndexIterator<'data> {
+    type Item = Result<u32>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
     }
 }
 

--- a/src/read/elf/note.rs
+++ b/src/read/elf/note.rs
@@ -51,19 +51,28 @@ where
 
     /// Returns the next note.
     pub fn next(&mut self) -> read::Result<Option<Note<'data, Elf>>> {
-        let mut data = self.data;
-        if data.is_empty() {
+        if self.data.is_empty() {
             return Ok(None);
         }
 
-        let header = data
+        let result = self.parse().map(Some);
+        if result.is_err() {
+            self.data = Bytes(&[]);
+        }
+        result
+    }
+
+    fn parse(&mut self) -> read::Result<Note<'data, Elf>> {
+        let header = self
+            .data
             .read_at::<Elf::NoteHeader>(0)
             .read_error("ELF note is too short")?;
 
         // The name has no alignment requirement.
         let offset = mem::size_of::<Elf::NoteHeader>();
         let namesz = header.n_namesz(self.endian) as usize;
-        let name = data
+        let name = self
+            .data
             .read_bytes_at(offset, namesz)
             .read_error("Invalid ELF note namesz")?
             .0;
@@ -71,33 +80,27 @@ where
         // The descriptor must be aligned.
         let offset = util::align(offset + namesz, self.align);
         let descsz = header.n_descsz(self.endian) as usize;
-        let desc = data
+        let desc = self
+            .data
             .read_bytes_at(offset, descsz)
             .read_error("Invalid ELF note descsz")?
             .0;
 
         // The next note (if any) must be aligned.
         let offset = util::align(offset + descsz, self.align);
-        if data.skip(offset).is_err() {
-            data = Bytes(&[]);
+        if self.data.skip(offset).is_err() {
+            self.data = Bytes(&[]);
         }
-        self.data = data;
 
-        Ok(Some(Note { header, name, desc }))
+        Ok(Note { header, name, desc })
     }
 }
 
 impl<'data, Elf: FileHeader> Iterator for NoteIterator<'data, Elf> {
     type Item = read::Result<Note<'data, Elf>>;
+
     fn next(&mut self) -> Option<Self::Item> {
-        match self.next() {
-            Err(e) => {
-                self.data = Bytes(&[]);
-                Some(Err(e))
-            }
-            Ok(Some(v)) => Some(Ok(v)),
-            Ok(None) => None,
-        }
+        self.next().transpose()
     }
 }
 
@@ -238,20 +241,34 @@ pub struct GnuPropertyIterator<'data, Endian: endian::Endian> {
 impl<'data, Endian: endian::Endian> GnuPropertyIterator<'data, Endian> {
     /// Returns the next property.
     pub fn next(&mut self) -> read::Result<Option<GnuProperty<'data>>> {
-        let mut data = self.data;
-        if data.is_empty() {
+        if self.data.is_empty() {
             return Ok(None);
         }
 
+        let result = self.parse().map(Some);
+        if result.is_err() {
+            self.data = Bytes(&[]);
+        }
+        result
+    }
+
+    fn parse(&mut self) -> read::Result<GnuProperty<'data>> {
         (|| -> Result<_, ()> {
-            let pr_type = data.read_at::<U32<Endian>>(0)?.get(self.endian);
-            let pr_datasz = data.read_at::<U32<Endian>>(4)?.get(self.endian) as usize;
-            let pr_data = data.read_bytes_at(8, pr_datasz)?.0;
-            data.skip(util::align(8 + pr_datasz, self.align))?;
-            self.data = data;
-            Ok(Some(GnuProperty { pr_type, pr_data }))
+            let pr_type = self.data.read_at::<U32<Endian>>(0)?.get(self.endian);
+            let pr_datasz = self.data.read_at::<U32<Endian>>(4)?.get(self.endian) as usize;
+            let pr_data = self.data.read_bytes_at(8, pr_datasz)?.0;
+            self.data.skip(util::align(8 + pr_datasz, self.align))?;
+            Ok(GnuProperty { pr_type, pr_data })
         })()
         .read_error("Invalid ELF GNU property")
+    }
+}
+
+impl<'data, Endian: endian::Endian> Iterator for GnuPropertyIterator<'data, Endian> {
+    type Item = read::Result<GnuProperty<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
     }
 }
 

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -29,6 +29,17 @@ impl<'data, E: Endian> LoadCommandIterator<'data, E> {
         if self.ncmds == 0 {
             return Ok(None);
         }
+
+        let result = self.parse().map(Some);
+        if result.is_err() {
+            self.ncmds = 0;
+        } else {
+            self.ncmds -= 1;
+        }
+        result
+    }
+
+    fn parse(&mut self) -> Result<LoadCommandData<'data, E>> {
         let header = self
             .data
             .read_at::<macho::LoadCommand<E>>(0)
@@ -42,12 +53,19 @@ impl<'data, E: Endian> LoadCommandIterator<'data, E> {
             .data
             .read_bytes(cmdsize)
             .read_error("Invalid Mach-O load command size")?;
-        self.ncmds -= 1;
-        Ok(Some(LoadCommandData {
+        Ok(LoadCommandData {
             cmd,
             data,
             marker: Default::default(),
-        }))
+        })
+    }
+}
+
+impl<'data, E: Endian> Iterator for LoadCommandIterator<'data, E> {
+    type Item = Result<LoadCommandData<'data, E>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
     }
 }
 

--- a/src/read/pe/relocation.rs
+++ b/src/read/pe/relocation.rs
@@ -23,6 +23,15 @@ impl<'data> RelocationBlockIterator<'data> {
         if self.data.is_empty() {
             return Ok(None);
         }
+
+        let result = self.parse().map(Some);
+        if result.is_err() {
+            self.data = Bytes(&[]);
+        }
+        result
+    }
+
+    fn parse(&mut self) -> Result<RelocationIterator<'data>> {
         let header = self
             .data
             .read::<pe::ImageBaseRelocation>()
@@ -38,11 +47,19 @@ impl<'data> RelocationBlockIterator<'data> {
             .read_slice::<U16<LE>>(count as usize)
             .read_error("Invalid PE reloc block size")?
             .iter();
-        Ok(Some(RelocationIterator {
+        Ok(RelocationIterator {
             virtual_address,
             size,
             relocs,
-        }))
+        })
+    }
+}
+
+impl<'data> Iterator for RelocationBlockIterator<'data> {
+    type Item = Result<RelocationIterator<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
     }
 }
 


### PR DESCRIPTION
This also changes the underlying `next` methods to fuse on error.