### PR TITLE
Update `wasmparser` to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasmparser"
-version = "0.214.0"
+version = "0.215.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+checksum = "53fbde0881f24199b81cf49b6ff8f9c145ac8eb1b7fc439adb5c099734f7d90e"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ['doc']
 crc32fast = { version = "1.2", default-features = false, optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "2.0", default-features = false, optional = true }
-wasmparser = { version = "0.214.0", default-features = false, optional = true }
+wasmparser = { version = "0.215.0", default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
 hashbrown = { version = "0.14.0", features = ["ahash"], default-features = false, optional = true }
 ruzstd = { version = "0.7.0", optional = true }


### PR DESCRIPTION
The latest `wasmparser` includes a licensing change from Apache-2.0 with the LLVM exception to Apache-2.0 with the exception, or vanilla Apache-2.0, or MIT.

Update to the latest version, which makes figuring out licensing a bit easier for dependents of `object`.