### PR TITLE
Add new pe::IMAGE_FILE_MACHINE_ constants

### DIFF
--- a/src/pe.rs
+++ b/src/pe.rs
@@ -368,6 +368,10 @@ pub const IMAGE_FILE_MACHINE_RISCV32: u16 = 0x5032;
 pub const IMAGE_FILE_MACHINE_RISCV64: u16 = 0x5064;
 /// RISCV128
 pub const IMAGE_FILE_MACHINE_RISCV128: u16 = 0x5128;
+/// ARM64X (Mixed ARM64 and ARM64EC)
+pub const IMAGE_FILE_MACHINE_ARM64X: u16 = 0xA64E;
+/// CHPE x86 ("Compiled Hybrid Portable Executable")
+pub const IMAGE_FILE_MACHINE_CHPE_X86: u16 = 0x3A64;
 
 //
 // Directory format.


### PR DESCRIPTION
Listed in [`km/ntimage.h`](https://github.com/microsoft/wdkmetadata/blob/99192741981aa7b7dc7db4aca3401f5d20496c91/generation/WDK/IdlHeaders/km/ntimage.h#L245-L247)