### PR TITLE
write/coff: Set checksum for BSS section symbols

### DIFF
--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -654,10 +654,9 @@ impl<'a> Object<'a> {
                         length: section.size as u32,
                         number_of_relocations: section.relocations.len() as u32,
                         number_of_linenumbers: 0,
-                        check_sum: if section.is_bss() { 
-                            0 
-                        } 
-                        else {
+                        check_sum: if section.is_bss() {
+                            0
+                        } else {
                             checksum(section.data())
                         },
                         number: section_offsets[section_index].associative_section,

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -654,7 +654,12 @@ impl<'a> Object<'a> {
                         length: section.size as u32,
                         number_of_relocations: section.relocations.len() as u32,
                         number_of_linenumbers: 0,
-                        check_sum: checksum(section.data()),
+                        check_sum: if section.is_bss() { 
+                            0 
+                        } 
+                        else {
+                            checksum(section.data())
+                        },
                         number: section_offsets[section_index].associative_section,
                         selection: section_offsets[section_index].selection,
                     });

--- a/tests/round_trip/bss.rs
+++ b/tests/round_trip/bss.rs
@@ -13,6 +13,8 @@ fn coff_x86_64_bss() {
 
     let section = object.section_id(write::StandardSection::UninitializedData);
 
+    let _bss_section_symbol = object.section_symbol(section);
+
     let symbol = object.add_symbol(write::Symbol {
         name: b"v1".to_vec(),
         value: 0,
@@ -59,6 +61,16 @@ fn coff_x86_64_bss() {
     assert!(section.is_none(), "unexpected section {:?}", section);
 
     let mut symbols = object.symbols();
+
+    let section_symbol = symbols.next().unwrap();
+    println!("{:?}", section_symbol);
+    assert_eq!(section_symbol.name(), Ok(".bss"));
+    assert_eq!(section_symbol.kind(), SymbolKind::Section);
+    assert_eq!(section_symbol.section_index(), Some(bss_index));
+    assert_eq!(section_symbol.scope(), SymbolScope::Compilation);
+    assert!(!section_symbol.is_weak());
+    assert!(!section_symbol.is_undefined());
+    assert_eq!(section_symbol.address(), 0);
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);


### PR DESCRIPTION
Some compilers generate section symbols for the BSS section, which is then used with relocations in other sections.
This causes a panic on the current version since the checksum is done on `section.data()`, which fails the assertion `!self.is_bss()`.
With this, I am setting the checksum of a BSS section to 0, which it is also set to with the compiler I am using.