### PR TITLE
Add keep-error-msg feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ xcoff = []
 
 #=======================================
 # By default, support all read features.
-default = ["read", "compression"]
+default = ["read", "compression", "keep-error-msg"]
 
 #=======================================
 # Umbrella feature for enabling all user-facing features of this crate. Does not
@@ -110,6 +110,8 @@ unstable-all = ["all", "unstable"]
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
 rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc', 'memchr/rustc-dep-of-std']
+
+keep-error-msg = []
 
 [workspace]
 members = ["crates/*"]

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -1,4 +1,6 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
+#[cfg(feature = "keep-error-msg")]
+use alloc::string::ToString;
 use core::{fmt, result};
 #[cfg(feature = "std")]
 use std::error;
@@ -11,6 +13,7 @@ pub struct Error(#[cfg(feature = "keep-error-msg")] pub(crate) String);
 
 impl Error {
     #[inline(always)]
+    #[allow(dead_code)]
     pub(super) fn new(#[allow(unused_variables)] message: impl Into<String>) -> Self {
         Self(
             #[cfg(feature = "keep-error-msg")]
@@ -39,7 +42,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {}
 
 impl From<read::Error> for Error {
-    fn from(error: read::Error) -> Error {
+    fn from(#[allow(unused_variables)] error: read::Error) -> Error {
         Error(
             #[cfg(feature = "keep-error-msg")]
             error.0.to_string(),
@@ -48,7 +51,7 @@ impl From<read::Error> for Error {
 }
 
 impl From<write::Error> for Error {
-    fn from(error: write::Error) -> Error {
+    fn from(#[allow(unused_variables)] error: write::Error) -> Error {
         Error(
             #[cfg(feature = "keep-error-msg")]
             error.0,

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -262,7 +262,7 @@ impl<'data, R: ReadRef<'data>> File<'data, R> {
             #[cfg(feature = "xcoff")]
             FileKind::Xcoff64 => File::Xcoff64(xcoff::XcoffFile64::parse(data)?),
             #[allow(unreachable_patterns)]
-            _ => return Err(Error("Unsupported file format")),
+            _ => return Err(Error::new("Unsupported file format")),
         })
     }
 
@@ -278,7 +278,7 @@ impl<'data, R: ReadRef<'data>> File<'data, R> {
             Some(read::AddressSize::U32) => {
                 File::MachO32(macho::MachOFile32::parse_dyld_cache_image(image)?)
             }
-            _ => return Err(Error("Unsupported file format")),
+            _ => return Err(Error::new("Unsupported file format")),
         })
     }
 

--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -88,7 +88,7 @@ impl<'data, R: ReadRef<'data>> ArchiveFile<'data, R> {
         } else if magic == archive::MAGIC {
             false
         } else {
-            return Err(Error("Unsupported archive identifier"));
+            return Err(Error::new("Unsupported archive identifier"));
         };
 
         let mut members_offset = tail;
@@ -294,7 +294,7 @@ impl<'data, R: ReadRef<'data>> ArchiveFile<'data, R> {
         match self.members {
             Members::Common { offset, end_offset } => {
                 if member.0 < offset || member.0 >= end_offset {
-                    return Err(Error("Invalid archive member offset"));
+                    return Err(Error::new("Invalid archive member offset"));
                 }
                 let mut offset = member.0;
                 ArchiveMember::parse(self.data, &mut offset, self.names, self.thin)
@@ -393,7 +393,7 @@ impl<'data> ArchiveMember<'data> {
             .read::<archive::Header>(offset)
             .read_error("Invalid archive member header")?;
         if header.terminator != archive::TERMINATOR {
-            return Err(Error("Invalid archive terminator"));
+            return Err(Error::new("Invalid archive terminator"));
         }
 
         let header_file_size =
@@ -484,7 +484,7 @@ impl<'data> ArchiveMember<'data> {
             .read_bytes(&mut offset, 2)
             .read_error("Invalid AIX big archive terminator")?;
         if terminator != archive::TERMINATOR {
-            return Err(Error("Invalid AIX big archive terminator"));
+            return Err(Error::new("Invalid AIX big archive terminator"));
         }
 
         let size = parse_u64_digits(&header.size, 10)

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -372,7 +372,7 @@ impl CoffHeader for pe::AnonObjectHeaderBigobj {
             || header.version.get(LE) < 2
             || header.class_id != pe::ANON_OBJECT_HEADER_BIGOBJ_CLASS_ID
         {
-            return Err(read::Error("Invalid COFF bigobj header values"));
+            return Err(read::Error::new("Invalid COFF bigobj header values"));
         }
 
         // TODO: maybe validate that the machine is known?

--- a/src/read/coff/import.rs
+++ b/src/read/coff/import.rs
@@ -47,7 +47,7 @@ impl<'data> ImportFile<'data> {
                 pe::IMPORT_OBJECT_CODE => ImportType::Code,
                 pe::IMPORT_OBJECT_DATA => ImportType::Data,
                 pe::IMPORT_OBJECT_CONST => ImportType::Const,
-                _ => return Err(Error("Invalid COFF import library import type")),
+                _ => return Err(Error::new("Invalid COFF import library import type")),
             },
             import: match header.name_type() {
                 pe::IMPORT_OBJECT_ORDINAL => None,
@@ -60,7 +60,7 @@ impl<'data> ImportFile<'data> {
                         .unwrap(),
                 ),
                 pe::IMPORT_OBJECT_NAME_EXPORTAS => data.export(),
-                _ => return Err(Error("Unknown COFF import library name type")),
+                _ => return Err(Error::new("Unknown COFF import library name type")),
             }
             .map(ByteString),
         })
@@ -139,9 +139,9 @@ impl pe::ImportObjectHeader {
             .read::<pe::ImportObjectHeader>(offset)
             .read_error("Invalid COFF import library header size")?;
         if header.sig1.get(LE) != 0 || header.sig2.get(LE) != pe::IMPORT_OBJECT_HDR_SIG2 {
-            Err(Error("Invalid COFF import library header"))
+            Err(Error::new("Invalid COFF import library header"))
         } else if header.version.get(LE) != 0 {
-            Err(Error("Unknown COFF import library header version"))
+            Err(Error::new("Unknown COFF import library header version"))
         } else {
             Ok(header)
         }

--- a/src/read/coff/section.rs
+++ b/src/read/coff/section.rs
@@ -468,7 +468,7 @@ impl pe::ImageSectionHeader {
                     b'0'..=b'9' => byte - b'0' + 52,
                     b'+' => 62,
                     b'/' => 63,
-                    _ => return Err(Error("Invalid COFF section name base-64 offset")),
+                    _ => return Err(Error::new("Invalid COFF section name base-64 offset")),
                 };
                 offset = offset * 64 + digit as u64;
             }
@@ -482,7 +482,7 @@ impl pe::ImageSectionHeader {
                 let digit = match byte {
                     b'0'..=b'9' => byte - b'0',
                     0 => break,
-                    _ => return Err(Error("Invalid COFF section name base-10 offset")),
+                    _ => return Err(Error::new("Invalid COFF section name base-10 offset")),
                 };
                 offset = offset * 10 + digit as u32;
             }
@@ -583,7 +583,7 @@ impl pe::ImageSectionHeader {
                 .read_error("Invalid COFF relocation offset or number")?;
             number = extended_relocation_info.virtual_address.get(LE) as usize;
             if number == 0 {
-                return Err(Error("Invalid COFF relocation number"));
+                return Err(Error::new("Invalid COFF relocation number"));
             }
             pointer += core::mem::size_of::<pe::ImageRelocation>() as u64;
             // Extended relocation info does not contribute to the count of sections.

--- a/src/read/elf/attributes.rs
+++ b/src/read/elf/attributes.rs
@@ -46,7 +46,7 @@ impl<'data, Elf: FileHeader> AttributesSection<'data, Elf> {
     pub fn subsections(&self) -> Result<AttributesSubsectionIterator<'data, Elf>> {
         // There is currently only one format version.
         if self.version != b'A' {
-            return Err(Error("Unsupported ELF attributes section version"));
+            return Err(Error::new("Unsupported ELF attributes section version"));
         }
 
         Ok(AttributesSubsectionIterator {
@@ -201,7 +201,9 @@ impl<'data, Elf: FileHeader> AttributesSubsubsectionIterator<'data, Elf> {
         } else if tag == elf::Tag_File {
             Bytes(&[])
         } else {
-            return Err(Error("Unimplemented ELF attributes sub-subsection tag"));
+            return Err(Error::new(
+                "Unimplemented ELF attributes sub-subsection tag",
+            ));
         };
 
         Ok(AttributesSubsubsection {

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -529,7 +529,7 @@ pub trait FileHeader: Debug + Pod {
             .read_at::<Self>(0)
             .read_error("Invalid ELF header size or alignment")?;
         if !header.is_supported() {
-            return Err(Error("Unsupported ELF header"));
+            return Err(Error::new("Unsupported ELF header"));
         }
         // TODO: Check self.e_ehsize?
         Ok(header)
@@ -585,7 +585,7 @@ pub trait FileHeader: Debug + Pod {
         let shentsize = usize::from(self.e_shentsize(endian));
         if shentsize != mem::size_of::<Self::SectionHeader>() {
             // Section header size must match.
-            return Err(Error("Invalid ELF section header entry size"));
+            return Err(Error::new("Invalid ELF section header entry size"));
         }
         data.read_at(shoff)
             .map(Some)
@@ -607,7 +607,9 @@ pub trait FileHeader: Debug + Pod {
             Ok(section_0.sh_info(endian) as usize)
         } else {
             // Section 0 must exist if e_phnum overflows.
-            Err(Error("Missing ELF section headers for e_phnum overflow"))
+            Err(Error::new(
+                "Missing ELF section headers for e_phnum overflow",
+            ))
         }
     }
 
@@ -650,10 +652,12 @@ pub trait FileHeader: Debug + Pod {
             section_0.sh_link(endian)
         } else {
             // Section 0 must exist if we're trying to read e_shstrndx.
-            return Err(Error("Missing ELF section headers for e_shstrndx overflow"));
+            return Err(Error::new(
+                "Missing ELF section headers for e_shstrndx overflow",
+            ));
         };
         if index == 0 {
-            return Err(Error("Missing ELF e_shstrndx"));
+            return Err(Error::new("Missing ELF e_shstrndx"));
         }
         Ok(index)
     }
@@ -680,7 +684,7 @@ pub trait FileHeader: Debug + Pod {
         let phentsize = self.e_phentsize(endian) as usize;
         if phentsize != mem::size_of::<Self::ProgramHeader>() {
             // Program header size must match.
-            return Err(Error("Invalid ELF program header entry size"));
+            return Err(Error::new("Invalid ELF program header entry size"));
         }
         data.read_slice_at(phoff, phnum)
             .read_error("Invalid ELF program header size or alignment")
@@ -708,7 +712,7 @@ pub trait FileHeader: Debug + Pod {
         let shentsize = usize::from(self.e_shentsize(endian));
         if shentsize != mem::size_of::<Self::SectionHeader>() {
             // Section header size must match.
-            return Err(Error("Invalid ELF section header entry size"));
+            return Err(Error::new("Invalid ELF section header entry size"));
         }
         data.read_slice_at(shoff, shnum)
             .read_error("Invalid ELF section header offset/size/alignment")

--- a/src/read/elf/note.rs
+++ b/src/read/elf/note.rs
@@ -39,7 +39,7 @@ where
         let align = match align.into() {
             0u64..=4 => 4,
             8 => 8,
-            _ => return Err(Error("Invalid ELF note alignment")),
+            _ => return Err(Error::new("Invalid ELF note alignment")),
         };
         // TODO: check data alignment?
         Ok(NoteIterator {

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -45,14 +45,14 @@ impl RelocationSections {
                     continue;
                 }
                 if sh_info.0 >= relocations.len() {
-                    return Err(Error("Invalid ELF sh_info for relocation section"));
+                    return Err(Error::new("Invalid ELF sh_info for relocation section"));
                 }
 
                 // We don't support relocations that apply to other relocation sections
                 // because it interferes with the chaining of relocation sections below.
                 let sh_info_type = sections.section(sh_info)?.sh_type(endian);
                 if sh_info_type == elf::SHT_REL || sh_info_type == elf::SHT_RELA {
-                    return Err(Error("Unsupported ELF sh_info for relocation section"));
+                    return Err(Error::new("Unsupported ELF sh_info for relocation section"));
                 }
 
                 // Handle multiple relocation sections by chaining them.

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -82,7 +82,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SectionTable<'data, Elf, R> {
     /// Returns an error for the null section at index 0.
     pub fn section(&self, index: SectionIndex) -> read::Result<&'data Elf::SectionHeader> {
         if index == SectionIndex(0) {
-            return Err(read::Error("Invalid ELF section index"));
+            return Err(read::Error::new("Invalid ELF section index"));
         }
         self.sections
             .get(index.0)
@@ -162,7 +162,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SectionTable<'data, Elf, R> {
         let section = self.section(index)?;
         match section.sh_type(endian) {
             elf::SHT_DYNSYM | elf::SHT_SYMTAB => {}
-            _ => return Err(Error("Invalid ELF symbol table section type")),
+            _ => return Err(Error::new("Invalid ELF symbol table section type")),
         }
         SymbolTable::parse(endian, data, self, index, section)
     }
@@ -433,7 +433,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ElfSection<'data, 'file, 
             return Ok(None);
         };
         if self.file.relocations.get(relocation_index).is_some() {
-            return Err(Error(
+            return Err(Error::new(
                 "Unsupported ELF section with multiple relocation sections",
             ));
         }
@@ -495,7 +495,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ElfSection<'data, 'file, 
             let format = match header.ch_type(endian) {
                 elf::ELFCOMPRESS_ZLIB => CompressionFormat::Zlib,
                 elf::ELFCOMPRESS_ZSTD => CompressionFormat::Zstandard,
-                _ => return Err(Error("Unsupported ELF compression type")),
+                _ => return Err(Error::new("Unsupported ELF compression type")),
             };
             let uncompressed_size = header.ch_size(endian).into();
             Ok(Some(CompressedFileRange {

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -154,7 +154,7 @@ impl<'data, Elf: FileHeader, R: ReadRef<'data>> SymbolTable<'data, Elf, R> {
     /// Returns an error for null entry at index 0.
     pub fn symbol(&self, index: SymbolIndex) -> read::Result<&'data Elf::Sym> {
         if index == SymbolIndex(0) {
-            return Err(read::Error("Invalid ELF symbol index"));
+            return Err(read::Error::new("Invalid ELF symbol index"));
         }
         self.symbols
             .get(index.0)

--- a/src/read/gnu_compression.rs
+++ b/src/read/gnu_compression.rs
@@ -17,7 +17,7 @@ pub(super) fn compressed_file_range<'data, R: ReadRef<'data>>(
         .read_bytes(&mut offset, 8)
         .read_error("GNU compressed section is too short")?;
     if header != b"ZLIB\0\0\0\0" {
-        return Err(Error("Invalid GNU compressed section header"));
+        return Err(Error::new("Invalid GNU compressed section header"));
     }
     let uncompressed_size = file_data
         .read::<U32Bytes<_>>(&mut offset)

--- a/src/read/macho/fat.rs
+++ b/src/read/macho/fat.rs
@@ -35,7 +35,7 @@ impl<'data, Fat: FatArch> MachOFatFile<'data, Fat> {
             .read::<FatHeader>(&mut offset)
             .read_error("Invalid fat header size or alignment")?;
         if header.magic.get(BigEndian) != Fat::MAGIC {
-            return Err(Error("Invalid fat magic"));
+            return Err(Error::new("Invalid fat magic"));
         }
         let arches = data
             .read_slice::<Fat>(&mut offset, header.nfat_arch.get(BigEndian) as usize)

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -637,7 +637,7 @@ pub trait MachHeader: Debug + Pod {
             .read_at::<Self>(offset)
             .read_error("Invalid Mach-O header size or alignment")?;
         if !header.is_supported() {
-            return Err(Error("Unsupported Mach-O header"));
+            return Err(Error::new("Unsupported Mach-O header"));
         }
         Ok(header)
     }

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -47,7 +47,7 @@ impl<'data, E: Endian> LoadCommandIterator<'data, E> {
         let cmd = header.cmd.get(self.endian);
         let cmdsize = header.cmdsize.get(self.endian) as usize;
         if cmdsize < mem::size_of::<macho::LoadCommand<E>>() {
-            return Err(Error("Invalid Mach-O load command size"));
+            return Err(Error::new("Invalid Mach-O load command size"));
         }
         let data = self
             .data

--- a/src/read/pe/data_directory.rs
+++ b/src/read/pe/data_directory.rs
@@ -187,7 +187,7 @@ impl pe::ImageDataDirectory {
             .read_error("Invalid data dir virtual address")?;
         let size = self.size.get(LE);
         if size > section_size {
-            return Err(Error("Invalid data dir size"));
+            return Err(Error::new("Invalid data dir size"));
         }
         Ok((offset, size))
     }

--- a/src/read/pe/export.rs
+++ b/src/read/pe/export.rs
@@ -116,7 +116,7 @@ impl<'data> ExportTable<'data> {
         let address_of_name_ordinals = directory.address_of_name_ordinals.get(LE);
         if address_of_names != 0 {
             if address_of_name_ordinals == 0 {
-                return Err(Error("Missing PE export ordinal table"));
+                return Err(Error::new("Missing PE export ordinal table"));
             }
 
             let number = directory.number_of_names.get(LE) as usize;
@@ -247,7 +247,7 @@ impl<'data> ExportTable<'data> {
                     ExportTarget::ForwardByOrdinal(library, ordinal)
                 }
                 [] => {
-                    return Err(Error("Missing PE forwarded export name"));
+                    return Err(Error::new("Missing PE forwarded export name"));
                 }
                 name => ExportTarget::ForwardByName(library, name),
             }

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -513,7 +513,7 @@ impl pe::ImageDosHeader {
             .read_at::<pe::ImageDosHeader>(0)
             .read_error("Invalid DOS header size or alignment")?;
         if dos_header.e_magic.get(LE) != pe::IMAGE_DOS_SIGNATURE {
-            return Err(Error("Invalid DOS magic"));
+            return Err(Error::new("Invalid DOS magic"));
         }
         Ok(dos_header)
     }
@@ -539,7 +539,7 @@ pub fn optional_header_magic<'data, R: ReadRef<'data>>(data: R) -> Result<u16> {
         .read_at::<pe::ImageNtHeaders32>(offset)
         .read_error("Invalid NT headers offset, size, or alignment")?;
     if nt_headers.signature() != pe::IMAGE_NT_SIGNATURE {
-        return Err(Error("Invalid PE magic"));
+        return Err(Error::new("Invalid PE magic"));
     }
     Ok(nt_headers.optional_header().magic())
 }
@@ -586,10 +586,10 @@ pub trait ImageNtHeaders: Debug + Pod {
             .read::<Self>(offset)
             .read_error("Invalid PE headers offset or size")?;
         if nt_headers.signature() != pe::IMAGE_NT_SIGNATURE {
-            return Err(Error("Invalid PE magic"));
+            return Err(Error::new("Invalid PE magic"));
         }
         if !nt_headers.is_valid_optional_magic() {
-            return Err(Error("Invalid PE optional header magic"));
+            return Err(Error::new("Invalid PE optional header magic"));
         }
 
         // Read the rest of the optional header, and then read the data directories from that.

--- a/src/read/pe/relocation.rs
+++ b/src/read/pe/relocation.rs
@@ -39,7 +39,7 @@ impl<'data> RelocationBlockIterator<'data> {
         let virtual_address = header.virtual_address.get(LE);
         let size = header.size_of_block.get(LE);
         if size <= 8 || size & 3 != 0 {
-            return Err(Error("Invalid PE reloc block size"));
+            return Err(Error::new("Invalid PE reloc block size"));
         }
         let count = (size - 8) / 2;
         let relocs = self

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -116,7 +116,7 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
             match payload {
                 wp::Payload::Version { encoding, .. } => {
                     if encoding != wp::Encoding::Module {
-                        return Err(Error("Unsupported Wasm encoding"));
+                        return Err(Error::new("Unsupported Wasm encoding"));
                     }
                 }
                 wp::Payload::TypeSection(section) => {

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -293,7 +293,7 @@ pub trait FileHeader: Debug + Pod {
             .read::<Self>(offset)
             .read_error("Invalid XCOFF header size or alignment")?;
         if !header.is_supported() {
-            return Err(Error("Unsupported XCOFF header"));
+            return Err(Error::new("Unsupported XCOFF header"));
         }
         Ok(header)
     }

--- a/src/read/xcoff/section.rs
+++ b/src/read/xcoff/section.rs
@@ -389,7 +389,7 @@ impl SectionHeader for xcoff::SectionHeader32 {
         // and an STYP_OVRFLO section header will contain the actual count of relocation entries in
         // the s_paddr field.
         if reloc_num == 65535 {
-            return Err(Error("Overflow section is not supported yet."));
+            return Err(Error::new("Overflow section is not supported yet."));
         }
         data.read_slice_at(self.s_relptr().into(), reloc_num)
             .read_error("Invalid XCOFF relocation offset or number")

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -131,7 +131,7 @@ where
     pub fn symbol(&self, index: SymbolIndex) -> Result<&'data Xcoff::Symbol> {
         let symbol = self.symbol_unchecked(index)?;
         if symbol.is_null() {
-            return Err(Error("Invalid XCOFF symbol index"));
+            return Err(Error::new("Invalid XCOFF symbol index"));
         }
         Ok(symbol)
     }
@@ -142,7 +142,7 @@ where
         let aux_file = self.get::<Xcoff::FileAux>(index, offset)?;
         if let Some(aux_type) = aux_file.x_auxtype() {
             if aux_type != xcoff::AUX_FILE {
-                return Err(Error("Invalid index for file auxiliary symbol."));
+                return Err(Error::new("Invalid index for file auxiliary symbol."));
             }
         }
         Ok(aux_file)
@@ -154,7 +154,9 @@ where
         let aux_csect = self.get::<Xcoff::CsectAux>(index, offset)?;
         if let Some(aux_type) = aux_csect.x_auxtype() {
             if aux_type != xcoff::AUX_CSECT {
-                return Err(Error("Invalid index/offset for csect auxiliary symbol."));
+                return Err(Error::new(
+                    "Invalid index/offset for csect auxiliary symbol.",
+                ));
             }
         }
         Ok(aux_csect)

--- a/src/write/coff/writer.rs
+++ b/src/write/coff/writer.rs
@@ -128,7 +128,7 @@ impl<'a> Writer<'a> {
         // Start writing.
         self.buffer
             .reserve(self.len)
-            .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+            .map_err(|_| Error::new(String::from("Cannot allocate buffer")))?;
 
         // Write file header.
         let header = pe::ImageFileHeader {

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -148,7 +148,7 @@ impl<'a> Object<'a> {
             Architecture::Sparc64 => true,
             Architecture::Xtensa => true,
             _ => {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unimplemented architecture {:?}",
                     self.architecture
                 )));
@@ -171,7 +171,12 @@ impl<'a> Object<'a> {
             return Ok(());
         };
 
-        let unsupported_reloc = || Err(Error(format!("unimplemented ELF relocation {:?}", reloc)));
+        let unsupported_reloc = || {
+            Err(Error::new(format!(
+                "unimplemented ELF relocation {:?}",
+                reloc
+            )))
+        };
         let r_type = match self.architecture {
             Architecture::Aarch64 => match (kind, encoding, size) {
                 (K::Absolute, E::Generic, 64) => elf::R_AARCH64_ABS64,
@@ -346,7 +351,7 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             _ => {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unimplemented architecture {:?}",
                     self.architecture
                 )));
@@ -366,7 +371,7 @@ impl<'a> Object<'a> {
         let r_type = if let RelocationFlags::Elf { r_type } = reloc.flags {
             r_type
         } else {
-            return Err(Error("invalid relocation flags".into()));
+            return Err(Error::new("invalid relocation flags"));
         };
         // This only needs to support architectures that use implicit addends.
         let size = match self.architecture {
@@ -403,13 +408,13 @@ impl<'a> Object<'a> {
                 _ => None,
             },
             _ => {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unimplemented architecture {:?}",
                     self.architecture
                 )));
             }
         };
-        size.ok_or_else(|| Error(format!("unsupported relocation for size {:?}", reloc)))
+        size.ok_or_else(|| Error::new(format!("unsupported relocation for size {:?}", reloc)))
     }
 
     pub(crate) fn elf_is_64(&self) -> bool {
@@ -449,7 +454,7 @@ impl<'a> Object<'a> {
         let mut comdat_offsets = Vec::with_capacity(self.comdats.len());
         for comdat in &self.comdats {
             if comdat.kind != ComdatKind::Any {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unsupported COMDAT symbol `{}` kind {:?}",
                     self.symbols[comdat.symbol.0].name().unwrap_or(""),
                     comdat.kind
@@ -558,7 +563,7 @@ impl<'a> Object<'a> {
             (Architecture::Sparc64, None) => elf::EM_SPARCV9,
             (Architecture::Xtensa, None) => elf::EM_XTENSA,
             _ => {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unimplemented architecture {:?} with sub-architecture {:?}",
                     self.architecture, self.sub_architecture
                 )));
@@ -627,7 +632,7 @@ impl<'a> Object<'a> {
                         if symbol.is_undefined() {
                             elf::STT_NOTYPE
                         } else {
-                            return Err(Error(format!(
+                            return Err(Error::new(format!(
                                 "unimplemented symbol `{}` kind {:?}",
                                 symbol.name().unwrap_or(""),
                                 symbol.kind
@@ -696,7 +701,7 @@ impl<'a> Object<'a> {
                     let r_type = if let RelocationFlags::Elf { r_type } = reloc.flags {
                         r_type
                     } else {
-                        return Err(Error("invalid relocation flags".into()));
+                        return Err(Error::new("invalid relocation flags"));
                     };
                     let r_sym = symbol_offsets[reloc.symbol.0].index.0;
                     writer.write_relocation(
@@ -759,7 +764,7 @@ impl<'a> Object<'a> {
                     | SectionKind::Note
                     | SectionKind::Elf(_) => 0,
                     SectionKind::Unknown | SectionKind::Common | SectionKind::TlsVariables => {
-                        return Err(Error(format!(
+                        return Err(Error::new(format!(
                             "unimplemented section `{}` kind {:?}",
                             section.name().unwrap_or(""),
                             section.kind

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -294,7 +294,7 @@ impl<'a> Writer<'a> {
         // Start writing.
         self.buffer
             .reserve(self.len)
-            .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+            .map_err(|_| Error::new(String::from("Cannot allocate buffer")))?;
 
         // Write file header.
         let e_ident = elf::Ident {

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -267,9 +267,9 @@ impl<'a> Object<'a> {
             16 => 1,
             32 => 2,
             64 => 3,
-            _ => return Err(Error(format!("unimplemented reloc size {:?}", reloc))),
+            _ => return Err(Error::new(format!("unimplemented reloc size {:?}", reloc))),
         };
-        let unsupported_reloc = || Err(Error(format!("unimplemented relocation {:?}", reloc)));
+        let unsupported_reloc = || Err(Error::new(format!("unimplemented relocation {:?}", reloc)));
         let (r_pcrel, r_type) = match self.architecture {
             Architecture::I386 => match kind {
                 K::Absolute => (false, macho::GENERIC_RELOC_VANILLA),
@@ -291,7 +291,7 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             _ => {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unimplemented architecture {:?}",
                     self.architecture
                 )));
@@ -312,7 +312,10 @@ impl<'a> Object<'a> {
         {
             (r_type, r_pcrel)
         } else {
-            return Err(Error(format!("invalid relocation flags {:?}", relocation)));
+            return Err(Error::new(format!(
+                "invalid relocation flags {:?}",
+                relocation
+            )));
         };
         if r_pcrel {
             // For PC relative relocations on some architectures, the
@@ -351,7 +354,7 @@ impl<'a> Object<'a> {
         if let RelocationFlags::MachO { r_length, .. } = reloc.flags {
             Ok(8 << r_length)
         } else {
-            Err(Error("invalid relocation flags".into()))
+            Err(Error::new("invalid relocation flags"))
         }
     }
 
@@ -444,7 +447,7 @@ impl<'a> Object<'a> {
                 SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls | SymbolKind::Unknown => {}
                 SymbolKind::File | SymbolKind::Section => continue,
                 SymbolKind::Label => {
-                    return Err(Error(format!(
+                    return Err(Error::new(format!(
                         "unimplemented symbol `{}` kind {:?}",
                         symbol.name().unwrap_or(""),
                         symbol.kind
@@ -511,7 +514,7 @@ impl<'a> Object<'a> {
         // Start writing.
         buffer
             .reserve(offset)
-            .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+            .map_err(|_| Error::new(String::from("Cannot allocate buffer")))?;
 
         // Write file header.
         let (cputype, mut cpusubtype) = match (self.architecture, self.sub_architecture) {
@@ -532,7 +535,7 @@ impl<'a> Object<'a> {
                 (macho::CPU_TYPE_POWERPC64, macho::CPU_SUBTYPE_POWERPC_ALL)
             }
             _ => {
-                return Err(Error(format!(
+                return Err(Error::new(format!(
                     "unimplemented architecture {:?} with sub-architecture {:?}",
                     self.architecture, self.sub_architecture
                 )));
@@ -586,7 +589,7 @@ impl<'a> Object<'a> {
             sectname
                 .get_mut(..section.name.len())
                 .ok_or_else(|| {
-                    Error(format!(
+                    Error::new(format!(
                         "section name `{}` is too long",
                         section.name().unwrap_or(""),
                     ))
@@ -596,7 +599,7 @@ impl<'a> Object<'a> {
             segname
                 .get_mut(..section.segment.len())
                 .ok_or_else(|| {
-                    Error(format!(
+                    Error::new(format!(
                         "segment name `{}` is too long",
                         section.segment().unwrap_or(""),
                     ))
@@ -620,7 +623,7 @@ impl<'a> Object<'a> {
                     SectionKind::OtherString => macho::S_CSTRING_LITERALS,
                     SectionKind::Other | SectionKind::Linker | SectionKind::Metadata => 0,
                     SectionKind::Note | SectionKind::Unknown | SectionKind::Elf(_) => {
-                        return Err(Error(format!(
+                        return Err(Error::new(format!(
                             "unimplemented section `{}` kind {:?}",
                             section.name().unwrap_or(""),
                             section.kind
@@ -722,7 +725,7 @@ impl<'a> Object<'a> {
                     {
                         (r_type, r_pcrel, r_length)
                     } else {
-                        return Err(Error("invalid relocation flags".into()));
+                        return Err(Error::new("invalid relocation flags"));
                     };
 
                     // Write explicit addend.
@@ -732,7 +735,10 @@ impl<'a> Object<'a> {
                                 macho::ARM64_RELOC_ADDEND
                             }
                             _ => {
-                                return Err(Error(format!("unimplemented relocation {:?}", reloc)))
+                                return Err(Error::new(format!(
+                                    "unimplemented relocation {:?}",
+                                    reloc
+                                )))
                             }
                         };
 
@@ -810,7 +816,7 @@ impl<'a> Object<'a> {
                 SymbolSection::Absolute => (macho::N_ABS, 0),
                 SymbolSection::Section(id) => (macho::N_SECT, id.0 + 1),
                 SymbolSection::None | SymbolSection::Common => {
-                    return Err(Error(format!(
+                    return Err(Error::new(format!(
                         "unimplemented symbol `{}` section {:?}",
                         symbol.name().unwrap_or(""),
                         symbol.section

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -10,6 +10,7 @@
 //! and [PE](pe::Writer).
 
 use alloc::borrow::Cow;
+#[cfg(feature = "keep-error-msg")]
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::{fmt, result, str};

--- a/src/write/pe.rs
+++ b/src/write/pe.rs
@@ -194,7 +194,7 @@ impl<'a> Writer<'a> {
         // Start writing.
         self.buffer
             .reserve(self.len as usize)
-            .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+            .map_err(|_| Error::new(String::from("Cannot allocate buffer")))?;
 
         self.buffer.write(dos_header);
         Ok(())

--- a/src/write/xcoff.rs
+++ b/src/write/xcoff.rs
@@ -83,7 +83,7 @@ impl<'a> Object<'a> {
             RelocationKind::Relative => xcoff::R_REL,
             RelocationKind::Got => xcoff::R_TOC,
             _ => {
-                return Err(Error(format!("unimplemented relocation {:?}", reloc)));
+                return Err(Error::new(format!("unimplemented relocation {:?}", reloc)));
             }
         };
         let r_rsize = size - 1;
@@ -95,7 +95,10 @@ impl<'a> Object<'a> {
         let r_rtype = if let RelocationFlags::Xcoff { r_rtype, .. } = relocation.flags {
             r_rtype
         } else {
-            return Err(Error(format!("invalid relocation flags {:?}", relocation)));
+            return Err(Error::new(format!(
+                "invalid relocation flags {:?}",
+                relocation
+            )));
         };
         if r_rtype == xcoff::R_REL {
             relocation.addend += 4;
@@ -107,7 +110,7 @@ impl<'a> Object<'a> {
         let r_rsize = if let RelocationFlags::Xcoff { r_rsize, .. } = reloc.flags {
             r_rsize
         } else {
-            return Err(Error(format!("unexpected relocation {:?}", reloc)));
+            return Err(Error::new(format!("unexpected relocation {:?}", reloc)));
         };
         Ok(r_rsize + 1)
     }
@@ -205,7 +208,7 @@ impl<'a> Object<'a> {
                         }
                     }
                     SymbolKind::Section | SymbolKind::Label | SymbolKind::Unknown => {
-                        return Err(Error(format!(
+                        return Err(Error::new(format!(
                             "unimplemented symbol `{}` kind {:?}",
                             symbol.name().unwrap_or(""),
                             symbol.kind
@@ -255,7 +258,7 @@ impl<'a> Object<'a> {
         // Start writing.
         buffer
             .reserve(offset)
-            .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+            .map_err(|_| Error::new(String::from("Cannot allocate buffer")))?;
 
         // Write file header.
         if is_64 {
@@ -294,7 +297,7 @@ impl<'a> Object<'a> {
             sectname
                 .get_mut(..section.name.len())
                 .ok_or_else(|| {
-                    Error(format!(
+                    Error::new(format!(
                         "section name `{}` is too long",
                         section.name().unwrap_or(""),
                     ))
@@ -321,7 +324,7 @@ impl<'a> Object<'a> {
                     | SectionKind::Unknown
                     | SectionKind::TlsVariables
                     | SectionKind::Elf(_) => {
-                        return Err(Error(format!(
+                        return Err(Error::new(format!(
                             "unimplemented section `{}` kind {:?}",
                             section.name().unwrap_or(""),
                             section.kind
@@ -386,7 +389,7 @@ impl<'a> Object<'a> {
                         if let RelocationFlags::Xcoff { r_rtype, r_rsize } = reloc.flags {
                             (r_rtype, r_rsize)
                         } else {
-                            return Err(Error("invalid relocation flags".into()));
+                            return Err(Error::new("invalid relocation flags"));
                         };
                     if is_64 {
                         let xcoff_rel = xcoff::Rel64 {
@@ -533,7 +536,7 @@ impl<'a> Object<'a> {
                             }
                         }
                         _ => {
-                            return Err(Error(format!(
+                            return Err(Error::new(format!(
                                 "unimplemented symbol `{}` kind {:?}",
                                 symbol.name().unwrap_or(""),
                                 symbol.kind


### PR DESCRIPTION
This PR allows the user to remove the message embedded into each Error of the read/write/build crates, since Rust is terrible at removing dead code. The string will stay due to Error construction, which is effectively discarded, even if the user doesn't care about the error message (aka just want to have a boolean indicating error), which means precise ROM space wasted.