### PR TITLE
Add Mips64 N32 ABI

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -22,6 +22,8 @@ pub enum Architecture {
     M68k,
     Mips,
     Mips64,
+    #[allow(non_camel_case_types)]
+    Mips64_N32,
     Msp430,
     PowerPc,
     PowerPc64,
@@ -70,6 +72,7 @@ impl Architecture {
             Architecture::M68k => Some(AddressSize::U32),
             Architecture::Mips => Some(AddressSize::U32),
             Architecture::Mips64 => Some(AddressSize::U64),
+            Architecture::Mips64_N32 => Some(AddressSize::U32),
             Architecture::Msp430 => Some(AddressSize::U16),
             Architecture::PowerPc => Some(AddressSize::U32),
             Architecture::PowerPc64 => Some(AddressSize::U64),

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -217,7 +217,13 @@ where
             (elf::EM_HEXAGON, _) => Architecture::Hexagon,
             (elf::EM_LOONGARCH, true) => Architecture::LoongArch64,
             (elf::EM_68K, false) => Architecture::M68k,
-            (elf::EM_MIPS, false) => Architecture::Mips,
+            (elf::EM_MIPS, false) => {
+                if (self.header.e_flags(self.endian) & elf::EF_MIPS_ABI2) != 0 {
+                    Architecture::Mips64_N32
+                } else {
+                    Architecture::Mips
+                }
+            }
             (elf::EM_MIPS, true) => Architecture::Mips64,
             (elf::EM_MSP430, _) => Architecture::Msp430,
             (elf::EM_PPC, _) => Architecture::PowerPc,

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -282,9 +282,7 @@ impl<'a> Object<'a> {
                     (K::Absolute, _, 16) => elf::R_MIPS_16,
                     (K::Absolute, _, 32) => elf::R_MIPS_32,
                     (K::Absolute, _, 64) => elf::R_MIPS_64,
-                    _ => {
-                        return Err(Error(format!("unimplemented relocation {:?}", reloc)));
-                    }
+                    _ => return unsupported_reloc(),
                 }
             }
             Architecture::Msp430 => match (kind, encoding, size) {

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -275,6 +275,7 @@ fn elf_any() {
         (Architecture::M68k, Endianness::Big),
         (Architecture::Mips, Endianness::Little),
         (Architecture::Mips64, Endianness::Little),
+        (Architecture::Mips64_N32, Endianness::Little),
         (Architecture::Msp430, Endianness::Little),
         (Architecture::PowerPc, Endianness::Big),
         (Architecture::PowerPc64, Endianness::Big),


### PR DESCRIPTION
This PR adds Mips N32, which is yet another ILP32 ABI. 