### PR TITLE
Initial SHT_RELR support

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -317,6 +317,7 @@ fn print_section_headers<Elf: FileHeader>(
                 }
                 SHT_REL => print_section_rel(p, endian, data, elf, sections, section),
                 SHT_RELA => print_section_rela(p, endian, data, elf, sections, section),
+                SHT_RELR => print_section_relr(p, endian, data, elf, section),
                 SHT_NOTE => print_section_notes(p, endian, data, elf, section),
                 SHT_DYNAMIC => print_section_dynamic(p, endian, data, elf, sections, section),
                 SHT_GROUP => print_section_group(p, endian, data, elf, sections, section),
@@ -557,6 +558,23 @@ fn rel_flag_type<Elf: FileHeader>(endian: Elf::Endian, elf: &Elf) -> &'static [F
         EM_METAG => FLAGS_R_METAG,
         EM_NDS32 => FLAGS_R_NDS32,
         _ => &[],
+    }
+}
+
+fn print_section_relr<Elf: FileHeader>(
+    p: &mut Printer<'_>,
+    endian: Elf::Endian,
+    data: &[u8],
+    _elf: &Elf,
+    section: &Elf::SectionHeader,
+) {
+    if !p.options.relocations {
+        return;
+    }
+    if let Some(Some(relocations)) = section.relr(endian, data).print_err(p) {
+        for relocation in relocations {
+            p.field_hex("Offset", relocation.into());
+        }
     }
 }
 
@@ -1373,6 +1391,7 @@ const FLAGS_SHT: &[Flag<u32>] = &flags!(
     SHT_PREINIT_ARRAY,
     SHT_GROUP,
     SHT_SYMTAB_SHNDX,
+    SHT_RELR,
     SHT_LLVM_DEPENDENT_LIBRARIES,
     SHT_GNU_ATTRIBUTES,
     SHT_GNU_HASH,

--- a/crates/examples/testfiles/elf/base-relr-i686.objdump
+++ b/crates/examples/testfiles/elf/base-relr-i686.objdump
@@ -1,0 +1,130 @@
+Format: Elf Little-endian 32-bit
+Kind: Dynamic
+Architecture: I386
+Flags: Elf { os_abi: 0, abi_version: 0, e_flags: 0 }
+Relative Address Base: 0
+Entry Address: 1060
+Build ID: [20, f1, cf, 5c, 28, a0, 2e, 84, 7f, 7d, 64, 9b, 89, ed, 5e, 93, 3e, 47, 4b, 98]
+Segment { address: 0, size: 3e8 }
+Segment { address: 1000, size: 1e8 }
+Segment { address: 2000, size: 114 }
+Segment { address: 3ec0, size: 14c }
+1: Section { name: ".interp", address: 194, size: 13, align: 1, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+2: Section { name: ".note.gnu.build-id", address: 1a8, size: 24, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
+3: Section { name: ".note.ABI-tag", address: 1cc, size: 20, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
+4: Section { name: ".gnu.hash", address: 1ec, size: 20, align: 4, kind: Elf(6ffffff6), flags: Elf { sh_flags: 2 } }
+5: Section { name: ".dynsym", address: 20c, size: 80, align: 4, kind: Metadata, flags: Elf { sh_flags: 2 } }
+6: Section { name: ".dynstr", address: 28c, size: ba, align: 1, kind: Metadata, flags: Elf { sh_flags: 2 } }
+7: Section { name: ".gnu.version", address: 346, size: 10, align: 2, kind: Elf(6fffffff), flags: Elf { sh_flags: 2 } }
+8: Section { name: ".gnu.version_r", address: 358, size: 50, align: 4, kind: Elf(6ffffffe), flags: Elf { sh_flags: 2 } }
+9: Section { name: ".rel.dyn", address: 3a8, size: 20, align: 4, kind: Metadata, flags: Elf { sh_flags: 2 } }
+10: Section { name: ".rel.plt", address: 3c8, size: 10, align: 4, kind: Metadata, flags: Elf { sh_flags: 42 } }
+11: Section { name: ".relr.dyn", address: 3d8, size: 10, align: 4, kind: Elf(13), flags: Elf { sh_flags: 2 } }
+12: Section { name: ".init", address: 1000, size: 20, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
+13: Section { name: ".plt", address: 1020, size: 30, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+14: Section { name: ".plt.got", address: 1050, size: 8, align: 8, kind: Text, flags: Elf { sh_flags: 6 } }
+15: Section { name: ".text", address: 1060, size: 171, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+16: Section { name: ".fini", address: 11d4, size: 14, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
+17: Section { name: ".rodata", address: 2000, size: 15, align: 4, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+18: Section { name: ".eh_frame_hdr", address: 2018, size: 34, align: 4, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+19: Section { name: ".eh_frame", address: 204c, size: c8, align: 4, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+20: Section { name: ".init_array", address: 3ec0, size: 4, align: 4, kind: Elf(e), flags: Elf { sh_flags: 3 } }
+21: Section { name: ".fini_array", address: 3ec4, size: 4, align: 4, kind: Elf(f), flags: Elf { sh_flags: 3 } }
+22: Section { name: ".dynamic", address: 3ec8, size: 110, align: 4, kind: Metadata, flags: Elf { sh_flags: 3 } }
+23: Section { name: ".got", address: 3fd8, size: 28, align: 4, kind: Data, flags: Elf { sh_flags: 3 } }
+24: Section { name: ".data", address: 4000, size: 8, align: 4, kind: Data, flags: Elf { sh_flags: 3 } }
+25: Section { name: ".bss", address: 4008, size: 4, align: 1, kind: UninitializedData, flags: Elf { sh_flags: 3 } }
+26: Section { name: ".comment", address: 0, size: 26, align: 1, kind: OtherString, flags: Elf { sh_flags: 30 } }
+27: Section { name: ".symtab", address: 0, size: 280, align: 4, kind: Metadata, flags: Elf { sh_flags: 0 } }
+28: Section { name: ".strtab", address: 0, size: 223, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
+29: Section { name: ".shstrtab", address: 0, size: 106, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
+
+Symbols
+1: Symbol { name: "Scrt1.o", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+2: Symbol { name: "__abi_tag", address: 1cc, size: 20, kind: Data, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+3: Symbol { name: "crtstuff.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+4: Symbol { name: "deregister_tm_clones", address: 10a0, size: 0, kind: Text, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+5: Symbol { name: "register_tm_clones", address: 10e0, size: 0, kind: Text, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+6: Symbol { name: "__do_global_dtors_aux", address: 1130, size: 0, kind: Text, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+7: Symbol { name: "completed.0", address: 4008, size: 1, kind: Data, section: Section(SectionIndex(19)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+8: Symbol { name: "__do_global_dtors_aux_fini_array_entry", address: 3ec4, size: 0, kind: Data, section: Section(SectionIndex(15)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+9: Symbol { name: "frame_dummy", address: 1180, size: 0, kind: Text, section: Section(SectionIndex(f)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+10: Symbol { name: "__frame_dummy_init_array_entry", address: 3ec0, size: 0, kind: Data, section: Section(SectionIndex(14)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+11: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+12: Symbol { name: "crtstuff.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+13: Symbol { name: "__FRAME_END__", address: 2110, size: 0, kind: Data, section: Section(SectionIndex(13)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+14: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+15: Symbol { name: "_DYNAMIC", address: 3ec8, size: 0, kind: Data, section: Section(SectionIndex(16)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+16: Symbol { name: "__GNU_EH_FRAME_HDR", address: 2018, size: 0, kind: Unknown, section: Section(SectionIndex(12)), scope: Compilation, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
+17: Symbol { name: "_GLOBAL_OFFSET_TABLE_", address: 3fd8, size: 0, kind: Data, section: Section(SectionIndex(17)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+18: Symbol { name: "__libc_start_main@GLIBC_2.34", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+19: Symbol { name: "_ITM_deregisterTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+20: Symbol { name: "__x86.get_pc_thunk.bx", address: 1090, size: 4, kind: Text, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+21: Symbol { name: "data_start", address: 4000, size: 0, kind: Unknown, section: Section(SectionIndex(18)), scope: Dynamic, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+22: Symbol { name: "printf@GLIBC_2.0", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+23: Symbol { name: "_edata", address: 4008, size: 0, kind: Unknown, section: Section(SectionIndex(18)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+24: Symbol { name: "_fini", address: 11d4, size: 0, kind: Text, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+25: Symbol { name: "__x86.get_pc_thunk.dx", address: 1189, size: 0, kind: Text, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+26: Symbol { name: "__cxa_finalize@GLIBC_2.1.3", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 22, st_other: 0 } }
+27: Symbol { name: "__data_start", address: 4000, size: 0, kind: Unknown, section: Section(SectionIndex(18)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+28: Symbol { name: "__gmon_start__", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+29: Symbol { name: "__dso_handle", address: 4004, size: 0, kind: Data, section: Section(SectionIndex(18)), scope: Linkage, weak: false, flags: Elf { st_info: 11, st_other: 2 } }
+30: Symbol { name: "_IO_stdin_used", address: 2004, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Dynamic, weak: false, flags: Elf { st_info: 11, st_other: 0 } }
+31: Symbol { name: "_end", address: 400c, size: 0, kind: Unknown, section: Section(SectionIndex(19)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+32: Symbol { name: "_start", address: 1060, size: 2c, kind: Text, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+33: Symbol { name: "_fp_hw", address: 2000, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Dynamic, weak: false, flags: Elf { st_info: 11, st_other: 0 } }
+34: Symbol { name: "__bss_start", address: 4008, size: 0, kind: Unknown, section: Section(SectionIndex(19)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+35: Symbol { name: "main", address: 118d, size: 40, kind: Text, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+36: Symbol { name: "__x86.get_pc_thunk.ax", address: 11cd, size: 0, kind: Text, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+37: Symbol { name: "__TMC_END__", address: 4008, size: 0, kind: Data, section: Section(SectionIndex(18)), scope: Linkage, weak: false, flags: Elf { st_info: 11, st_other: 2 } }
+38: Symbol { name: "_ITM_registerTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+39: Symbol { name: "_init", address: 1000, size: 0, kind: Text, section: Section(SectionIndex(c)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+
+Dynamic symbols
+1: Symbol { name: "__libc_start_main", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+2: Symbol { name: "_ITM_deregisterTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+3: Symbol { name: "printf", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+4: Symbol { name: "__cxa_finalize", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 22, st_other: 0 } }
+5: Symbol { name: "__gmon_start__", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+6: Symbol { name: "_ITM_registerTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+7: Symbol { name: "_IO_stdin_used", address: 2004, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Dynamic, weak: false, flags: Elf { st_info: 11, st_other: 0 } }
+
+Dynamic relocations
+(3fec, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(2)), addend: 0, implicit_addend: true, flags: Elf { r_type: 6 } })
+(3ff0, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(4)), addend: 0, implicit_addend: true, flags: Elf { r_type: 6 } })
+(3ff4, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(5)), addend: 0, implicit_addend: true, flags: Elf { r_type: 6 } })
+(3ffc, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(6)), addend: 0, implicit_addend: true, flags: Elf { r_type: 6 } })
+(3fe4, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(1)), addend: 0, implicit_addend: true, flags: Elf { r_type: 7 } })
+(3fe8, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(3)), addend: 0, implicit_addend: true, flags: Elf { r_type: 7 } })
+
+Import { library: "libc.so.6", name: "__libc_start_main" }
+Import { library: "", name: "_ITM_deregisterTMCloneTable" }
+Import { library: "libc.so.6", name: "printf" }
+Import { library: "libc.so.6", name: "__cxa_finalize" }
+Import { library: "", name: "__gmon_start__" }
+Import { library: "", name: "_ITM_registerTMCloneTable" }
+
+Export { name: "_IO_stdin_used", address: 2004 }
+
+Symbol map
+0x1cc "__abi_tag"
+0x1000 "_init"
+0x1060 "_start"
+0x1090 "__x86.get_pc_thunk.bx"
+0x10a0 "deregister_tm_clones"
+0x10e0 "register_tm_clones"
+0x1130 "__do_global_dtors_aux"
+0x1180 "frame_dummy"
+0x1189 "__x86.get_pc_thunk.dx"
+0x118d "main"
+0x11cd "__x86.get_pc_thunk.ax"
+0x11d4 "_fini"
+0x2000 "_fp_hw"
+0x2004 "_IO_stdin_used"
+0x2110 "__FRAME_END__"
+0x3ec0 "__frame_dummy_init_array_entry"
+0x3ec4 "__do_global_dtors_aux_fini_array_entry"
+0x3ec8 "_DYNAMIC"
+0x3fd8 "_GLOBAL_OFFSET_TABLE_"
+0x4004 "__dso_handle"
+0x4008 "__TMC_END__"

--- a/crates/examples/testfiles/elf/base-relr-i686.objdump
+++ b/crates/examples/testfiles/elf/base-relr-i686.objdump
@@ -19,7 +19,7 @@ Segment { address: 3ec0, size: 14c }
 8: Section { name: ".gnu.version_r", address: 358, size: 50, align: 4, kind: Elf(6ffffffe), flags: Elf { sh_flags: 2 } }
 9: Section { name: ".rel.dyn", address: 3a8, size: 20, align: 4, kind: Metadata, flags: Elf { sh_flags: 2 } }
 10: Section { name: ".rel.plt", address: 3c8, size: 10, align: 4, kind: Metadata, flags: Elf { sh_flags: 42 } }
-11: Section { name: ".relr.dyn", address: 3d8, size: 10, align: 4, kind: Elf(13), flags: Elf { sh_flags: 2 } }
+11: Section { name: ".relr.dyn", address: 3d8, size: 10, align: 4, kind: Metadata, flags: Elf { sh_flags: 2 } }
 12: Section { name: ".init", address: 1000, size: 20, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
 13: Section { name: ".plt", address: 1020, size: 30, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
 14: Section { name: ".plt.got", address: 1050, size: 8, align: 8, kind: Text, flags: Elf { sh_flags: 6 } }

--- a/crates/examples/testfiles/elf/base-relr-i686.readobj
+++ b/crates/examples/testfiles/elf/base-relr-i686.readobj
@@ -1,0 +1,1429 @@
+Format: ELF 32-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS32 (0x1)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_DYN (0x3)
+    Machine: EM_386 (0x3)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x1060
+    ProgramHeaderOffset: 0x34
+    SectionHeaderOffset: 0x35DC
+    Flags: 0x0
+    HeaderSize: 0x34
+    ProgramHeaderEntrySize: 0x20
+    ProgramHeaderCount: 11
+    SectionHeaderEntrySize: 0x28
+    SectionHeaderCount: 30
+    SectionHeaderStringTableIndex: 29
+}
+ProgramHeader {
+    Type: PT_PHDR (0x6)
+    Offset: 0x34
+    VirtualAddress: 0x34
+    PhysicalAddress: 0x34
+    FileSize: 0x160
+    MemorySize: 0x160
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_INTERP (0x3)
+    Offset: 0x194
+    VirtualAddress: 0x194
+    PhysicalAddress: 0x194
+    FileSize: 0x13
+    MemorySize: 0x13
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+    Interpreter: "/lib/ld-linux.so.2"
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x3E8
+    MemorySize: 0x3E8
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x1000
+    VirtualAddress: 0x1000
+    PhysicalAddress: 0x1000
+    FileSize: 0x1E8
+    MemorySize: 0x1E8
+    Flags: 0x5
+        PF_X (0x1)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2000
+    VirtualAddress: 0x2000
+    PhysicalAddress: 0x2000
+    FileSize: 0x114
+    MemorySize: 0x114
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2EC0
+    VirtualAddress: 0x3EC0
+    PhysicalAddress: 0x3EC0
+    FileSize: 0x148
+    MemorySize: 0x14C
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_DYNAMIC (0x2)
+    Offset: 0x2EC8
+    VirtualAddress: 0x3EC8
+    PhysicalAddress: 0x3EC8
+    FileSize: 0x110
+    MemorySize: 0x110
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x4
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x38)
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x11D4
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3EC0
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3EC4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x1EC
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x28C
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x20C
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xBA
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FD8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x11
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x3C8
+    }
+    Dynamic {
+        Tag: DT_REL (0x11)
+        Value: 0x3A8
+    }
+    Dynamic {
+        Tag: DT_RELSZ (0x12)
+        Value: 0x20
+    }
+    Dynamic {
+        Tag: DT_RELENT (0x13)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x358
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x346
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+ProgramHeader {
+    Type: PT_NOTE (0x4)
+    Offset: 0x1A8
+    VirtualAddress: 0x1A8
+    PhysicalAddress: 0x1A8
+    FileSize: 0x44
+    MemorySize: 0x44
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [20, F1, CF, 5C, 28, A0, 2E, 84, 7F, 7D, 64, 9B, 89, ED, 5E, 93, 3E, 47, 4B, 98]
+    }
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+ProgramHeader {
+    Type: PT_GNU_EH_FRAME (0x6474E550)
+    Offset: 0x2018
+    VirtualAddress: 0x2018
+    PhysicalAddress: 0x2018
+    FileSize: 0x34
+    MemorySize: 0x34
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_GNU_STACK (0x6474E551)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x0
+    MemorySize: 0x0
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x10
+}
+ProgramHeader {
+    Type: PT_GNU_RELRO (0x6474E552)
+    Offset: 0x2EC0
+    VirtualAddress: 0x3EC0
+    PhysicalAddress: 0x3EC0
+    FileSize: 0x140
+    MemorySize: 0x140
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".interp" (0x1B)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x194
+    Offset: 0x194
+    Size: 0x13
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".note.gnu.build-id" (0x23)
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x1A8
+    Offset: 0x1A8
+    Size: 0x24
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [20, F1, CF, 5C, 28, A0, 2E, 84, 7F, 7D, 64, 9B, 89, ED, 5E, 93, 3E, 47, 4B, 98]
+    }
+}
+SectionHeader {
+    Index: 3
+    Name: ".note.ABI-tag" (0x36)
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x1CC
+    Offset: 0x1CC
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".gnu.hash" (0x44)
+    Type: SHT_GNU_HASH (0x6FFFFFF6)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x1EC
+    Offset: 0x1EC
+    Size: 0x20
+    Link: 5
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+    GnuHash {
+        BucketCount: 2
+        SymbolBase: 7
+        BloomCount: 1
+        BloomShift: 5
+    }
+}
+SectionHeader {
+    Index: 5
+    Name: ".dynsym" (0x4E)
+    Type: SHT_DYNSYM (0xB)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x20C
+    Offset: 0x20C
+    Size: 0x80
+    Link: 6
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x10
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "__libc_start_main" (0x10)
+        Version: "GLIBC_2.34" (0x2)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 2
+        Name: "_ITM_deregisterTMCloneTable" (0x75)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 3
+        Name: "printf" (0x31)
+        Version: "GLIBC_2.0" (0x3)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 4
+        Name: "__cxa_finalize" (0x22)
+        Version: "GLIBC_2.1.3" (0x4)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 5
+        Name: "__gmon_start__" (0x91)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 6
+        Name: "_ITM_registerTMCloneTable" (0xA0)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 7
+        Name: "_IO_stdin_used" (0x1)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x2004
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".dynstr" (0x56)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x28C
+    Offset: 0x28C
+    Size: 0xBA
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 7
+    Name: ".gnu.version" (0x5E)
+    Type: SHT_GNU_VERSYM (0x6FFFFFFF)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x346
+    Offset: 0x346
+    Size: 0x10
+    Link: 5
+    Info: 0
+    AddressAlign: 0x2
+    EntrySize: 0x2
+    VersionSymbol {
+        Index: 0
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 1
+        Version: "GLIBC_2.34" (0x2)
+    }
+    VersionSymbol {
+        Index: 2
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 3
+        Version: "GLIBC_2.0" (0x3)
+    }
+    VersionSymbol {
+        Index: 4
+        Version: "GLIBC_2.1.3" (0x4)
+    }
+    VersionSymbol {
+        Index: 5
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 6
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 7
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+}
+SectionHeader {
+    Index: 8
+    Name: ".gnu.version_r" (0x6B)
+    Type: SHT_GNU_VERNEED (0x6FFFFFFE)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x358
+    Offset: 0x358
+    Size: 0x50
+    Link: 6
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    VersionNeed {
+        Version: 1
+        AuxCount: 4
+        Filename: "libc.so.6" (0x38)
+        AuxOffset: 16
+        NextOffset: 0
+        Aux {
+            Hash: 0xFD0E42
+            Flags: 0x0
+            Index: 5
+            Name: "GLIBC_ABI_DT_RELR" (0x42)
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x9691F73
+            Flags: 0x0
+            Index: 4
+            Name: "GLIBC_2.1.3" (0x54)
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0xD696910
+            Flags: 0x0
+            Index: 3
+            Name: "GLIBC_2.0" (0x60)
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x69691B4
+            Flags: 0x0
+            Index: 2
+            Name: "GLIBC_2.34" (0x6A)
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 9
+    Name: ".rel.dyn" (0x7A)
+    Type: SHT_REL (0x9)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3A8
+    Offset: 0x3A8
+    Size: 0x20
+    Link: 5
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Relocation {
+        Offset: 0x3FEC
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "_ITM_deregisterTMCloneTable" (0x2)
+    }
+    Relocation {
+        Offset: 0x3FF0
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "__cxa_finalize" (0x4)
+    }
+    Relocation {
+        Offset: 0x3FF4
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "__gmon_start__" (0x5)
+    }
+    Relocation {
+        Offset: 0x3FFC
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "_ITM_registerTMCloneTable" (0x6)
+    }
+}
+SectionHeader {
+    Index: 10
+    Name: ".rel.plt" (0x83)
+    Type: SHT_REL (0x9)
+    Flags: 0x42
+        SHF_ALLOC (0x2)
+        SHF_INFO_LINK (0x40)
+    Address: 0x3C8
+    Offset: 0x3C8
+    Size: 0x10
+    Link: 5
+    Info: 23
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Relocation {
+        Offset: 0x3FE4
+        Type: R_386_JMP_SLOT (0x7)
+        Symbol: "__libc_start_main" (0x1)
+    }
+    Relocation {
+        Offset: 0x3FE8
+        Type: R_386_JMP_SLOT (0x7)
+        Symbol: "printf" (0x3)
+    }
+}
+SectionHeader {
+    Index: 11
+    Name: ".relr.dyn" (0x8C)
+    Type: 0x13
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3D8
+    Offset: 0x3D8
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 12
+    Name: ".init" (0x96)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1000
+    Offset: 0x1000
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 13
+    Name: ".plt" (0x87)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1020
+    Offset: 0x1020
+    Size: 0x30
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 14
+    Name: ".plt.got" (0x9C)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1050
+    Offset: 0x1050
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 15
+    Name: ".text" (0xA5)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1060
+    Offset: 0x1060
+    Size: 0x171
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 16
+    Name: ".fini" (0xAB)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x11D4
+    Offset: 0x11D4
+    Size: 0x14
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 17
+    Name: ".rodata" (0xB1)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2000
+    Offset: 0x2000
+    Size: 0x15
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 18
+    Name: ".eh_frame_hdr" (0xB9)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2018
+    Offset: 0x2018
+    Size: 0x34
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 19
+    Name: ".eh_frame" (0xC7)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x204C
+    Offset: 0x204C
+    Size: 0xC8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 20
+    Name: ".init_array" (0xD1)
+    Type: SHT_INIT_ARRAY (0xE)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3EC0
+    Offset: 0x2EC0
+    Size: 0x4
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 21
+    Name: ".fini_array" (0xDD)
+    Type: SHT_FINI_ARRAY (0xF)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3EC4
+    Offset: 0x2EC4
+    Size: 0x4
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 22
+    Name: ".dynamic" (0xE9)
+    Type: SHT_DYNAMIC (0x6)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3EC8
+    Offset: 0x2EC8
+    Size: 0x110
+    Link: 6
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x38)
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x11D4
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3EC0
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3EC4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x1EC
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x28C
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x20C
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xBA
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FD8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x11
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x3C8
+    }
+    Dynamic {
+        Tag: DT_REL (0x11)
+        Value: 0x3A8
+    }
+    Dynamic {
+        Tag: DT_RELSZ (0x12)
+        Value: 0x20
+    }
+    Dynamic {
+        Tag: DT_RELENT (0x13)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x358
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x346
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 23
+    Name: ".got" (0xA0)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3FD8
+    Offset: 0x2FD8
+    Size: 0x28
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 24
+    Name: ".data" (0xF2)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4000
+    Offset: 0x3000
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 25
+    Name: ".bss" (0xF8)
+    Type: SHT_NOBITS (0x8)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4008
+    Offset: 0x3008
+    Size: 0x4
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 26
+    Name: ".comment" (0xFD)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x3008
+    Size: 0x26
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 27
+    Name: ".symtab" (0x1)
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3030
+    Size: 0x280
+    Link: 28
+    Info: 18
+    AddressAlign: 0x4
+    EntrySize: 0x10
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "Scrt1.o" (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 2
+        Name: "__abi_tag" (0x9)
+        Value: 0x1CC
+        Size: 0x20
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 3
+        Name: "crtstuff.c" (0x13)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 4
+        Name: "deregister_tm_clones" (0x1E)
+        Value: 0x10A0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 5
+        Name: "register_tm_clones" (0x20)
+        Value: 0x10E0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 6
+        Name: "__do_global_dtors_aux" (0x33)
+        Value: 0x1130
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 7
+        Name: "completed.0" (0x49)
+        Value: 0x4008
+        Size: 0x1
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 8
+        Name: "__do_global_dtors_aux_fini_array_entry" (0x55)
+        Value: 0x3EC4
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 21
+    }
+    Symbol {
+        Index: 9
+        Name: "frame_dummy" (0x7C)
+        Value: 0x1180
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 10
+        Name: "__frame_dummy_init_array_entry" (0x88)
+        Value: 0x3EC0
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 20
+    }
+    Symbol {
+        Index: 11
+        Name: "base.c" (0xA7)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 12
+        Name: "crtstuff.c" (0x13)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 13
+        Name: "__FRAME_END__" (0xAE)
+        Value: 0x2110
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 19
+    }
+    Symbol {
+        Index: 14
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 15
+        Name: "_DYNAMIC" (0xBC)
+        Value: 0x3EC8
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 22
+    }
+    Symbol {
+        Index: 16
+        Name: "__GNU_EH_FRAME_HDR" (0xC5)
+        Value: 0x2018
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 18
+    }
+    Symbol {
+        Index: 17
+        Name: "_GLOBAL_OFFSET_TABLE_" (0xD8)
+        Value: 0x3FD8
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 23
+    }
+    Symbol {
+        Index: 18
+        Name: "__libc_start_main@GLIBC_2.34" (0xEE)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 19
+        Name: "_ITM_deregisterTMCloneTable" (0x10B)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 20
+        Name: "__x86.get_pc_thunk.bx" (0x127)
+        Value: 0x1090
+        Size: 0x4
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 21
+        Name: "data_start" (0x18E)
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 22
+        Name: "printf@GLIBC_2.0" (0x13D)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 23
+        Name: "_edata" (0x14E)
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 24
+        Name: "_fini" (0x155)
+        Value: 0x11D4
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 16
+    }
+    Symbol {
+        Index: 25
+        Name: "__x86.get_pc_thunk.dx" (0x15B)
+        Value: 0x1189
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 26
+        Name: "__cxa_finalize@GLIBC_2.1.3" (0x171)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 27
+        Name: "__data_start" (0x18C)
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 28
+        Name: "__gmon_start__" (0x199)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 29
+        Name: "__dso_handle" (0x1A8)
+        Value: 0x4004
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 30
+        Name: "_IO_stdin_used" (0x1B5)
+        Value: 0x2004
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 31
+        Name: "_end" (0x1C4)
+        Value: 0x400C
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 32
+        Name: "_start" (0x192)
+        Value: 0x1060
+        Size: 0x2C
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 33
+        Name: "_fp_hw" (0x1C9)
+        Value: 0x2000
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 34
+        Name: "__bss_start" (0x1D0)
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 35
+        Name: "main" (0x1DC)
+        Value: 0x118D
+        Size: 0x40
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 36
+        Name: "__x86.get_pc_thunk.ax" (0x1E1)
+        Value: 0x11CD
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 37
+        Name: "__TMC_END__" (0x1F7)
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 38
+        Name: "_ITM_registerTMCloneTable" (0x203)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 39
+        Name: "_init" (0x21D)
+        Value: 0x1000
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 12
+    }
+}
+SectionHeader {
+    Index: 28
+    Name: ".strtab" (0x9)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x32B0
+    Size: 0x223
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 29
+    Name: ".shstrtab" (0x11)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x34D3
+    Size: 0x106
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/crates/examples/testfiles/elf/base-relr-i686.readobj
+++ b/crates/examples/testfiles/elf/base-relr-i686.readobj
@@ -636,7 +636,7 @@ SectionHeader {
 SectionHeader {
     Index: 11
     Name: ".relr.dyn" (0x8C)
-    Type: 0x13
+    Type: SHT_RELR (0x13)
     Flags: 0x2
         SHF_ALLOC (0x2)
     Address: 0x3D8
@@ -646,6 +646,10 @@ SectionHeader {
     Info: 0
     AddressAlign: 0x4
     EntrySize: 0x4
+    Offset: 0x3EC0
+    Offset: 0x3EC4
+    Offset: 0x3FF8
+    Offset: 0x4004
 }
 SectionHeader {
     Index: 12

--- a/crates/examples/testfiles/elf/base-relr-x86_64.objdump
+++ b/crates/examples/testfiles/elf/base-relr-x86_64.objdump
@@ -1,0 +1,121 @@
+Format: Elf Little-endian 64-bit
+Kind: Dynamic
+Architecture: X86_64
+Flags: Elf { os_abi: 0, abi_version: 0, e_flags: 0 }
+Relative Address Base: 0
+Entry Address: 1060
+Build ID: [1f, 9b, 45, 6b, d0, 2a, 5, f3, 6b, 88, 90, ba, b6, bc, fb, 39, e9, 39, cd, 99]
+Segment { address: 0, size: 618 }
+Segment { address: 1000, size: 179 }
+Segment { address: 2000, size: f4 }
+Segment { address: 3d88, size: 290 }
+1: Section { name: ".interp", address: 318, size: 1c, align: 1, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+2: Section { name: ".note.gnu.property", address: 338, size: 30, align: 8, kind: Note, flags: Elf { sh_flags: 2 } }
+3: Section { name: ".note.gnu.build-id", address: 368, size: 24, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
+4: Section { name: ".note.ABI-tag", address: 38c, size: 20, align: 4, kind: Note, flags: Elf { sh_flags: 2 } }
+5: Section { name: ".gnu.hash", address: 3b0, size: 24, align: 8, kind: Elf(6ffffff6), flags: Elf { sh_flags: 2 } }
+6: Section { name: ".dynsym", address: 3d8, size: a8, align: 8, kind: Metadata, flags: Elf { sh_flags: 2 } }
+7: Section { name: ".dynstr", address: 480, size: a1, align: 1, kind: Metadata, flags: Elf { sh_flags: 2 } }
+8: Section { name: ".gnu.version", address: 522, size: e, align: 2, kind: Elf(6fffffff), flags: Elf { sh_flags: 2 } }
+9: Section { name: ".gnu.version_r", address: 530, size: 40, align: 8, kind: Elf(6ffffffe), flags: Elf { sh_flags: 2 } }
+10: Section { name: ".rela.dyn", address: 570, size: 78, align: 8, kind: Metadata, flags: Elf { sh_flags: 2 } }
+11: Section { name: ".rela.plt", address: 5e8, size: 18, align: 8, kind: Metadata, flags: Elf { sh_flags: 42 } }
+12: Section { name: ".relr.dyn", address: 600, size: 18, align: 8, kind: Elf(13), flags: Elf { sh_flags: 2 } }
+13: Section { name: ".init", address: 1000, size: 1b, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
+14: Section { name: ".plt", address: 1020, size: 20, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+15: Section { name: ".plt.got", address: 1040, size: 10, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+16: Section { name: ".plt.sec", address: 1050, size: 10, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+17: Section { name: ".text", address: 1060, size: 10c, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+18: Section { name: ".fini", address: 116c, size: d, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
+19: Section { name: ".rodata", address: 2000, size: 11, align: 4, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+20: Section { name: ".eh_frame_hdr", address: 2014, size: 34, align: 4, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+21: Section { name: ".eh_frame", address: 2048, size: ac, align: 8, kind: ReadOnlyData, flags: Elf { sh_flags: 2 } }
+22: Section { name: ".init_array", address: 3d88, size: 8, align: 8, kind: Elf(e), flags: Elf { sh_flags: 3 } }
+23: Section { name: ".fini_array", address: 3d90, size: 8, align: 8, kind: Elf(f), flags: Elf { sh_flags: 3 } }
+24: Section { name: ".dynamic", address: 3d98, size: 220, align: 8, kind: Metadata, flags: Elf { sh_flags: 3 } }
+25: Section { name: ".got", address: 3fb8, size: 48, align: 8, kind: Data, flags: Elf { sh_flags: 3 } }
+26: Section { name: ".data", address: 4000, size: 10, align: 8, kind: Data, flags: Elf { sh_flags: 3 } }
+27: Section { name: ".bss", address: 4010, size: 8, align: 1, kind: UninitializedData, flags: Elf { sh_flags: 3 } }
+28: Section { name: ".comment", address: 0, size: 26, align: 1, kind: OtherString, flags: Elf { sh_flags: 30 } }
+29: Section { name: ".symtab", address: 0, size: 360, align: 8, kind: Metadata, flags: Elf { sh_flags: 0 } }
+30: Section { name: ".strtab", address: 0, size: 1dc, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
+31: Section { name: ".shstrtab", address: 0, size: 124, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
+
+Symbols
+1: Symbol { name: "Scrt1.o", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+2: Symbol { name: "__abi_tag", address: 38c, size: 20, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+3: Symbol { name: "crtstuff.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+4: Symbol { name: "deregister_tm_clones", address: 1090, size: 0, kind: Text, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+5: Symbol { name: "register_tm_clones", address: 10c0, size: 0, kind: Text, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+6: Symbol { name: "__do_global_dtors_aux", address: 1100, size: 0, kind: Text, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+7: Symbol { name: "completed.0", address: 4010, size: 1, kind: Data, section: Section(SectionIndex(1b)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+8: Symbol { name: "__do_global_dtors_aux_fini_array_entry", address: 3d90, size: 0, kind: Data, section: Section(SectionIndex(17)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+9: Symbol { name: "frame_dummy", address: 1140, size: 0, kind: Text, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: Elf { st_info: 2, st_other: 0 } }
+10: Symbol { name: "__frame_dummy_init_array_entry", address: 3d88, size: 0, kind: Data, section: Section(SectionIndex(16)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+11: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+12: Symbol { name: "crtstuff.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+13: Symbol { name: "__FRAME_END__", address: 20f0, size: 0, kind: Data, section: Section(SectionIndex(15)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+14: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+15: Symbol { name: "_DYNAMIC", address: 3d98, size: 0, kind: Data, section: Section(SectionIndex(18)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+16: Symbol { name: "__GNU_EH_FRAME_HDR", address: 2014, size: 0, kind: Unknown, section: Section(SectionIndex(14)), scope: Compilation, weak: false, flags: Elf { st_info: 0, st_other: 0 } }
+17: Symbol { name: "_GLOBAL_OFFSET_TABLE_", address: 3fb8, size: 0, kind: Data, section: Section(SectionIndex(19)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+18: Symbol { name: "__libc_start_main@GLIBC_2.34", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+19: Symbol { name: "_ITM_deregisterTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+20: Symbol { name: "data_start", address: 4000, size: 0, kind: Unknown, section: Section(SectionIndex(1a)), scope: Dynamic, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+21: Symbol { name: "_edata", address: 4010, size: 0, kind: Unknown, section: Section(SectionIndex(1a)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+22: Symbol { name: "_fini", address: 116c, size: 0, kind: Text, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+23: Symbol { name: "printf@GLIBC_2.2.5", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+24: Symbol { name: "__data_start", address: 4000, size: 0, kind: Unknown, section: Section(SectionIndex(1a)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+25: Symbol { name: "__gmon_start__", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+26: Symbol { name: "__dso_handle", address: 4008, size: 0, kind: Data, section: Section(SectionIndex(1a)), scope: Linkage, weak: false, flags: Elf { st_info: 11, st_other: 2 } }
+27: Symbol { name: "_IO_stdin_used", address: 2000, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: Elf { st_info: 11, st_other: 0 } }
+28: Symbol { name: "_end", address: 4018, size: 0, kind: Unknown, section: Section(SectionIndex(1b)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+29: Symbol { name: "_start", address: 1060, size: 26, kind: Text, section: Section(SectionIndex(11)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+30: Symbol { name: "__bss_start", address: 4010, size: 0, kind: Unknown, section: Section(SectionIndex(1b)), scope: Dynamic, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+31: Symbol { name: "main", address: 1149, size: 23, kind: Text, section: Section(SectionIndex(11)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+32: Symbol { name: "__TMC_END__", address: 4010, size: 0, kind: Data, section: Section(SectionIndex(1a)), scope: Linkage, weak: false, flags: Elf { st_info: 11, st_other: 2 } }
+33: Symbol { name: "_ITM_registerTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+34: Symbol { name: "__cxa_finalize@GLIBC_2.2.5", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 22, st_other: 0 } }
+35: Symbol { name: "_init", address: 1000, size: 0, kind: Text, section: Section(SectionIndex(d)), scope: Linkage, weak: false, flags: Elf { st_info: 12, st_other: 2 } }
+
+Dynamic symbols
+1: Symbol { name: "__libc_start_main", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+2: Symbol { name: "_ITM_deregisterTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+3: Symbol { name: "printf", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+4: Symbol { name: "__gmon_start__", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+5: Symbol { name: "_ITM_registerTMCloneTable", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 20, st_other: 0 } }
+6: Symbol { name: "__cxa_finalize", address: 0, size: 0, kind: Text, section: Undefined, scope: Unknown, weak: true, flags: Elf { st_info: 22, st_other: 0 } }
+
+Dynamic relocations
+(3fd8, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(1)), addend: 0, implicit_addend: false, flags: Elf { r_type: 6 } })
+(3fe0, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(2)), addend: 0, implicit_addend: false, flags: Elf { r_type: 6 } })
+(3fe8, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(4)), addend: 0, implicit_addend: false, flags: Elf { r_type: 6 } })
+(3ff0, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(5)), addend: 0, implicit_addend: false, flags: Elf { r_type: 6 } })
+(3ff8, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(6)), addend: 0, implicit_addend: false, flags: Elf { r_type: 6 } })
+(3fd0, Relocation { kind: Unknown, encoding: Generic, size: 0, target: Symbol(SymbolIndex(3)), addend: 0, implicit_addend: false, flags: Elf { r_type: 7 } })
+
+Import { library: "libc.so.6", name: "__libc_start_main" }
+Import { library: "", name: "_ITM_deregisterTMCloneTable" }
+Import { library: "libc.so.6", name: "printf" }
+Import { library: "", name: "__gmon_start__" }
+Import { library: "", name: "_ITM_registerTMCloneTable" }
+Import { library: "libc.so.6", name: "__cxa_finalize" }
+
+Symbol map
+0x38c "__abi_tag"
+0x1000 "_init"
+0x1060 "_start"
+0x1090 "deregister_tm_clones"
+0x10c0 "register_tm_clones"
+0x1100 "__do_global_dtors_aux"
+0x1140 "frame_dummy"
+0x1149 "main"
+0x116c "_fini"
+0x2000 "_IO_stdin_used"
+0x20f0 "__FRAME_END__"
+0x3d88 "__frame_dummy_init_array_entry"
+0x3d90 "__do_global_dtors_aux_fini_array_entry"
+0x3d98 "_DYNAMIC"
+0x3fb8 "_GLOBAL_OFFSET_TABLE_"
+0x4008 "__dso_handle"
+0x4010 "__TMC_END__"

--- a/crates/examples/testfiles/elf/base-relr-x86_64.objdump
+++ b/crates/examples/testfiles/elf/base-relr-x86_64.objdump
@@ -20,7 +20,7 @@ Segment { address: 3d88, size: 290 }
 9: Section { name: ".gnu.version_r", address: 530, size: 40, align: 8, kind: Elf(6ffffffe), flags: Elf { sh_flags: 2 } }
 10: Section { name: ".rela.dyn", address: 570, size: 78, align: 8, kind: Metadata, flags: Elf { sh_flags: 2 } }
 11: Section { name: ".rela.plt", address: 5e8, size: 18, align: 8, kind: Metadata, flags: Elf { sh_flags: 42 } }
-12: Section { name: ".relr.dyn", address: 600, size: 18, align: 8, kind: Elf(13), flags: Elf { sh_flags: 2 } }
+12: Section { name: ".relr.dyn", address: 600, size: 18, align: 8, kind: Metadata, flags: Elf { sh_flags: 2 } }
 13: Section { name: ".init", address: 1000, size: 1b, align: 4, kind: Text, flags: Elf { sh_flags: 6 } }
 14: Section { name: ".plt", address: 1020, size: 20, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
 15: Section { name: ".plt.got", address: 1040, size: 10, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }

--- a/crates/examples/testfiles/elf/base-relr-x86_64.readobj
+++ b/crates/examples/testfiles/elf/base-relr-x86_64.readobj
@@ -1,0 +1,1448 @@
+Format: ELF 64-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS64 (0x2)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_DYN (0x3)
+    Machine: EM_X86_64 (0x3E)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x1060
+    ProgramHeaderOffset: 0x40
+    SectionHeaderOffset: 0x3698
+    Flags: 0x0
+    HeaderSize: 0x40
+    ProgramHeaderEntrySize: 0x38
+    ProgramHeaderCount: 13
+    SectionHeaderEntrySize: 0x40
+    SectionHeaderCount: 32
+    SectionHeaderStringTableIndex: 31
+}
+ProgramHeader {
+    Type: PT_PHDR (0x6)
+    Offset: 0x40
+    VirtualAddress: 0x40
+    PhysicalAddress: 0x40
+    FileSize: 0x2D8
+    MemorySize: 0x2D8
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+}
+ProgramHeader {
+    Type: PT_INTERP (0x3)
+    Offset: 0x318
+    VirtualAddress: 0x318
+    PhysicalAddress: 0x318
+    FileSize: 0x1C
+    MemorySize: 0x1C
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+    Interpreter: "/lib64/ld-linux-x86-64.so.2"
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x618
+    MemorySize: 0x618
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x1000
+    VirtualAddress: 0x1000
+    PhysicalAddress: 0x1000
+    FileSize: 0x179
+    MemorySize: 0x179
+    Flags: 0x5
+        PF_X (0x1)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2000
+    VirtualAddress: 0x2000
+    PhysicalAddress: 0x2000
+    FileSize: 0xF4
+    MemorySize: 0xF4
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2D88
+    VirtualAddress: 0x3D88
+    PhysicalAddress: 0x3D88
+    FileSize: 0x288
+    MemorySize: 0x290
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_DYNAMIC (0x2)
+    Offset: 0x2D98
+    VirtualAddress: 0x3D98
+    PhysicalAddress: 0x3D98
+    FileSize: 0x220
+    MemorySize: 0x220
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x8
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x29)
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x116C
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3D88
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3D90
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x3B0
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x480
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xA1
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FB8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x7
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x5E8
+    }
+    Dynamic {
+        Tag: DT_RELA (0x7)
+        Value: 0x570
+    }
+    Dynamic {
+        Tag: DT_RELASZ (0x8)
+        Value: 0x78
+    }
+    Dynamic {
+        Tag: DT_RELAENT (0x9)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x530
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x522
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x600
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+ProgramHeader {
+    Type: PT_NOTE (0x4)
+    Offset: 0x338
+    VirtualAddress: 0x338
+    PhysicalAddress: 0x338
+    FileSize: 0x30
+    MemorySize: 0x30
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_PROPERTY_TYPE_0 (0x5)
+        Property {
+            Type: GNU_PROPERTY_X86_FEATURE_1_AND (0xC0000002)
+            Value: 0x3
+                GNU_PROPERTY_X86_FEATURE_1_IBT (0x1)
+                GNU_PROPERTY_X86_FEATURE_1_SHSTK (0x2)
+        }
+        Property {
+            Type: GNU_PROPERTY_X86_ISA_1_NEEDED (0xC0008002)
+            Value: 0x1
+                GNU_PROPERTY_X86_ISA_1_BASELINE (0x1)
+        }
+    }
+}
+ProgramHeader {
+    Type: PT_NOTE (0x4)
+    Offset: 0x368
+    VirtualAddress: 0x368
+    PhysicalAddress: 0x368
+    FileSize: 0x44
+    MemorySize: 0x44
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [1F, 9B, 45, 6B, D0, 2A, 5, F3, 6B, 88, 90, BA, B6, BC, FB, 39, E9, 39, CD, 99]
+    }
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+ProgramHeader {
+    Type: PT_GNU_PROPERTY (0x6474E553)
+    Offset: 0x338
+    VirtualAddress: 0x338
+    PhysicalAddress: 0x338
+    FileSize: 0x30
+    MemorySize: 0x30
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+}
+ProgramHeader {
+    Type: PT_GNU_EH_FRAME (0x6474E550)
+    Offset: 0x2014
+    VirtualAddress: 0x2014
+    PhysicalAddress: 0x2014
+    FileSize: 0x34
+    MemorySize: 0x34
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_GNU_STACK (0x6474E551)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x0
+    MemorySize: 0x0
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x10
+}
+ProgramHeader {
+    Type: PT_GNU_RELRO (0x6474E552)
+    Offset: 0x2D88
+    VirtualAddress: 0x3D88
+    PhysicalAddress: 0x3D88
+    FileSize: 0x278
+    MemorySize: 0x278
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".interp" (0x1B)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x318
+    Offset: 0x318
+    Size: 0x1C
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".note.gnu.property" (0x23)
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x338
+    Offset: 0x338
+    Size: 0x30
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_PROPERTY_TYPE_0 (0x5)
+        Property {
+            Type: GNU_PROPERTY_X86_FEATURE_1_AND (0xC0000002)
+            Value: 0x3
+                GNU_PROPERTY_X86_FEATURE_1_IBT (0x1)
+                GNU_PROPERTY_X86_FEATURE_1_SHSTK (0x2)
+        }
+        Property {
+            Type: GNU_PROPERTY_X86_ISA_1_NEEDED (0xC0008002)
+            Value: 0x1
+                GNU_PROPERTY_X86_ISA_1_BASELINE (0x1)
+        }
+    }
+}
+SectionHeader {
+    Index: 3
+    Name: ".note.gnu.build-id" (0x36)
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x368
+    Offset: 0x368
+    Size: 0x24
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [1F, 9B, 45, 6B, D0, 2A, 5, F3, 6B, 88, 90, BA, B6, BC, FB, 39, E9, 39, CD, 99]
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".note.ABI-tag" (0x49)
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x38C
+    Offset: 0x38C
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU" (0x4)
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+SectionHeader {
+    Index: 5
+    Name: ".gnu.hash" (0x57)
+    Type: SHT_GNU_HASH (0x6FFFFFF6)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3B0
+    Offset: 0x3B0
+    Size: 0x24
+    Link: 6
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+    GnuHash {
+        BucketCount: 2
+        SymbolBase: 6
+        BloomCount: 1
+        BloomShift: 6
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".dynsym" (0x61)
+    Type: SHT_DYNSYM (0xB)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3D8
+    Offset: 0x3D8
+    Size: 0xA8
+    Link: 7
+    Info: 1
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "__libc_start_main" (0x1)
+        Version: "GLIBC_2.34" (0x2)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 2
+        Name: "_ITM_deregisterTMCloneTable" (0x5C)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 3
+        Name: "printf" (0x22)
+        Version: "GLIBC_2.2.5" (0x3)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 4
+        Name: "__gmon_start__" (0x78)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 5
+        Name: "_ITM_registerTMCloneTable" (0x87)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 6
+        Name: "__cxa_finalize" (0x13)
+        Version: "GLIBC_2.2.5" (0x3)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+}
+SectionHeader {
+    Index: 7
+    Name: ".dynstr" (0x69)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x480
+    Offset: 0x480
+    Size: 0xA1
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 8
+    Name: ".gnu.version" (0x71)
+    Type: SHT_GNU_VERSYM (0x6FFFFFFF)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x522
+    Offset: 0x522
+    Size: 0xE
+    Link: 6
+    Info: 0
+    AddressAlign: 0x2
+    EntrySize: 0x2
+    VersionSymbol {
+        Index: 0
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 1
+        Version: "GLIBC_2.34" (0x2)
+    }
+    VersionSymbol {
+        Index: 2
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 3
+        Version: "GLIBC_2.2.5" (0x3)
+    }
+    VersionSymbol {
+        Index: 4
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 5
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 6
+        Version: "GLIBC_2.2.5" (0x3)
+    }
+}
+SectionHeader {
+    Index: 9
+    Name: ".gnu.version_r" (0x7E)
+    Type: SHT_GNU_VERNEED (0x6FFFFFFE)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x530
+    Offset: 0x530
+    Size: 0x40
+    Link: 7
+    Info: 1
+    AddressAlign: 0x8
+    EntrySize: 0x0
+    VersionNeed {
+        Version: 1
+        AuxCount: 3
+        Filename: "libc.so.6" (0x29)
+        AuxOffset: 16
+        NextOffset: 0
+        Aux {
+            Hash: 0xFD0E42
+            Flags: 0x0
+            Index: 4
+            Name: "GLIBC_ABI_DT_RELR" (0x33)
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x9691A75
+            Flags: 0x0
+            Index: 3
+            Name: "GLIBC_2.2.5" (0x45)
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x69691B4
+            Flags: 0x0
+            Index: 2
+            Name: "GLIBC_2.34" (0x51)
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 10
+    Name: ".rela.dyn" (0x8D)
+    Type: SHT_RELA (0x4)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x570
+    Offset: 0x570
+    Size: 0x78
+    Link: 6
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Relocation {
+        Offset: 0x3FD8
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "__libc_start_main" (0x1)
+    }
+    Relocation {
+        Offset: 0x3FE0
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "_ITM_deregisterTMCloneTable" (0x2)
+    }
+    Relocation {
+        Offset: 0x3FE8
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "__gmon_start__" (0x4)
+    }
+    Relocation {
+        Offset: 0x3FF0
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "_ITM_registerTMCloneTable" (0x5)
+    }
+    Relocation {
+        Offset: 0x3FF8
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "__cxa_finalize" (0x6)
+    }
+}
+SectionHeader {
+    Index: 11
+    Name: ".rela.plt" (0x97)
+    Type: SHT_RELA (0x4)
+    Flags: 0x42
+        SHF_ALLOC (0x2)
+        SHF_INFO_LINK (0x40)
+    Address: 0x5E8
+    Offset: 0x5E8
+    Size: 0x18
+    Link: 6
+    Info: 25
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Relocation {
+        Offset: 0x3FD0
+        Type: R_X86_64_JUMP_SLOT (0x7)
+        Symbol: "printf" (0x3)
+    }
+}
+SectionHeader {
+    Index: 12
+    Name: ".relr.dyn" (0xA1)
+    Type: 0x13
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x600
+    Offset: 0x600
+    Size: 0x18
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 13
+    Name: ".init" (0xAB)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1000
+    Offset: 0x1000
+    Size: 0x1B
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 14
+    Name: ".plt" (0x9C)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1020
+    Offset: 0x1020
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x10
+}
+SectionHeader {
+    Index: 15
+    Name: ".plt.got" (0xB1)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1040
+    Offset: 0x1040
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x10
+}
+SectionHeader {
+    Index: 16
+    Name: ".plt.sec" (0xBA)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1050
+    Offset: 0x1050
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x10
+}
+SectionHeader {
+    Index: 17
+    Name: ".text" (0xC3)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1060
+    Offset: 0x1060
+    Size: 0x10C
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 18
+    Name: ".fini" (0xC9)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x116C
+    Offset: 0x116C
+    Size: 0xD
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 19
+    Name: ".rodata" (0xCF)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2000
+    Offset: 0x2000
+    Size: 0x11
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 20
+    Name: ".eh_frame_hdr" (0xD7)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2014
+    Offset: 0x2014
+    Size: 0x34
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 21
+    Name: ".eh_frame" (0xE5)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2048
+    Offset: 0x2048
+    Size: 0xAC
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 22
+    Name: ".init_array" (0xEF)
+    Type: SHT_INIT_ARRAY (0xE)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3D88
+    Offset: 0x2D88
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 23
+    Name: ".fini_array" (0xFB)
+    Type: SHT_FINI_ARRAY (0xF)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3D90
+    Offset: 0x2D90
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 24
+    Name: ".dynamic" (0x107)
+    Type: SHT_DYNAMIC (0x6)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3D98
+    Offset: 0x2D98
+    Size: 0x220
+    Link: 7
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x10
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x29)
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x116C
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3D88
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3D90
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x3B0
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x480
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xA1
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FB8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x7
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x5E8
+    }
+    Dynamic {
+        Tag: DT_RELA (0x7)
+        Value: 0x570
+    }
+    Dynamic {
+        Tag: DT_RELASZ (0x8)
+        Value: 0x78
+    }
+    Dynamic {
+        Tag: DT_RELAENT (0x9)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x530
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x522
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x600
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 25
+    Name: ".got" (0xB5)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3FB8
+    Offset: 0x2FB8
+    Size: 0x48
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 26
+    Name: ".data" (0x110)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4000
+    Offset: 0x3000
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 27
+    Name: ".bss" (0x116)
+    Type: SHT_NOBITS (0x8)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4010
+    Offset: 0x3010
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 28
+    Name: ".comment" (0x11B)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x3010
+    Size: 0x26
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 29
+    Name: ".symtab" (0x1)
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3038
+    Size: 0x360
+    Link: 30
+    Info: 18
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "Scrt1.o" (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 2
+        Name: "__abi_tag" (0x9)
+        Value: 0x38C
+        Size: 0x20
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 4
+    }
+    Symbol {
+        Index: 3
+        Name: "crtstuff.c" (0x13)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 4
+        Name: "deregister_tm_clones" (0x1E)
+        Value: 0x1090
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 5
+        Name: "register_tm_clones" (0x20)
+        Value: 0x10C0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 6
+        Name: "__do_global_dtors_aux" (0x33)
+        Value: 0x1100
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 7
+        Name: "completed.0" (0x49)
+        Value: 0x4010
+        Size: 0x1
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 27
+    }
+    Symbol {
+        Index: 8
+        Name: "__do_global_dtors_aux_fini_array_entry" (0x55)
+        Value: 0x3D90
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 23
+    }
+    Symbol {
+        Index: 9
+        Name: "frame_dummy" (0x7C)
+        Value: 0x1140
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 10
+        Name: "__frame_dummy_init_array_entry" (0x88)
+        Value: 0x3D88
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 22
+    }
+    Symbol {
+        Index: 11
+        Name: "base.c" (0xA7)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 12
+        Name: "crtstuff.c" (0x13)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 13
+        Name: "__FRAME_END__" (0xAE)
+        Value: 0x20F0
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 21
+    }
+    Symbol {
+        Index: 14
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 15
+        Name: "_DYNAMIC" (0xBC)
+        Value: 0x3D98
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 16
+        Name: "__GNU_EH_FRAME_HDR" (0xC5)
+        Value: 0x2014
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 20
+    }
+    Symbol {
+        Index: 17
+        Name: "_GLOBAL_OFFSET_TABLE_" (0xD8)
+        Value: 0x3FB8
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 18
+        Name: "__libc_start_main@GLIBC_2.34" (0xEE)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 19
+        Name: "_ITM_deregisterTMCloneTable" (0x10B)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 20
+        Name: "data_start" (0x149)
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 21
+        Name: "_edata" (0x127)
+        Value: 0x4010
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 22
+        Name: "_fini" (0x12E)
+        Value: 0x116C
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 18
+    }
+    Symbol {
+        Index: 23
+        Name: "printf@GLIBC_2.2.5" (0x134)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 24
+        Name: "__data_start" (0x147)
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 25
+        Name: "__gmon_start__" (0x154)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 26
+        Name: "__dso_handle" (0x163)
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 27
+        Name: "_IO_stdin_used" (0x170)
+        Value: 0x2000
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 19
+    }
+    Symbol {
+        Index: 28
+        Name: "_end" (0x17F)
+        Value: 0x4018
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 27
+    }
+    Symbol {
+        Index: 29
+        Name: "_start" (0x14D)
+        Value: 0x1060
+        Size: 0x26
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 30
+        Name: "__bss_start" (0x184)
+        Value: 0x4010
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 27
+    }
+    Symbol {
+        Index: 31
+        Name: "main" (0x190)
+        Value: 0x1149
+        Size: 0x23
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 32
+        Name: "__TMC_END__" (0x195)
+        Value: 0x4010
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 33
+        Name: "_ITM_registerTMCloneTable" (0x1A1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 34
+        Name: "__cxa_finalize@GLIBC_2.2.5" (0x1BB)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 35
+        Name: "_init" (0x1D6)
+        Value: 0x1000
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 13
+    }
+}
+SectionHeader {
+    Index: 30
+    Name: ".strtab" (0x9)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3398
+    Size: 0x1DC
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 31
+    Name: ".shstrtab" (0x11)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3574
+    Size: 0x124
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/crates/examples/testfiles/elf/base-relr-x86_64.readobj
+++ b/crates/examples/testfiles/elf/base-relr-x86_64.readobj
@@ -680,7 +680,7 @@ SectionHeader {
 SectionHeader {
     Index: 12
     Name: ".relr.dyn" (0xA1)
-    Type: 0x13
+    Type: SHT_RELR (0x13)
     Flags: 0x2
         SHF_ALLOC (0x2)
     Address: 0x600
@@ -690,6 +690,9 @@ SectionHeader {
     Info: 0
     AddressAlign: 0x8
     EntrySize: 0x8
+    Offset: 0x3D88
+    Offset: 0x3D90
+    Offset: 0x4008
 }
 SectionHeader {
     Index: 13

--- a/crates/rewrite/testfiles/elf/base-relr-i686.noop
+++ b/crates/rewrite/testfiles/elf/base-relr-i686.noop
@@ -1,0 +1,1433 @@
+Format: ELF 32-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS32 (0x1)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_DYN (0x3)
+    Machine: EM_386 (0x3)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x1060
+    ProgramHeaderOffset: 0x34
+    SectionHeaderOffset: 0x35DC
+    Flags: 0x0
+    HeaderSize: 0x34
+    ProgramHeaderEntrySize: 0x20
+    ProgramHeaderCount: 11
+    SectionHeaderEntrySize: 0x28
+    SectionHeaderCount: 30
+    SectionHeaderStringTableIndex: 29
+}
+ProgramHeader {
+    Type: PT_PHDR (0x6)
+    Offset: 0x34
+    VirtualAddress: 0x34
+    PhysicalAddress: 0x34
+    FileSize: 0x160
+    MemorySize: 0x160
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_INTERP (0x3)
+    Offset: 0x194
+    VirtualAddress: 0x194
+    PhysicalAddress: 0x194
+    FileSize: 0x13
+    MemorySize: 0x13
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+    Interpreter: "/lib/ld-linux.so.2"
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x3E8
+    MemorySize: 0x3E8
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x1000
+    VirtualAddress: 0x1000
+    PhysicalAddress: 0x1000
+    FileSize: 0x1E8
+    MemorySize: 0x1E8
+    Flags: 0x5
+        PF_X (0x1)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2000
+    VirtualAddress: 0x2000
+    PhysicalAddress: 0x2000
+    FileSize: 0x114
+    MemorySize: 0x114
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2EC0
+    VirtualAddress: 0x3EC0
+    PhysicalAddress: 0x3EC0
+    FileSize: 0x148
+    MemorySize: 0x14C
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_DYNAMIC (0x2)
+    Offset: 0x2EC8
+    VirtualAddress: 0x3EC8
+    PhysicalAddress: 0x3EC8
+    FileSize: 0x110
+    MemorySize: 0x110
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x4
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6"
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x11D4
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3EC0
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3EC4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x1EC
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x28C
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x20C
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xBA
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FD8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x11
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x3C8
+    }
+    Dynamic {
+        Tag: DT_REL (0x11)
+        Value: 0x3A8
+    }
+    Dynamic {
+        Tag: DT_RELSZ (0x12)
+        Value: 0x20
+    }
+    Dynamic {
+        Tag: DT_RELENT (0x13)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x358
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x346
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+ProgramHeader {
+    Type: PT_NOTE (0x4)
+    Offset: 0x1A8
+    VirtualAddress: 0x1A8
+    PhysicalAddress: 0x1A8
+    FileSize: 0x44
+    MemorySize: 0x44
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [20, F1, CF, 5C, 28, A0, 2E, 84, 7F, 7D, 64, 9B, 89, ED, 5E, 93, 3E, 47, 4B, 98]
+    }
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+ProgramHeader {
+    Type: PT_GNU_EH_FRAME (0x6474E550)
+    Offset: 0x2018
+    VirtualAddress: 0x2018
+    PhysicalAddress: 0x2018
+    FileSize: 0x34
+    MemorySize: 0x34
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_GNU_STACK (0x6474E551)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x0
+    MemorySize: 0x0
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x10
+}
+ProgramHeader {
+    Type: PT_GNU_RELRO (0x6474E552)
+    Offset: 0x2EC0
+    VirtualAddress: 0x3EC0
+    PhysicalAddress: 0x3EC0
+    FileSize: 0x140
+    MemorySize: 0x140
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+}
+SectionHeader {
+    Index: 0
+    Name: ""
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".interp"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x194
+    Offset: 0x194
+    Size: 0x13
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".note.gnu.build-id"
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x1A8
+    Offset: 0x1A8
+    Size: 0x24
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [20, F1, CF, 5C, 28, A0, 2E, 84, 7F, 7D, 64, 9B, 89, ED, 5E, 93, 3E, 47, 4B, 98]
+    }
+}
+SectionHeader {
+    Index: 3
+    Name: ".note.ABI-tag"
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x1CC
+    Offset: 0x1CC
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".gnu.hash"
+    Type: SHT_GNU_HASH (0x6FFFFFF6)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x1EC
+    Offset: 0x1EC
+    Size: 0x20
+    Link: 5
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+    GnuHash {
+        BucketCount: 2
+        SymbolBase: 7
+        BloomCount: 1
+        BloomShift: 5
+    }
+}
+SectionHeader {
+    Index: 5
+    Name: ".dynsym"
+    Type: SHT_DYNSYM (0xB)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x20C
+    Offset: 0x20C
+    Size: 0x80
+    Link: 6
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x10
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "__libc_start_main"
+        Version: "GLIBC_2.34"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 2
+        Name: "_ITM_deregisterTMCloneTable"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 3
+        Name: "printf"
+        Version: "GLIBC_2.0"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 4
+        Name: "__cxa_finalize"
+        Version: "GLIBC_2.1.3"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 5
+        Name: "__gmon_start__"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 6
+        Name: "_ITM_registerTMCloneTable"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 7
+        Name: "_IO_stdin_used"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x2004
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".dynstr"
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x28C
+    Offset: 0x28C
+    Size: 0xBA
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 7
+    Name: ".gnu.version"
+    Type: SHT_GNU_VERSYM (0x6FFFFFFF)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x346
+    Offset: 0x346
+    Size: 0x10
+    Link: 5
+    Info: 0
+    AddressAlign: 0x2
+    EntrySize: 0x2
+    VersionSymbol {
+        Index: 0
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 1
+        Version: "GLIBC_2.34"
+    }
+    VersionSymbol {
+        Index: 2
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 3
+        Version: "GLIBC_2.0"
+    }
+    VersionSymbol {
+        Index: 4
+        Version: "GLIBC_2.1.3"
+    }
+    VersionSymbol {
+        Index: 5
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 6
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 7
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+}
+SectionHeader {
+    Index: 8
+    Name: ".gnu.version_r"
+    Type: SHT_GNU_VERNEED (0x6FFFFFFE)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x358
+    Offset: 0x358
+    Size: 0x50
+    Link: 6
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    VersionNeed {
+        Version: 1
+        AuxCount: 4
+        Filename: "libc.so.6"
+        AuxOffset: 16
+        NextOffset: 0
+        Aux {
+            Hash: 0xFD0E42
+            Flags: 0x0
+            Index: 2
+            Name: "GLIBC_ABI_DT_RELR"
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x9691F73
+            Flags: 0x0
+            Index: 3
+            Name: "GLIBC_2.1.3"
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0xD696910
+            Flags: 0x0
+            Index: 4
+            Name: "GLIBC_2.0"
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x69691B4
+            Flags: 0x0
+            Index: 5
+            Name: "GLIBC_2.34"
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 9
+    Name: ".rel.dyn"
+    Type: SHT_REL (0x9)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3A8
+    Offset: 0x3A8
+    Size: 0x20
+    Link: 5
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Relocation {
+        Offset: 0x3FEC
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "_ITM_deregisterTMCloneTable"
+    }
+    Relocation {
+        Offset: 0x3FF0
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "__cxa_finalize"
+    }
+    Relocation {
+        Offset: 0x3FF4
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "__gmon_start__"
+    }
+    Relocation {
+        Offset: 0x3FFC
+        Type: R_386_GLOB_DAT (0x6)
+        Symbol: "_ITM_registerTMCloneTable"
+    }
+}
+SectionHeader {
+    Index: 10
+    Name: ".rel.plt"
+    Type: SHT_REL (0x9)
+    Flags: 0x42
+        SHF_ALLOC (0x2)
+        SHF_INFO_LINK (0x40)
+    Address: 0x3C8
+    Offset: 0x3C8
+    Size: 0x10
+    Link: 5
+    Info: 23
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Relocation {
+        Offset: 0x3FE4
+        Type: R_386_JMP_SLOT (0x7)
+        Symbol: "__libc_start_main"
+    }
+    Relocation {
+        Offset: 0x3FE8
+        Type: R_386_JMP_SLOT (0x7)
+        Symbol: "printf"
+    }
+}
+SectionHeader {
+    Index: 11
+    Name: ".relr.dyn"
+    Type: SHT_RELR (0x13)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3D8
+    Offset: 0x3D8
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+    Offset: 0x3EC0
+    Offset: 0x3EC4
+    Offset: 0x3FF8
+    Offset: 0x4004
+}
+SectionHeader {
+    Index: 12
+    Name: ".init"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1000
+    Offset: 0x1000
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 13
+    Name: ".plt"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1020
+    Offset: 0x1020
+    Size: 0x30
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 14
+    Name: ".plt.got"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1050
+    Offset: 0x1050
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 15
+    Name: ".text"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1060
+    Offset: 0x1060
+    Size: 0x171
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 16
+    Name: ".fini"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x11D4
+    Offset: 0x11D4
+    Size: 0x14
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 17
+    Name: ".rodata"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2000
+    Offset: 0x2000
+    Size: 0x15
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 18
+    Name: ".eh_frame_hdr"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2018
+    Offset: 0x2018
+    Size: 0x34
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 19
+    Name: ".eh_frame"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x204C
+    Offset: 0x204C
+    Size: 0xC8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 20
+    Name: ".init_array"
+    Type: SHT_INIT_ARRAY (0xE)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3EC0
+    Offset: 0x2EC0
+    Size: 0x4
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 21
+    Name: ".fini_array"
+    Type: SHT_FINI_ARRAY (0xF)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3EC4
+    Offset: 0x2EC4
+    Size: 0x4
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 22
+    Name: ".dynamic"
+    Type: SHT_DYNAMIC (0x6)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3EC8
+    Offset: 0x2EC8
+    Size: 0xE8
+    Link: 6
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x8
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6"
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x11D4
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3EC0
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3EC4
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x1EC
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x28C
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x20C
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xBA
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FD8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x11
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x3C8
+    }
+    Dynamic {
+        Tag: DT_REL (0x11)
+        Value: 0x3A8
+    }
+    Dynamic {
+        Tag: DT_RELSZ (0x12)
+        Value: 0x20
+    }
+    Dynamic {
+        Tag: DT_RELENT (0x13)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x358
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x346
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x10
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x4
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 23
+    Name: ".got"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3FD8
+    Offset: 0x2FD8
+    Size: 0x28
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+}
+SectionHeader {
+    Index: 24
+    Name: ".data"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4000
+    Offset: 0x3000
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 25
+    Name: ".bss"
+    Type: SHT_NOBITS (0x8)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4008
+    Offset: 0x3008
+    Size: 0x4
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 26
+    Name: ".comment"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x3008
+    Size: 0x26
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 27
+    Name: ".symtab"
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3030
+    Size: 0x280
+    Link: 28
+    Info: 18
+    AddressAlign: 0x4
+    EntrySize: 0x10
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "Scrt1.o"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 2
+        Name: "__abi_tag"
+        Value: 0x1CC
+        Size: 0x20
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 3
+    }
+    Symbol {
+        Index: 3
+        Name: "crtstuff.c"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 4
+        Name: "deregister_tm_clones"
+        Value: 0x10A0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 5
+        Name: "register_tm_clones"
+        Value: 0x10E0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 6
+        Name: "__do_global_dtors_aux"
+        Value: 0x1130
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 7
+        Name: "completed.0"
+        Value: 0x4008
+        Size: 0x1
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 8
+        Name: "__do_global_dtors_aux_fini_array_entry"
+        Value: 0x3EC4
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 21
+    }
+    Symbol {
+        Index: 9
+        Name: "frame_dummy"
+        Value: 0x1180
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 10
+        Name: "__frame_dummy_init_array_entry"
+        Value: 0x3EC0
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 20
+    }
+    Symbol {
+        Index: 11
+        Name: "base.c"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 12
+        Name: "crtstuff.c"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 13
+        Name: "__FRAME_END__"
+        Value: 0x2110
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 19
+    }
+    Symbol {
+        Index: 14
+        Name: ""
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 15
+        Name: "_DYNAMIC"
+        Value: 0x3EC8
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 22
+    }
+    Symbol {
+        Index: 16
+        Name: "__GNU_EH_FRAME_HDR"
+        Value: 0x2018
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 18
+    }
+    Symbol {
+        Index: 17
+        Name: "_GLOBAL_OFFSET_TABLE_"
+        Value: 0x3FD8
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 23
+    }
+    Symbol {
+        Index: 18
+        Name: "__libc_start_main@GLIBC_2.34"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 19
+        Name: "_ITM_deregisterTMCloneTable"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 20
+        Name: "__x86.get_pc_thunk.bx"
+        Value: 0x1090
+        Size: 0x4
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 21
+        Name: "data_start"
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 22
+        Name: "printf@GLIBC_2.0"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 23
+        Name: "_edata"
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 24
+        Name: "_fini"
+        Value: 0x11D4
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 16
+    }
+    Symbol {
+        Index: 25
+        Name: "__x86.get_pc_thunk.dx"
+        Value: 0x1189
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 26
+        Name: "__cxa_finalize@GLIBC_2.1.3"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 27
+        Name: "__data_start"
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 28
+        Name: "__gmon_start__"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 29
+        Name: "__dso_handle"
+        Value: 0x4004
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 30
+        Name: "_IO_stdin_used"
+        Value: 0x2004
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 31
+        Name: "_end"
+        Value: 0x400C
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 32
+        Name: "_start"
+        Value: 0x1060
+        Size: 0x2C
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 33
+        Name: "_fp_hw"
+        Value: 0x2000
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 34
+        Name: "__bss_start"
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 35
+        Name: "main"
+        Value: 0x118D
+        Size: 0x40
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 36
+        Name: "__x86.get_pc_thunk.ax"
+        Value: 0x11CD
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 15
+    }
+    Symbol {
+        Index: 37
+        Name: "__TMC_END__"
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 38
+        Name: "_ITM_registerTMCloneTable"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 39
+        Name: "_init"
+        Value: 0x1000
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 12
+    }
+}
+SectionHeader {
+    Index: 28
+    Name: ".strtab"
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x32B0
+    Size: 0x223
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 29
+    Name: ".shstrtab"
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x34D3
+    Size: 0x106
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/crates/rewrite/testfiles/elf/base-relr-x86_64.noop
+++ b/crates/rewrite/testfiles/elf/base-relr-x86_64.noop
@@ -1,0 +1,1451 @@
+Format: ELF 64-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS64 (0x2)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_DYN (0x3)
+    Machine: EM_X86_64 (0x3E)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x1060
+    ProgramHeaderOffset: 0x40
+    SectionHeaderOffset: 0x3698
+    Flags: 0x0
+    HeaderSize: 0x40
+    ProgramHeaderEntrySize: 0x38
+    ProgramHeaderCount: 13
+    SectionHeaderEntrySize: 0x40
+    SectionHeaderCount: 32
+    SectionHeaderStringTableIndex: 31
+}
+ProgramHeader {
+    Type: PT_PHDR (0x6)
+    Offset: 0x40
+    VirtualAddress: 0x40
+    PhysicalAddress: 0x40
+    FileSize: 0x2D8
+    MemorySize: 0x2D8
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+}
+ProgramHeader {
+    Type: PT_INTERP (0x3)
+    Offset: 0x318
+    VirtualAddress: 0x318
+    PhysicalAddress: 0x318
+    FileSize: 0x1C
+    MemorySize: 0x1C
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+    Interpreter: "/lib64/ld-linux-x86-64.so.2"
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x618
+    MemorySize: 0x618
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x1000
+    VirtualAddress: 0x1000
+    PhysicalAddress: 0x1000
+    FileSize: 0x179
+    MemorySize: 0x179
+    Flags: 0x5
+        PF_X (0x1)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2000
+    VirtualAddress: 0x2000
+    PhysicalAddress: 0x2000
+    FileSize: 0xF4
+    MemorySize: 0xF4
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x2D88
+    VirtualAddress: 0x3D88
+    PhysicalAddress: 0x3D88
+    FileSize: 0x288
+    MemorySize: 0x290
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_DYNAMIC (0x2)
+    Offset: 0x2D98
+    VirtualAddress: 0x3D98
+    PhysicalAddress: 0x3D98
+    FileSize: 0x220
+    MemorySize: 0x220
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x8
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6"
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x116C
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3D88
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3D90
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x3B0
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x480
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xA1
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FB8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x7
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x5E8
+    }
+    Dynamic {
+        Tag: DT_RELA (0x7)
+        Value: 0x570
+    }
+    Dynamic {
+        Tag: DT_RELASZ (0x8)
+        Value: 0x78
+    }
+    Dynamic {
+        Tag: DT_RELAENT (0x9)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x530
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x522
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x600
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+ProgramHeader {
+    Type: PT_NOTE (0x4)
+    Offset: 0x338
+    VirtualAddress: 0x338
+    PhysicalAddress: 0x338
+    FileSize: 0x30
+    MemorySize: 0x30
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_PROPERTY_TYPE_0 (0x5)
+        Property {
+            Type: GNU_PROPERTY_X86_FEATURE_1_AND (0xC0000002)
+            Value: 0x3
+                GNU_PROPERTY_X86_FEATURE_1_IBT (0x1)
+                GNU_PROPERTY_X86_FEATURE_1_SHSTK (0x2)
+        }
+        Property {
+            Type: GNU_PROPERTY_X86_ISA_1_NEEDED (0xC0008002)
+            Value: 0x1
+                GNU_PROPERTY_X86_ISA_1_BASELINE (0x1)
+        }
+    }
+}
+ProgramHeader {
+    Type: PT_NOTE (0x4)
+    Offset: 0x368
+    VirtualAddress: 0x368
+    PhysicalAddress: 0x368
+    FileSize: 0x44
+    MemorySize: 0x44
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [1F, 9B, 45, 6B, D0, 2A, 5, F3, 6B, 88, 90, BA, B6, BC, FB, 39, E9, 39, CD, 99]
+    }
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+ProgramHeader {
+    Type: PT_GNU_PROPERTY (0x6474E553)
+    Offset: 0x338
+    VirtualAddress: 0x338
+    PhysicalAddress: 0x338
+    FileSize: 0x30
+    MemorySize: 0x30
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x8
+}
+ProgramHeader {
+    Type: PT_GNU_EH_FRAME (0x6474E550)
+    Offset: 0x2014
+    VirtualAddress: 0x2014
+    PhysicalAddress: 0x2014
+    FileSize: 0x34
+    MemorySize: 0x34
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x4
+}
+ProgramHeader {
+    Type: PT_GNU_STACK (0x6474E551)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x0
+    MemorySize: 0x0
+    Flags: 0x6
+        PF_W (0x2)
+        PF_R (0x4)
+    Align: 0x10
+}
+ProgramHeader {
+    Type: PT_GNU_RELRO (0x6474E552)
+    Offset: 0x2D88
+    VirtualAddress: 0x3D88
+    PhysicalAddress: 0x3D88
+    FileSize: 0x278
+    MemorySize: 0x278
+    Flags: 0x4
+        PF_R (0x4)
+    Align: 0x1
+}
+SectionHeader {
+    Index: 0
+    Name: ""
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".interp"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x318
+    Offset: 0x318
+    Size: 0x1C
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".note.gnu.property"
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x338
+    Offset: 0x338
+    Size: 0x30
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_PROPERTY_TYPE_0 (0x5)
+        Property {
+            Type: GNU_PROPERTY_X86_FEATURE_1_AND (0xC0000002)
+            Value: 0x3
+                GNU_PROPERTY_X86_FEATURE_1_IBT (0x1)
+                GNU_PROPERTY_X86_FEATURE_1_SHSTK (0x2)
+        }
+        Property {
+            Type: GNU_PROPERTY_X86_ISA_1_NEEDED (0xC0008002)
+            Value: 0x1
+                GNU_PROPERTY_X86_ISA_1_BASELINE (0x1)
+        }
+    }
+}
+SectionHeader {
+    Index: 3
+    Name: ".note.gnu.build-id"
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x368
+    Offset: 0x368
+    Size: 0x24
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_BUILD_ID (0x3)
+        Desc: [1F, 9B, 45, 6B, D0, 2A, 5, F3, 6B, 88, 90, BA, B6, BC, FB, 39, E9, 39, CD, 99]
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".note.ABI-tag"
+    Type: SHT_NOTE (0x7)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x38C
+    Offset: 0x38C
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    Note {
+        Name: "GNU"
+        Type: NT_GNU_ABI_TAG (0x1)
+        Desc: [0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+SectionHeader {
+    Index: 5
+    Name: ".gnu.hash"
+    Type: SHT_GNU_HASH (0x6FFFFFF6)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3B0
+    Offset: 0x3B0
+    Size: 0x20
+    Link: 6
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+    GnuHash {
+        BucketCount: 2
+        SymbolBase: 1
+        BloomCount: 1
+        BloomShift: 6
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".dynsym"
+    Type: SHT_DYNSYM (0xB)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x3D8
+    Offset: 0x3D8
+    Size: 0xA8
+    Link: 7
+    Info: 1
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "__libc_start_main"
+        Version: "GLIBC_2.34"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 2
+        Name: "_ITM_deregisterTMCloneTable"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 3
+        Name: "printf"
+        Version: "GLIBC_2.2.5"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 4
+        Name: "__gmon_start__"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 5
+        Name: "_ITM_registerTMCloneTable"
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 6
+        Name: "__cxa_finalize"
+        Version: "GLIBC_2.2.5"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+}
+SectionHeader {
+    Index: 7
+    Name: ".dynstr"
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x480
+    Offset: 0x480
+    Size: 0xA1
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 8
+    Name: ".gnu.version"
+    Type: SHT_GNU_VERSYM (0x6FFFFFFF)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x522
+    Offset: 0x522
+    Size: 0xE
+    Link: 6
+    Info: 0
+    AddressAlign: 0x2
+    EntrySize: 0x2
+    VersionSymbol {
+        Index: 0
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 1
+        Version: "GLIBC_2.34"
+    }
+    VersionSymbol {
+        Index: 2
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 3
+        Version: "GLIBC_2.2.5"
+    }
+    VersionSymbol {
+        Index: 4
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 5
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 6
+        Version: "GLIBC_2.2.5"
+    }
+}
+SectionHeader {
+    Index: 9
+    Name: ".gnu.version_r"
+    Type: SHT_GNU_VERNEED (0x6FFFFFFE)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x530
+    Offset: 0x530
+    Size: 0x40
+    Link: 7
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    VersionNeed {
+        Version: 1
+        AuxCount: 3
+        Filename: "libc.so.6"
+        AuxOffset: 16
+        NextOffset: 0
+        Aux {
+            Hash: 0xFD0E42
+            Flags: 0x0
+            Index: 2
+            Name: "GLIBC_ABI_DT_RELR"
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x9691A75
+            Flags: 0x0
+            Index: 3
+            Name: "GLIBC_2.2.5"
+            NextOffset: 16
+        }
+        Aux {
+            Hash: 0x69691B4
+            Flags: 0x0
+            Index: 4
+            Name: "GLIBC_2.34"
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 10
+    Name: ".rela.dyn"
+    Type: SHT_RELA (0x4)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x570
+    Offset: 0x570
+    Size: 0x78
+    Link: 6
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Relocation {
+        Offset: 0x3FD8
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "__libc_start_main"
+    }
+    Relocation {
+        Offset: 0x3FE0
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "_ITM_deregisterTMCloneTable"
+    }
+    Relocation {
+        Offset: 0x3FE8
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "__gmon_start__"
+    }
+    Relocation {
+        Offset: 0x3FF0
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "_ITM_registerTMCloneTable"
+    }
+    Relocation {
+        Offset: 0x3FF8
+        Type: R_X86_64_GLOB_DAT (0x6)
+        Symbol: "__cxa_finalize"
+    }
+}
+SectionHeader {
+    Index: 11
+    Name: ".rela.plt"
+    Type: SHT_RELA (0x4)
+    Flags: 0x42
+        SHF_ALLOC (0x2)
+        SHF_INFO_LINK (0x40)
+    Address: 0x5E8
+    Offset: 0x5E8
+    Size: 0x18
+    Link: 6
+    Info: 25
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Relocation {
+        Offset: 0x3FD0
+        Type: R_X86_64_JUMP_SLOT (0x7)
+        Symbol: "printf"
+    }
+}
+SectionHeader {
+    Index: 12
+    Name: ".relr.dyn"
+    Type: SHT_RELR (0x13)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x600
+    Offset: 0x600
+    Size: 0x18
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+    Offset: 0x3D88
+    Offset: 0x3D90
+    Offset: 0x4008
+}
+SectionHeader {
+    Index: 13
+    Name: ".init"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1000
+    Offset: 0x1000
+    Size: 0x1B
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 14
+    Name: ".plt"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1020
+    Offset: 0x1020
+    Size: 0x20
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x10
+}
+SectionHeader {
+    Index: 15
+    Name: ".plt.got"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1040
+    Offset: 0x1040
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x10
+}
+SectionHeader {
+    Index: 16
+    Name: ".plt.sec"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1050
+    Offset: 0x1050
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x10
+}
+SectionHeader {
+    Index: 17
+    Name: ".text"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x1060
+    Offset: 0x1060
+    Size: 0x10C
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 18
+    Name: ".fini"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x116C
+    Offset: 0x116C
+    Size: 0xD
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 19
+    Name: ".rodata"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2000
+    Offset: 0x2000
+    Size: 0x11
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 20
+    Name: ".eh_frame_hdr"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2014
+    Offset: 0x2014
+    Size: 0x34
+    Link: 0
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 21
+    Name: ".eh_frame"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x2048
+    Offset: 0x2048
+    Size: 0xAC
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 22
+    Name: ".init_array"
+    Type: SHT_INIT_ARRAY (0xE)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3D88
+    Offset: 0x2D88
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 23
+    Name: ".fini_array"
+    Type: SHT_FINI_ARRAY (0xF)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3D90
+    Offset: 0x2D90
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 24
+    Name: ".dynamic"
+    Type: SHT_DYNAMIC (0x6)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3D98
+    Offset: 0x2D98
+    Size: 0x1D0
+    Link: 7
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x10
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6"
+    }
+    Dynamic {
+        Tag: DT_INIT (0xC)
+        Value: 0x1000
+    }
+    Dynamic {
+        Tag: DT_FINI (0xD)
+        Value: 0x116C
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAY (0x19)
+        Value: 0x3D88
+    }
+    Dynamic {
+        Tag: DT_INIT_ARRAYSZ (0x1B)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAY (0x1A)
+        Value: 0x3D90
+    }
+    Dynamic {
+        Tag: DT_FINI_ARRAYSZ (0x1C)
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_GNU_HASH (0x6FFFFEF5)
+        Value: 0x3B0
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x480
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0x3D8
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0xA1
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_DEBUG (0x15)
+        Value: 0x0
+    }
+    Dynamic {
+        Tag: DT_PLTGOT (0x3)
+        Value: 0x3FB8
+    }
+    Dynamic {
+        Tag: DT_PLTRELSZ (0x2)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_PLTREL (0x14)
+        Value: 0x7
+    }
+    Dynamic {
+        Tag: DT_JMPREL (0x17)
+        Value: 0x5E8
+    }
+    Dynamic {
+        Tag: DT_RELA (0x7)
+        Value: 0x570
+    }
+    Dynamic {
+        Tag: DT_RELASZ (0x8)
+        Value: 0x78
+    }
+    Dynamic {
+        Tag: DT_RELAENT (0x9)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: 0x8
+            DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x530
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x522
+    }
+    Dynamic {
+        Tag: 0x24
+        Value: 0x600
+    }
+    Dynamic {
+        Tag: 0x23
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: 0x25
+        Value: 0x8
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 25
+    Name: ".got"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x3FB8
+    Offset: 0x2FB8
+    Size: 0x48
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x8
+}
+SectionHeader {
+    Index: 26
+    Name: ".data"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4000
+    Offset: 0x3000
+    Size: 0x10
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 27
+    Name: ".bss"
+    Type: SHT_NOBITS (0x8)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x4010
+    Offset: 0x3010
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 28
+    Name: ".comment"
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x3010
+    Size: 0x26
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 29
+    Name: ".symtab"
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3038
+    Size: 0x360
+    Link: 30
+    Info: 18
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "Scrt1.o"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 2
+        Name: "__abi_tag"
+        Value: 0x38C
+        Size: 0x20
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 4
+    }
+    Symbol {
+        Index: 3
+        Name: "crtstuff.c"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 4
+        Name: "deregister_tm_clones"
+        Value: 0x1090
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 5
+        Name: "register_tm_clones"
+        Value: 0x10C0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 6
+        Name: "__do_global_dtors_aux"
+        Value: 0x1100
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 7
+        Name: "completed.0"
+        Value: 0x4010
+        Size: 0x1
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 27
+    }
+    Symbol {
+        Index: 8
+        Name: "__do_global_dtors_aux_fini_array_entry"
+        Value: 0x3D90
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 23
+    }
+    Symbol {
+        Index: 9
+        Name: "frame_dummy"
+        Value: 0x1140
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 10
+        Name: "__frame_dummy_init_array_entry"
+        Value: 0x3D88
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 22
+    }
+    Symbol {
+        Index: 11
+        Name: "base.c"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 12
+        Name: "crtstuff.c"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 13
+        Name: "__FRAME_END__"
+        Value: 0x20F0
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 21
+    }
+    Symbol {
+        Index: 14
+        Name: ""
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 15
+        Name: "_DYNAMIC"
+        Value: 0x3D98
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 24
+    }
+    Symbol {
+        Index: 16
+        Name: "__GNU_EH_FRAME_HDR"
+        Value: 0x2014
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 20
+    }
+    Symbol {
+        Index: 17
+        Name: "_GLOBAL_OFFSET_TABLE_"
+        Value: 0x3FB8
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 25
+    }
+    Symbol {
+        Index: 18
+        Name: "__libc_start_main@GLIBC_2.34"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 19
+        Name: "_ITM_deregisterTMCloneTable"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 20
+        Name: "data_start"
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 21
+        Name: "_edata"
+        Value: 0x4010
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 22
+        Name: "_fini"
+        Value: 0x116C
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 18
+    }
+    Symbol {
+        Index: 23
+        Name: "printf@GLIBC_2.2.5"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 24
+        Name: "__data_start"
+        Value: 0x4000
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 25
+        Name: "__gmon_start__"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 26
+        Name: "__dso_handle"
+        Value: 0x4008
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 27
+        Name: "_IO_stdin_used"
+        Value: 0x2000
+        Size: 0x4
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 19
+    }
+    Symbol {
+        Index: 28
+        Name: "_end"
+        Value: 0x4018
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 27
+    }
+    Symbol {
+        Index: 29
+        Name: "_start"
+        Value: 0x1060
+        Size: 0x26
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 30
+        Name: "__bss_start"
+        Value: 0x4010
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 27
+    }
+    Symbol {
+        Index: 31
+        Name: "main"
+        Value: 0x1149
+        Size: 0x23
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 17
+    }
+    Symbol {
+        Index: 32
+        Name: "__TMC_END__"
+        Value: 0x4010
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 26
+    }
+    Symbol {
+        Index: 33
+        Name: "_ITM_registerTMCloneTable"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 34
+        Name: "__cxa_finalize@GLIBC_2.2.5"
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 35
+        Name: "_init"
+        Value: 0x1000
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_HIDDEN (0x2)
+        SectionIndex: 13
+    }
+}
+SectionHeader {
+    Index: 30
+    Name: ".strtab"
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3398
+    Size: 0x1DC
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 31
+    Name: ".shstrtab"
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x3574
+    Size: 0x124
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/crates/rewrite/tests/testfiles.rs
+++ b/crates/rewrite/tests/testfiles.rs
@@ -42,6 +42,32 @@ fn rewrite_base_version() {
 }
 
 #[test]
+fn rewrite_base_relr() {
+    let print_options = readobj::PrintOptions {
+        string_indices: false,
+        ..readobj::PrintOptions::all()
+    };
+    let mut fail = false;
+
+    let options = object_rewrite::Options::default();
+    fail |= testfile(
+        "elf/base-relr-i686",
+        "elf/base-relr-i686.noop",
+        options,
+        &print_options,
+    );
+    let options = object_rewrite::Options::default();
+    fail |= testfile(
+        "elf/base-relr-x86_64",
+        "elf/base-relr-x86_64.noop",
+        options,
+        &print_options,
+    );
+
+    fail_message(fail);
+}
+
+#[test]
 fn rewrite_symbols() {
     let print_options = readobj::PrintOptions {
         string_indices: false,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -710,6 +710,8 @@ pub const SHT_PREINIT_ARRAY: u32 = 16;
 pub const SHT_GROUP: u32 = 17;
 /// Extended section indices for a symbol table.
 pub const SHT_SYMTAB_SHNDX: u32 = 18;
+/// Relocation entries; only offsets.
+pub const SHT_RELR: u32 = 19;
 /// Start of OS-specific section types.
 pub const SHT_LOOS: u32 = 0x6000_0000;
 /// LLVM-style dependent libraries.
@@ -1216,6 +1218,16 @@ impl<E: Endian> Rela64<E> {
         self.r_info = Self::r_info(endian, is_mips64el, r_sym, r_type);
     }
 }
+
+/// 32-bit relative relocation table entry.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Relr32<E: Endian>(pub U32<E>);
+
+/// 64-bit relative relocation table entry.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Relr64<E: Endian>(pub U64<E>);
 
 /// Program segment header.
 #[derive(Debug, Clone, Copy)]
@@ -6460,6 +6472,8 @@ unsafe_impl_endian_pod!(
     Rel64,
     Rela32,
     Rela64,
+    Relr32,
+    Relr64,
     ProgramHeader32,
     ProgramHeader64,
     Dyn32,

--- a/src/read/any.rs
+++ b/src/read/any.rs
@@ -307,16 +307,56 @@ impl<'data, R> Object<'data> for File<'data, R>
 where
     R: ReadRef<'data>,
 {
-    type Segment<'file> = Segment<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = SegmentIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type Section<'file> = Section<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = SectionIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = Comdat<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = ComdatIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = Symbol<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = SymbolIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = SymbolTable<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = DynamicRelocationIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = Segment<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = SegmentIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = Section<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = SectionIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = Comdat<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = ComdatIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = Symbol<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = SymbolIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = SymbolTable<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = DynamicRelocationIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
 
     fn architecture(&self) -> Architecture {
         with_inner!(self, File, |x| x.architecture())

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -90,16 +90,56 @@ where
     R: ReadRef<'data>,
     Coff: CoffHeader,
 {
-    type Segment<'file> = CoffSegment<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = CoffSegmentIterator<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type Section<'file> = CoffSection<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = CoffSectionIterator<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = CoffComdat<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = CoffComdatIterator<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = CoffSymbol<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = CoffSymbolIterator<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = CoffSymbolTable<'data, 'file, R, Coff> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = NoDynamicRelocationIterator where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = CoffSegment<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = CoffSegmentIterator<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = CoffSection<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = CoffSectionIterator<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = CoffComdat<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = CoffComdatIterator<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = CoffSymbol<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = CoffSymbolIterator<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = CoffSymbolTable<'data, 'file, R, Coff>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = NoDynamicRelocationIterator
+    where
+        Self: 'file,
+        'data: 'file;
 
     fn architecture(&self) -> Architecture {
         match self.header.machine() {

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -14,7 +14,7 @@ use crate::read::{
 use super::{
     CompressionHeader, Dyn, ElfComdat, ElfComdatIterator, ElfDynamicRelocationIterator, ElfSection,
     ElfSectionIterator, ElfSegment, ElfSegmentIterator, ElfSymbol, ElfSymbolIterator,
-    ElfSymbolTable, NoteHeader, ProgramHeader, Rel, Rela, RelocationSections, SectionHeader,
+    ElfSymbolTable, NoteHeader, ProgramHeader, Rel, Rela, RelocationSections, Relr, SectionHeader,
     SectionTable, Sym, SymbolTable,
 };
 
@@ -485,7 +485,7 @@ where
 #[allow(missing_docs)]
 pub trait FileHeader: Debug + Pod {
     // Ideally this would be a `u64: From<Word>`, but can't express that.
-    type Word: Into<u64>;
+    type Word: Into<u64> + Default + Copy;
     type Sword: Into<i64>;
     type Endian: endian::Endian;
     type ProgramHeader: ProgramHeader<Elf = Self, Endian = Self::Endian, Word = Self::Word>;
@@ -496,6 +496,7 @@ pub trait FileHeader: Debug + Pod {
     type Sym: Sym<Endian = Self::Endian, Word = Self::Word>;
     type Rel: Rel<Endian = Self::Endian, Word = Self::Word>;
     type Rela: Rela<Endian = Self::Endian, Word = Self::Word> + From<Self::Rel>;
+    type Relr: Relr<Endian = Self::Endian, Word = Self::Word>;
 
     /// Return true if this type is a 64-bit header.
     ///
@@ -785,6 +786,7 @@ impl<Endian: endian::Endian> FileHeader for elf::FileHeader32<Endian> {
     type Sym = elf::Sym32<Endian>;
     type Rel = elf::Rel32<Endian>;
     type Rela = elf::Rela32<Endian>;
+    type Relr = elf::Relr32<Endian>;
 
     #[inline]
     fn is_type_64(&self) -> bool {
@@ -882,6 +884,7 @@ impl<Endian: endian::Endian> FileHeader for elf::FileHeader64<Endian> {
     type Sym = elf::Sym64<Endian>;
     type Rel = elf::Rel64<Endian>;
     type Rela = elf::Rela64<Endian>;
+    type Relr = elf::Relr64<Endian>;
 
     #[inline]
     fn is_type_64(&self) -> bool {

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -187,16 +187,56 @@ where
     Elf: FileHeader,
     R: ReadRef<'data>,
 {
-    type Segment<'file> = ElfSegment<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = ElfSegmentIterator<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type Section<'file> = ElfSection<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = ElfSectionIterator<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = ElfComdat<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = ElfComdatIterator<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = ElfSymbol<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = ElfSymbolIterator<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = ElfSymbolTable<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = ElfDynamicRelocationIterator<'data, 'file, Elf, R> where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = ElfSegment<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = ElfSegmentIterator<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = ElfSection<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = ElfSectionIterator<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = ElfComdat<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = ElfComdatIterator<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = ElfSymbol<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = ElfSymbolIterator<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = ElfSymbolTable<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = ElfDynamicRelocationIterator<'data, 'file, Elf, R>
+    where
+        Self: 'file,
+        'data: 'file;
 
     fn architecture(&self) -> Architecture {
         match (

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -221,16 +221,56 @@ where
     Mach: MachHeader,
     R: ReadRef<'data>,
 {
-    type Segment<'file> = MachOSegment<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = MachOSegmentIterator<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type Section<'file> = MachOSection<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = MachOSectionIterator<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = MachOComdat<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = MachOComdatIterator<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = MachOSymbol<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = MachOSymbolIterator<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = MachOSymbolTable<'data, 'file, Mach, R> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = NoDynamicRelocationIterator where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = MachOSegment<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = MachOSegmentIterator<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = MachOSection<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = MachOSectionIterator<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = MachOComdat<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = MachOComdatIterator<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = MachOSymbol<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = MachOSymbolIterator<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = MachOSymbolTable<'data, 'file, Mach, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = NoDynamicRelocationIterator
+    where
+        Self: 'file,
+        'data: 'file;
 
     fn architecture(&self) -> Architecture {
         match self.header.cputype(self.endian) {

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -143,16 +143,56 @@ where
     Pe: ImageNtHeaders,
     R: ReadRef<'data>,
 {
-    type Segment<'file> = PeSegment<'data, 'file, Pe, R> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = PeSegmentIterator<'data, 'file, Pe, R> where Self: 'file, 'data: 'file;
-    type Section<'file> = PeSection<'data, 'file, Pe, R> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = PeSectionIterator<'data, 'file, Pe, R> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = PeComdat<'data, 'file, Pe, R> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = PeComdatIterator<'data, 'file, Pe, R> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = CoffSymbol<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = CoffSymbolIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = CoffSymbolTable<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = NoDynamicRelocationIterator where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = PeSegment<'data, 'file, Pe, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = PeSegmentIterator<'data, 'file, Pe, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = PeSection<'data, 'file, Pe, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = PeSectionIterator<'data, 'file, Pe, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = PeComdat<'data, 'file, Pe, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = PeComdatIterator<'data, 'file, Pe, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = CoffSymbol<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = CoffSymbolIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = CoffSymbolTable<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = NoDynamicRelocationIterator
+    where
+        Self: 'file,
+        'data: 'file;
 
     fn architecture(&self) -> Architecture {
         match self.nt_headers.file_header().machine.get(LE) {

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -372,16 +372,56 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
 impl<'data, R> read::private::Sealed for WasmFile<'data, R> {}
 
 impl<'data, R: ReadRef<'data>> Object<'data> for WasmFile<'data, R> {
-    type Segment<'file> = WasmSegment<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = WasmSegmentIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type Section<'file> = WasmSection<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = WasmSectionIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = WasmComdat<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = WasmComdatIterator<'data, 'file, R> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = WasmSymbol<'data, 'file> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = WasmSymbolIterator<'data, 'file> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = WasmSymbolTable<'data, 'file> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = NoDynamicRelocationIterator where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = WasmSegment<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = WasmSegmentIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = WasmSection<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = WasmSectionIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = WasmComdat<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = WasmComdatIterator<'data, 'file, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = WasmSymbol<'data, 'file>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = WasmSymbolIterator<'data, 'file>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = WasmSymbolTable<'data, 'file>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = NoDynamicRelocationIterator
+    where
+        Self: 'file,
+        'data: 'file;
 
     #[inline]
     fn architecture(&self) -> Architecture {

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -110,16 +110,56 @@ where
     Xcoff: FileHeader,
     R: ReadRef<'data>,
 {
-    type Segment<'file> = XcoffSegment<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type SegmentIterator<'file> = XcoffSegmentIterator<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type Section<'file> = XcoffSection<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type SectionIterator<'file> = XcoffSectionIterator<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type Comdat<'file> = XcoffComdat<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type ComdatIterator<'file> = XcoffComdatIterator<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type Symbol<'file> = XcoffSymbol<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type SymbolIterator<'file> = XcoffSymbolIterator<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type SymbolTable<'file> = XcoffSymbolTable<'data, 'file, Xcoff, R> where Self: 'file, 'data: 'file;
-    type DynamicRelocationIterator<'file> = NoDynamicRelocationIterator where Self: 'file, 'data: 'file;
+    type Segment<'file>
+        = XcoffSegment<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SegmentIterator<'file>
+        = XcoffSegmentIterator<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Section<'file>
+        = XcoffSection<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SectionIterator<'file>
+        = XcoffSectionIterator<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Comdat<'file>
+        = XcoffComdat<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type ComdatIterator<'file>
+        = XcoffComdatIterator<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type Symbol<'file>
+        = XcoffSymbol<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolIterator<'file>
+        = XcoffSymbolIterator<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type SymbolTable<'file>
+        = XcoffSymbolTable<'data, 'file, Xcoff, R>
+    where
+        Self: 'file,
+        'data: 'file;
+    type DynamicRelocationIterator<'file>
+        = NoDynamicRelocationIterator
+    where
+        Self: 'file,
+        'data: 'file;
 
     fn architecture(&self) -> Architecture {
         if self.is_64() {

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -1978,6 +1978,30 @@ impl<'a> Writer<'a> {
         });
     }
 
+    /// Write the section header for a relative relocation section.
+    ///
+    /// `offset` is the file offset of the relocations.
+    /// `size` is the size of the section in bytes.
+    pub fn write_relative_relocation_section_header(
+        &mut self,
+        name: StringId,
+        offset: usize,
+        size: usize,
+    ) {
+        self.write_section_header(&SectionHeader {
+            name: Some(name),
+            sh_type: elf::SHT_RELA,
+            sh_flags: 0,
+            sh_addr: 0,
+            sh_offset: offset as u64,
+            sh_size: size as u64,
+            sh_link: 0,
+            sh_info: 0,
+            sh_addralign: self.elf_align as u64,
+            sh_entsize: self.class().relr_size() as u64,
+        });
+    }
+
     /// Reserve a file range for a COMDAT section.
     ///
     /// `count` is the number of sections in the COMDAT group.
@@ -2219,6 +2243,15 @@ impl Class {
             } else {
                 mem::size_of::<elf::Rel32<Endianness>>()
             }
+        }
+    }
+
+    /// Return the size of a relative relocation entry.
+    pub fn relr_size(self) -> usize {
+        if self.is_64 {
+            mem::size_of::<elf::Relr64<Endianness>>()
+        } else {
+            mem::size_of::<elf::Relr32<Endianness>>()
         }
     }
 


### PR DESCRIPTION
This adds a low level API for reading `SHT_RELR` relocations, and changes the ELF builder to copy the section.

This doesn't add the relocations to the `read::Object` trait. It's not clear what the best way to support this is. Adding them into `Object::dynamic_relocations` would require synthesizing fields of the `Relocation`. An alternative is to add a new method, and perhaps this method could cover PE base relocations (which are also not currently handled by the `read::Object` trait). This can wait until someone has a use case for these so that it can be tested properly.

In the future, the ELF builder may need to support modifying the relocations. The difficulty with this is that the relocations would need to be encoded again before doing layout. Again, this can wait until someone has a use case for this. This is the same as the existing support for various other sections.

Closes #722, closes #744 (cc @bjorn3, @fg-scontain)