### PR TITLE
Implement `core::error::Error` on Rust 1.81+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2018"
 keywords = ["object", "elf", "mach-o", "pe", "coff"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/gimli-rs/object"
+# NB: if this number increases to 1.81-or-later delete the `build.rs` script
+# as it's no longer necessary.
 rust-version = "1.65"
 description = "A unified interface for reading and writing object file formats."
 include = [

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+use std::str;
+
+fn main() {
+    // Temporary check to see if the rustc version >= 1.81 in which case the
+    // `Error` trait is always available. This is temporary because in the
+    // future the MSRV of this crate will be beyond 1.81 in which case this
+    // build script can be deleted.
+    let minor = rustc_minor_version().unwrap_or(0);
+    if minor >= 81 {
+        println!("cargo:rustc-cfg=core_error");
+    }
+    if minor >= 80 {
+        println!("cargo:rustc-check-cfg=cfg(core_error)");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = std::env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -24,6 +24,8 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl error::Error for Error {}
+#[cfg(all(not(feature = "std"), core_error))]
+impl core::error::Error for Error {}
 
 impl From<read::Error> for Error {
     fn from(error: read::Error) -> Error {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -124,6 +124,8 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
+#[cfg(all(not(feature = "std"), core_error))]
+impl core::error::Error for Error {}
 
 /// The result type used within the read module.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -60,6 +60,8 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl error::Error for Error {}
+#[cfg(all(not(feature = "std"), core_error))]
+impl core::error::Error for Error {}
 
 /// The result type used within the write module.
 pub type Result<T> = result::Result<T, Error>;


### PR DESCRIPTION
This commit updates when the `Error` trait is implemented to account for how in Rust 1.81-and-prior the `Error` trait is always available, even in `core`. This is currently done with detection at build-time of the current Rust compiler version because the MSRV for this crate is below 1.81. In the future when the MSRV is increased, however, the build script can be deleted.