### PR TITLE
Skip . and $ in section name for subsections when an empty name is given

### DIFF
--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -76,8 +76,10 @@ impl<'a> Object<'a> {
 
     pub(crate) fn coff_subsection_name(&self, section: &[u8], value: &[u8]) -> Vec<u8> {
         let mut name = section.to_vec();
-        name.push(b'$');
-        name.extend_from_slice(value);
+        if !value.is_empty() {
+            name.push(b'$');
+            name.extend_from_slice(value);
+        }
         name
     }
 

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -113,8 +113,10 @@ impl<'a> Object<'a> {
 
     pub(crate) fn elf_subsection_name(&self, section: &[u8], value: &[u8]) -> Vec<u8> {
         let mut name = section.to_vec();
-        name.push(b'.');
-        name.extend_from_slice(value);
+        if !value.is_empty() {
+            name.push(b'.');
+            name.extend_from_slice(value);
+        }
         name
     }
 


### PR DESCRIPTION
So rather than producing `.text.` it now produces `.text`

Fixes https://github.com/gimli-rs/object/issues/409