### PR TITLE
Add `.size_hint()` implementation for `ArchiveSymbolIterator`

### DIFF
--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -806,15 +806,11 @@ impl<'data> Iterator for ArchiveSymbolIterator<'data> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match &self.0 {
             SymbolIteratorInternal::None => (0, None),
-            SymbolIteratorInternal::Gnu { offsets, names: _ } => offsets.size_hint(),
-            SymbolIteratorInternal::Gnu64 { offsets, names: _ } => offsets.size_hint(),
-            SymbolIteratorInternal::Bsd { offsets, names: _ } => offsets.size_hint(),
-            SymbolIteratorInternal::Bsd64 { offsets, names: _ } => offsets.size_hint(),
-            SymbolIteratorInternal::Coff {
-                members: _,
-                indices,
-                names: _,
-            } => {
+            SymbolIteratorInternal::Gnu { offsets, .. } => offsets.size_hint(),
+            SymbolIteratorInternal::Gnu64 { offsets, .. } => offsets.size_hint(),
+            SymbolIteratorInternal::Bsd { offsets, .. } => offsets.size_hint(),
+            SymbolIteratorInternal::Bsd64 { offsets, .. } => offsets.size_hint(),
+            SymbolIteratorInternal::Coff { indices, .. } => {
                 // The `slice::Iter` is in the indices field for this variant
                 indices.size_hint()
             }

--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -802,6 +802,24 @@ impl<'data> Iterator for ArchiveSymbolIterator<'data> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.0 {
+            SymbolIteratorInternal::None => (0, None),
+            SymbolIteratorInternal::Gnu { offsets, names: _ } => offsets.size_hint(),
+            SymbolIteratorInternal::Gnu64 { offsets, names: _ } => offsets.size_hint(),
+            SymbolIteratorInternal::Bsd { offsets, names: _ } => offsets.size_hint(),
+            SymbolIteratorInternal::Bsd64 { offsets, names: _ } => offsets.size_hint(),
+            SymbolIteratorInternal::Coff {
+                members: _,
+                indices,
+                names: _,
+            } => {
+                // The `slice::Iter` is in the indices field for this variant
+                indices.size_hint()
+            }
+        }
+    }
 }
 
 /// A symbol in the archive symbol table.


### PR DESCRIPTION
This PR adds a [`.size_hint()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.size_hint) implementation to the `ArchiveSymbolIterator`.

The value returned for this is the size hint value of the underlying `slice::Iter`. This provides the most accurate size hint without needing to add additional fields for keeping track of the iterator's state.


I have been working on a project where it would be nice to pre-allocate collections based on the number of symbols inside an archive's symbol map. The default `.size_hint()` implementation returns 0 and there is no API in this library that will get this value.