### PR TITLE
Add support for parsing N_STSYM from the Mach-O symbol table

### DIFF
--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -104,7 +104,7 @@ impl<'data, Mach: MachHeader, R: ReadRef<'data>> SymbolTable<'data, Mach, R> {
             if n_type & macho::N_STAB == 0 {
                 continue;
             }
-            // TODO: includes variables too (N_GSYM, N_STSYM). These may need to get their
+            // TODO: includes global symbols too (N_GSYM). These may need to get their
             // address from regular symbols though.
             match n_type {
                 macho::N_SO => {
@@ -145,6 +145,20 @@ impl<'data, Mach: MachHeader, R: ReadRef<'data>> SymbolTable<'data, Mach, R> {
                                     object,
                                 });
                             }
+                        }
+                    }
+                }
+                macho::N_STSYM => {
+                    // Static symbols have a single entry with the address of the symbol
+                    // but no size
+                    if let Ok(name) = nlist.name(endian, self.strings) {
+                        if let Some(object) = object {
+                            symbols.push(ObjectMapEntry {
+                                address: nlist.n_value(endian).into(),
+                                size: 0,
+                                name,
+                                object,
+                            })
                         }
                     }
                 }


### PR DESCRIPTION
Closes #763 

I couldn't see any test cases this would hit, but a few examples of running this locally using the `objectmap` example vs main:

<details>
  <summary>Full diff output on a compiled binary</summary>
  
```
❯ diff example_output_master example_output_branch
625a626,654
> 10003a198 0 __ZN11simple_test12STATIC_FIELD17hfda18a2f9fdf63afE /Users/sam/work/tardis/target/debug-test/deps/simple_test-f8e0227e6576d889.ektm87y5osdb2a6wchg62ejrj.rcgu.o
> 10003dbe8 0 __ZN4core7unicode12unicode_data15grapheme_extend17SHORT_OFFSET_RUNS17h5878be1170f5f7dfE /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcore-c8c2fe5a80a1416e.rlib(core-c8c2fe5a80a1416e.core.b495b0e88a16f434-cgu.0.rcgu.o)
> 10003dc70 0 __ZN4core7unicode12unicode_data15grapheme_extend7OFFSETS17h15156214a8e56da3E /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcore-c8c2fe5a80a1416e.rlib(core-c8c2fe5a80a1416e.core.b495b0e88a16f434-cgu.0.rcgu.o)
> 100048130 0 __ZN11simple_test18STATIC_TEST_STRUCT17he8be1661f8e21549E /Users/sam/work/tardis/target/debug-test/deps/simple_test-f8e0227e6576d889.ektm87y5osdb2a6wchg62ejrj.rcgu.o
> 100048590 0 __ZN11simple_test17TEST_STRUCT_SHAPE17hefda735d18036a5bE /Users/sam/work/tardis/target/debug-test/deps/simple_test-f8e0227e6576d889.ektm87y5osdb2a6wchg62ejrj.rcgu.o
> 10004c200 0 __ZN3std9panicking12default_hook28_$u7b$$u7b$closure$u7d$$u7d$11FIRST_PANIC17h81787064edade83aE /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004c208 0 __ZN3std12backtrace_rs9symbolize5gimli5Cache11with_global14MAPPINGS_CACHE17h79af92055f7b1400E /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cb80 0 __ZN3std3sys12thread_local11destructors4list5DTORS17hc57b9453bbec2501E /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cb98 0 __ZN3std3sys12thread_local5guard5apple6enable10REGISTERED17hd5c7fa533ca46ae3E.0 /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cbb0 0 __ZN3std9panicking11panic_count17LOCAL_PANIC_COUNT29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h300c4d3a855b9b6cE.0 /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cbc8 0 __ZN3std9panicking11panic_count17LOCAL_PANIC_COUNT29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h300c4d3a855b9b6cE.1 /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cbe0 0 __ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17ha28e7e1f57c36257E.0 /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cbf8 0 __ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17ha28e7e1f57c36257E.1 /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc10 0 __ZN3std2io5stdio14OUTPUT_CAPTURE29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h04e80ea78a732202E /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc40 0 __ZN3std3sys12thread_local11destructors4list5DTORS17hc57b9453bbec2501E$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc60 0 __ZN3std6thread7current2id2ID17h9bfd555bb30d0cf1E$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc68 0 __ZN3std3sys12thread_local5guard5apple6enable10REGISTERED17hd5c7fa533ca46ae3E.0$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc70 0 __ZN3std9panicking11panic_count17LOCAL_PANIC_COUNT29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h300c4d3a855b9b6cE.0$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc78 0 __ZN3std9panicking11panic_count17LOCAL_PANIC_COUNT29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h300c4d3a855b9b6cE.1$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc80 0 __ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17ha28e7e1f57c36257E.0$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc88 0 __ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17ha28e7e1f57c36257E.1$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cc90 0 __ZN3std2io5stdio14OUTPUT_CAPTURE29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h04e80ea78a732202E$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cca0 0 __ZN3std6thread7current7CURRENT17h7a3573743031cad3E$tlv$init /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004ccd9 0 __ZN3std2io5stdio19OUTPUT_CAPTURE_USED17hd4a803cab52bc138E.0 /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cce0 0 __ZN3std5panic14SHOULD_CAPTURE17hbafc4c052b95e524E /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cce8 0 __ZN3std3sys9backtrace4lock4LOCK17h3a225e1dd3a93eedE /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004ccf8 0 __ZN3std5alloc4HOOK17h937171acd6b050e0E /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cd00 0 __ZN3std3sys3pal4unix2os8ENV_LOCK17h8d86ce29d004ccfcE /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
> 10004cd10 0 __MergedGlobals /Users/sam/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-b14eaf39f161baba.rlib(std-b14eaf39f161baba.std.9558dde1fef45f95-cgu.0.rcgu.o)
```
</details>

And then searching for a specific address:

master:

```bash
❯ cargo run --bin objectmap -- simple-test  10003a198
4295205272 not found
```

this branch:

```bash
❯ cargo run --bin objectmap -- simple-test  10003a198
10003a198 0 __ZN11simple_test12STATIC_FIELD17hfda18a2f9fdf63afE /Users/sam/work/tardis/target/debug-test/deps/simple_test-f8e0227e6576d889.ektm87y5osdb2a6wchg62ejrj.rcgu.o
```