### PR TITLE
cleanup: update to latest ruzstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,18 +281,12 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "ruzstd"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 dependencies = [
  "twox-hash",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -302,13 +296,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ indexmap = { version = "2.0", default-features = false, optional = true }
 wasmparser = { version = "0.222.0", default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
 hashbrown = { version = "0.15.0", features = ["default-hasher"], default-features = false, optional = true }
-ruzstd = { version = "0.7.0", optional = true }
+ruzstd = { version = "0.8.0", optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -998,11 +998,11 @@ impl<'data> CompressedData<'data> {
                     CompressionFormat::Zstandard => {
                         let mut input = self.data;
                         while !input.is_empty() {
-                            let mut decoder = match ruzstd::StreamingDecoder::new(&mut input) {
+                            let mut decoder = match ruzstd::decoding::StreamingDecoder::new(&mut input) {
                                 Ok(decoder) => decoder,
                                 Err(
-                                    ruzstd::frame_decoder::FrameDecoderError::ReadFrameHeaderError(
-                                        ruzstd::frame::ReadFrameHeaderError::SkipFrame {
+                                    ruzstd::decoding::errors::FrameDecoderError::ReadFrameHeaderError(
+                                        ruzstd::decoding::errors::ReadFrameHeaderError::SkipFrame {
                                             length,
                                             ..
                                         },


### PR DESCRIPTION
I noticed this because one of our robots complained about RUSTSEC-2024-0400, as we didn't have 0.7.3 imported. It turns out updating to the 0.8.x series was sufficiently easy I decided to just do it.