### PR TITLE
Add test case for COFF auxiliary weak externals

### DIFF
--- a/tests/read/coff.rs
+++ b/tests/read/coff.rs
@@ -21,3 +21,35 @@ fn coff_extended_relocations() {
     let relocations = code_section.relocations().collect::<Vec<_>>();
     assert_eq!(relocations.len(), 65536);
 }
+
+#[cfg(feature = "coff")]
+#[test]
+fn coff_weak_external() {
+    use object::{coff::ImageSymbol, ObjectSymbol};
+
+    let path_to_obj: PathBuf = ["testfiles", "pe", "weak-extern.o"].iter().collect();
+    let contents = fs::read(path_to_obj).expect("Could not read weak-extern.o");
+    let file =
+        read::coff::CoffFile::<_>::parse(&contents[..]).expect("Could not parse weak-extern.o");
+    let weak_symbol = file
+        .symbol_by_name("weak_symbol")
+        .expect("Could not find 'weak_symbol' symbol in weak-extern.o");
+
+    assert!(
+        weak_symbol.coff_symbol().has_aux_weak_external(),
+        "'weak_symbol' should have an auxiliary weak external symbol."
+    );
+
+    let weak_external = file
+        .coff_symbol_table()
+        .aux_weak_external(weak_symbol.index())
+        .expect("Could not parse auxiliary weak external symbol.");
+
+    let default_symbol_index = weak_external
+        .weak_default_sym_index
+        .get(object::LittleEndian);
+
+    let _ = file
+        .symbol_by_index(read::SymbolIndex(default_symbol_index as usize))
+        .expect("Could not find default symbol for weak external symbol.");
+}


### PR DESCRIPTION
This adds a small test case for checking COFF auxiliary weak externals using the test file from https://github.com/gimli-rs/object-testfiles/pull/25.

It requires updating the testfiles submodule to include the changes in gimli-rs/object-testfiles#25 for it to run.

See: #770 