### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,6 @@ dependencies = [
 name = "object"
 version = "0.37.0"
 dependencies = [
- "compiler_builtins",
  "crc32fast",
  "flate2",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ ruzstd = { version = "0.8.1", optional = true }
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
-compiler_builtins = { version = '0.1.2', optional = true }
 alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
 
 [features]
@@ -112,7 +111,7 @@ unstable-all = ["all", "unstable"]
 #=======================================
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc', 'memchr/rustc-dep-of-std']
+rustc-dep-of-std = ['core', 'alloc', 'memchr/rustc-dep-of-std']
 
 [workspace]
 members = ["crates/*"]


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993