### PR TITLE
Add EF_RISCV_RV64ILP32 constant

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -1305,7 +1305,8 @@ const FLAGS_EF_SH_MACH: &[Flag<u32>] = &flags!(
     EF_SH2A_SH3E,
 );
 const FLAGS_EF_S390: &[Flag<u32>] = &flags!(EF_S390_HIGH_GPRS);
-const FLAGS_EF_RISCV: &[Flag<u32>] = &flags!(EF_RISCV_RVC, EF_RISCV_RVE, EF_RISCV_TSO);
+const FLAGS_EF_RISCV: &[Flag<u32>] =
+    &flags!(EF_RISCV_RVC, EF_RISCV_RVE, EF_RISCV_TSO, EF_RISCV_RV64ILP32);
 const FLAGS_EF_RISCV_FLOAT_ABI: &[Flag<u32>] = &flags!(
     EF_RISCV_FLOAT_ABI_SOFT,
     EF_RISCV_FLOAT_ABI_SINGLE,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -5825,6 +5825,7 @@ pub const EF_RISCV_FLOAT_ABI_DOUBLE: u32 = 0x0004;
 pub const EF_RISCV_FLOAT_ABI_QUAD: u32 = 0x0006;
 pub const EF_RISCV_RVE: u32 = 0x0008;
 pub const EF_RISCV_TSO: u32 = 0x0010;
+pub const EF_RISCV_RV64ILP32: u32 = 0x0020;
 
 // RISC-V values for `SectionHeader*::sh_type`.
 /// RISC-V attributes section.


### PR DESCRIPTION
Add missing constant defined here:
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#elf-object-files