### PR TITLE
Support big-endian PowerPC COFF

### DIFF
--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -654,9 +654,9 @@ fn print_relocations<'data, Coff: CoffHeader>(
                     | IMAGE_FILE_MACHINE_MIPSFPU
                     | IMAGE_FILE_MACHINE_MIPSFPU16 => FLAGS_IMAGE_REL_MIPS,
                     IMAGE_FILE_MACHINE_ALPHA | IMAGE_FILE_MACHINE_ALPHA64 => FLAGS_IMAGE_REL_ALPHA,
-                    IMAGE_FILE_MACHINE_POWERPC | IMAGE_FILE_MACHINE_POWERPCFP => {
-                        FLAGS_IMAGE_REL_PPC
-                    }
+                    IMAGE_FILE_MACHINE_POWERPC
+                    | IMAGE_FILE_MACHINE_POWERPCFP
+                    | IMAGE_FILE_MACHINE_POWERPCBE => FLAGS_IMAGE_REL_PPC,
                     IMAGE_FILE_MACHINE_SH3
                     | IMAGE_FILE_MACHINE_SH3DSP
                     | IMAGE_FILE_MACHINE_SH3E
@@ -676,9 +676,9 @@ fn print_relocations<'data, Coff: CoffHeader>(
                 let typ = relocation.typ.get(LE);
                 p.field_enum("Type", typ, proc);
                 match machine {
-                    IMAGE_FILE_MACHINE_POWERPC | IMAGE_FILE_MACHINE_POWERPCFP => {
-                        p.flags(typ, 0, FLAGS_IMAGE_REL_PPC_BITS)
-                    }
+                    IMAGE_FILE_MACHINE_POWERPC
+                    | IMAGE_FILE_MACHINE_POWERPCFP
+                    | IMAGE_FILE_MACHINE_POWERPCBE => p.flags(typ, 0, FLAGS_IMAGE_REL_PPC_BITS),
                     IMAGE_FILE_MACHINE_SH3
                     | IMAGE_FILE_MACHINE_SH3DSP
                     | IMAGE_FILE_MACHINE_SH3E

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -337,6 +337,8 @@ pub const IMAGE_FILE_MACHINE_AM33: u16 = 0x01d3;
 /// IBM PowerPC Little-Endian
 pub const IMAGE_FILE_MACHINE_POWERPC: u16 = 0x01F0;
 pub const IMAGE_FILE_MACHINE_POWERPCFP: u16 = 0x01f1;
+/// IBM PowerPC Big-Endian
+pub const IMAGE_FILE_MACHINE_POWERPCBE: u16 = 0x01f2;
 /// Intel 64
 pub const IMAGE_FILE_MACHINE_IA64: u16 = 0x0200;
 /// MIPS

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -147,6 +147,9 @@ where
             pe::IMAGE_FILE_MACHINE_ARM64 | pe::IMAGE_FILE_MACHINE_ARM64EC => Architecture::Aarch64,
             pe::IMAGE_FILE_MACHINE_I386 => Architecture::I386,
             pe::IMAGE_FILE_MACHINE_AMD64 => Architecture::X86_64,
+            pe::IMAGE_FILE_MACHINE_POWERPC
+            | pe::IMAGE_FILE_MACHINE_POWERPCFP
+            | pe::IMAGE_FILE_MACHINE_POWERPCBE => Architecture::PowerPc,
             _ => Architecture::Unknown,
         }
     }
@@ -160,7 +163,10 @@ where
 
     #[inline]
     fn is_little_endian(&self) -> bool {
-        true
+        match self.header.machine() {
+            pe::IMAGE_FILE_MACHINE_POWERPCBE => false,
+            _ => true,
+        }
     }
 
     #[inline]

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -338,6 +338,10 @@ impl FileKind {
             | [0x64, 0xaa, ..]
             // COFF arm64ec
             | [0x41, 0xa6, ..]
+            // COFF ppc
+            | [0xf0, 0x01, ..]
+            | [0xf1, 0x01, ..]
+            | [0xf2, 0x01, ..]
             // COFF x86
             | [0x4c, 0x01, ..]
             // COFF x86-64


### PR DESCRIPTION
Used in Xbox 360 COFF. Technically it should return `Architecture::PowerPc64`, but it's unclear how to determine this from the COFF itself, so it returns `Architecture::PowerPc` for now. Define name and comment from https://github.com/microsoft/microsoft-pdb/blob/805655a28bd8198004be2ac27e6e0290121a5e89/cvdump/cvdump.cpp#L21.

Also adds PPC COFF magic(s) to `File::parse`.