### PR TITLE
read/elf: various CREL fixes

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -501,7 +501,7 @@ fn print_section_rela<Elf: FileHeader>(
                 );
                 let sym = relocation.symbol(endian, elf.is_mips64el(endian));
                 print_rel_symbol(p, endian, symbols, sym);
-                let addend = relocation.r_addend(endian).into() as u64;
+                let addend = relocation.r_addend(endian).into();
                 if addend != 0 {
                     p.field_hex("Addend", addend);
                 }
@@ -604,13 +604,8 @@ fn print_section_crel<Elf: FileHeader>(
 
             p.group("Relocation", |p| {
                 p.field_hex("Offset", relocation.r_offset);
-                p.field_enum("Type", relocation.r_type as u32, proc);
-                print_rel_symbol(
-                    p,
-                    endian,
-                    symbols,
-                    Some(SymbolIndex(relocation.r_sym as usize)),
-                );
+                p.field_enum("Type", relocation.r_type, proc);
+                print_rel_symbol(p, endian, symbols, relocation.symbol());
                 let addend = relocation.r_addend;
                 if addend != 0 {
                     p.field_hex("Addend", addend);

--- a/crates/examples/testfiles/elf/base-crel.o.objdump
+++ b/crates/examples/testfiles/elf/base-crel.o.objdump
@@ -1,0 +1,37 @@
+Format: Elf Little-endian 64-bit
+Kind: Relocatable
+Architecture: X86_64
+Flags: Elf { os_abi: 0, abi_version: 0, e_flags: 0 }
+Relative Address Base: 0
+Entry Address: 0
+1: Section { name: ".strtab", address: 0, size: 7b, align: 1, kind: Metadata, flags: Elf { sh_flags: 0 } }
+2: Section { name: ".text", address: 0, size: 25, align: 10, kind: Text, flags: Elf { sh_flags: 6 } }
+3: Section { name: ".crel.text", address: 0, size: 9, align: 1, kind: Metadata, flags: Elf { sh_flags: 40 } }
+4: Section { name: ".rodata.str1.1", address: 0, size: d, align: 1, kind: ReadOnlyString, flags: Elf { sh_flags: 32 } }
+5: Section { name: ".comment", address: 0, size: 57, align: 1, kind: OtherString, flags: Elf { sh_flags: 30 } }
+6: Section { name: ".note.GNU-stack", address: 0, size: 0, align: 1, kind: Other, flags: Elf { sh_flags: 0 } }
+7: Section { name: ".eh_frame", address: 0, size: 38, align: 8, kind: Elf(70000001), flags: Elf { sh_flags: 2 } }
+8: Section { name: ".crel.eh_frame", address: 0, size: 4, align: 1, kind: Metadata, flags: Elf { sh_flags: 40 } }
+9: Section { name: ".llvm_addrsig", address: 0, size: 1, align: 1, kind: Elf(6fff4c03), flags: Elf { sh_flags: 80000000 } }
+10: Section { name: ".symtab", address: 0, size: 90, align: 8, kind: Metadata, flags: Elf { sh_flags: 0 } }
+
+Symbols
+1: Symbol { name: "base.c", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: Elf { st_info: 4, st_other: 0 } }
+2: Symbol { name: "", address: 0, size: 0, kind: Section, section: Section(SectionIndex(2)), scope: Compilation, weak: false, flags: Elf { st_info: 3, st_other: 0 } }
+3: Symbol { name: ".L.str", address: 0, size: d, kind: Data, section: Section(SectionIndex(4)), scope: Compilation, weak: false, flags: Elf { st_info: 1, st_other: 0 } }
+4: Symbol { name: "main", address: 0, size: 25, kind: Text, section: Section(SectionIndex(2)), scope: Dynamic, weak: false, flags: Elf { st_info: 12, st_other: 0 } }
+5: Symbol { name: "printf", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: false, flags: Elf { st_info: 10, st_other: 0 } }
+
+.text relocations
+(12, Relocation { kind: Relative, encoding: Generic, size: 20, target: Symbol(SymbolIndex(3)), addend: fffffffffffffffc, implicit_addend: false, flags: Elf { r_type: 2 } })
+(19, Relocation { kind: PltRelative, encoding: Generic, size: 20, target: Symbol(SymbolIndex(5)), addend: fffffffffffffffc, implicit_addend: false, flags: Elf { r_type: 4 } })
+
+.eh_frame relocations
+(20, Relocation { kind: Relative, encoding: Generic, size: 20, target: Symbol(SymbolIndex(2)), addend: 0, implicit_addend: false, flags: Elf { r_type: 2 } })
+
+Dynamic symbols
+
+Dynamic relocations
+
+Symbol map
+0x0 "main"

--- a/crates/examples/testfiles/elf/base-crel.o.readobj
+++ b/crates/examples/testfiles/elf/base-crel.o.readobj
@@ -1,0 +1,256 @@
+Format: ELF 64-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS64 (0x2)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_REL (0x1)
+    Machine: EM_X86_64 (0x3E)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x0
+    ProgramHeaderOffset: 0x0
+    SectionHeaderOffset: 0x228
+    Flags: 0x0
+    HeaderSize: 0x40
+    ProgramHeaderEntrySize: 0x0
+    ProgramHeaderCount: 0
+    SectionHeaderEntrySize: 0x40
+    SectionHeaderCount: 11
+    SectionHeaderStringTableIndex: 1
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".strtab" (0x5C)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x1A6
+    Size: 0x7B
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".text" (0x6)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x6
+        SHF_ALLOC (0x2)
+        SHF_EXECINSTR (0x4)
+    Address: 0x0
+    Offset: 0x40
+    Size: 0x25
+    Link: 0
+    Info: 0
+    AddressAlign: 0x10
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 3
+    Name: ".crel.text" (0x1)
+    Type: 0x40000014
+    Flags: 0x40
+        SHF_INFO_LINK (0x40)
+    Address: 0x0
+    Offset: 0x198
+    Size: 0x9
+    Link: 10
+    Info: 2
+    AddressAlign: 0x1
+    EntrySize: 0x1
+    Relocation {
+        Offset: 0x12
+        Type: R_X86_64_PC32 (0x2)
+        Symbol: ".L.str" (0x3)
+        Addend: 0xFFFFFFFFFFFFFFFC
+    }
+    Relocation {
+        Offset: 0x19
+        Type: R_X86_64_PLT32 (0x4)
+        Symbol: "printf" (0x5)
+        Addend: 0xFFFFFFFFFFFFFFFC
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".rodata.str1.1" (0x6C)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x32
+        SHF_ALLOC (0x2)
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x65
+    Size: 0xD
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 5
+    Name: ".comment" (0xC)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x30
+        SHF_MERGE (0x10)
+        SHF_STRINGS (0x20)
+    Address: 0x0
+    Offset: 0x72
+    Size: 0x57
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x1
+}
+SectionHeader {
+    Index: 6
+    Name: ".note.GNU-stack" (0x21)
+    Type: SHT_PROGBITS (0x1)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0xC9
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 7
+    Name: ".eh_frame" (0x4B)
+    Type: SHT_X86_64_UNWIND (0x70000001)
+    Flags: 0x2
+        SHF_ALLOC (0x2)
+    Address: 0x0
+    Offset: 0xD0
+    Size: 0x38
+    Link: 0
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 8
+    Name: ".crel.eh_frame" (0x46)
+    Type: 0x40000014
+    Flags: 0x40
+        SHF_INFO_LINK (0x40)
+    Address: 0x0
+    Offset: 0x1A1
+    Size: 0x4
+    Link: 10
+    Info: 7
+    AddressAlign: 0x1
+    EntrySize: 0x1
+    Relocation {
+        Offset: 0x20
+        Type: R_X86_64_PC32 (0x2)
+        Symbol: "" (0x2)
+    }
+}
+SectionHeader {
+    Index: 9
+    Name: ".llvm_addrsig" (0x31)
+    Type: 0x6FFF4C03
+    Flags: 0x80000000
+        SHF_EXCLUDE (0x80000000)
+    Address: 0x0
+    Offset: 0x1A5
+    Size: 0x1
+    Link: 10
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 10
+    Name: ".symtab" (0x64)
+    Type: SHT_SYMTAB (0x2)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x108
+    Size: 0x90
+    Link: 1
+    Info: 4
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "base.c" (0x55)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FILE (0x4)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+    Symbol {
+        Index: 2
+        Name: "" (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_SECTION (0x3)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 2
+    }
+    Symbol {
+        Index: 3
+        Name: ".L.str" (0x15)
+        Value: 0x0
+        Size: 0xD
+        Type: STT_OBJECT (0x1)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 4
+    }
+    Symbol {
+        Index: 4
+        Name: "main" (0x1C)
+        Value: 0x0
+        Size: 0x25
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 2
+    }
+    Symbol {
+        Index: 5
+        Name: "printf" (0x3F)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+}

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -12,8 +12,8 @@ use crate::read::{
 };
 
 use super::{
-    CompressionHeader, Crel, Dyn, ElfComdat, ElfComdatIterator, ElfDynamicRelocationIterator,
-    ElfSection, ElfSectionIterator, ElfSegment, ElfSegmentIterator, ElfSymbol, ElfSymbolIterator,
+    CompressionHeader, Dyn, ElfComdat, ElfComdatIterator, ElfDynamicRelocationIterator, ElfSection,
+    ElfSectionIterator, ElfSegment, ElfSegmentIterator, ElfSymbol, ElfSymbolIterator,
     ElfSymbolTable, NoteHeader, ProgramHeader, Rel, Rela, RelocationSections, Relr, SectionHeader,
     SectionTable, Sym, SymbolTable,
 };
@@ -537,7 +537,7 @@ pub trait FileHeader: Debug + Pod {
     type Dyn: Dyn<Endian = Self::Endian, Word = Self::Word>;
     type Sym: Sym<Endian = Self::Endian, Word = Self::Word>;
     type Rel: Rel<Endian = Self::Endian, Word = Self::Word>;
-    type Rela: Rela<Endian = Self::Endian, Word = Self::Word> + From<Self::Rel> + From<Crel>;
+    type Rela: Rela<Endian = Self::Endian, Word = Self::Word> + From<Self::Rel>;
     type Relr: Relr<Endian = Self::Endian, Word = Self::Word>;
 
     /// Return true if this type is a 64-bit header.

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -5,11 +5,10 @@ use core::slice;
 
 use crate::elf;
 use crate::endian::{self, Endianness};
-use crate::endian::{Endian, I32, I64, U32, U64};
 use crate::pod::Pod;
 use crate::read::{
-    self, Bytes, Error, ReadRef, Relocation, RelocationEncoding, RelocationFlags, RelocationKind,
-    RelocationTarget, SectionIndex, SymbolIndex,
+    self, Bytes, Error, ReadError, ReadRef, Relocation, RelocationEncoding, RelocationFlags,
+    RelocationKind, RelocationTarget, SectionIndex, SymbolIndex,
 };
 
 use super::{ElfFile, FileHeader, SectionHeader, SectionTable};
@@ -81,30 +80,35 @@ impl RelocationSections {
     }
 }
 
-pub(super) enum ElfRelaIterator<'data, Elf: FileHeader> {
-    Rel(slice::Iter<'data, Elf::Rel>),
-    Rela(slice::Iter<'data, Elf::Rela>),
+pub(super) enum ElfRelocationIterator<'data, Elf: FileHeader> {
+    Rel(slice::Iter<'data, Elf::Rel>, Elf::Endian),
+    Rela(slice::Iter<'data, Elf::Rela>, Elf::Endian, bool),
     Crel(CrelIterator<'data>),
 }
 
-impl<'data, Elf: FileHeader> ElfRelaIterator<'data, Elf> {
+impl<'data, Elf: FileHeader> ElfRelocationIterator<'data, Elf> {
     fn is_rel(&self) -> bool {
         match self {
-            ElfRelaIterator::Rel(_) => true,
-            ElfRelaIterator::Rela(_) => false,
-            ElfRelaIterator::Crel(iterator) => !iterator.is_rela(),
+            ElfRelocationIterator::Rel(..) => true,
+            ElfRelocationIterator::Rela(..) => false,
+            ElfRelocationIterator::Crel(i) => !i.is_rela(),
         }
     }
 }
 
-impl<'data, Elf: FileHeader> Iterator for ElfRelaIterator<'data, Elf> {
-    type Item = Elf::Rela;
+impl<'data, Elf: FileHeader> Iterator for ElfRelocationIterator<'data, Elf> {
+    type Item = Crel;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            ElfRelaIterator::Rel(ref mut i) => i.next().cloned().map(Self::Item::from),
-            ElfRelaIterator::Rela(ref mut i) => i.next().cloned(),
-            ElfRelaIterator::Crel(ref mut i) => i.next().and_then(Result::ok).map(Self::Item::from),
+            ElfRelocationIterator::Rel(ref mut i, endian) => {
+                i.next().cloned().map(|rel| rel.into_crel(*endian))
+            }
+            ElfRelocationIterator::Rela(ref mut i, endian, is_mips64el) => i
+                .next()
+                .cloned()
+                .map(|rel| rel.into_crel(*endian, *is_mips64el)),
+            ElfRelocationIterator::Crel(ref mut i) => i.next().and_then(Result::ok),
         }
     }
 }
@@ -125,7 +129,7 @@ where
     /// The current relocation section index.
     pub(super) section_index: SectionIndex,
     pub(super) file: &'file ElfFile<'data, Elf, R>,
-    pub(super) relocations: Option<ElfRelaIterator<'data, Elf>>,
+    pub(super) relocations: Option<ElfRelocationIterator<'data, Elf>>,
 }
 
 impl<'data, 'file, Elf, R> Iterator for ElfDynamicRelocationIterator<'data, 'file, Elf, R>
@@ -142,7 +146,7 @@ where
                 if let Some(reloc) = relocations.next() {
                     let relocation =
                         parse_relocation(self.file.header, endian, reloc, relocations.is_rel());
-                    return Some((reloc.r_offset(endian).into(), relocation));
+                    return Some((reloc.r_offset, relocation));
                 }
                 self.relocations = None;
             }
@@ -157,18 +161,23 @@ where
             match section.sh_type(endian) {
                 elf::SHT_REL => {
                     if let Ok(relocations) = section.data_as_array(endian, self.file.data) {
-                        self.relocations = Some(ElfRelaIterator::Rel(relocations.iter()));
+                        self.relocations =
+                            Some(ElfRelocationIterator::Rel(relocations.iter(), endian));
                     }
                 }
                 elf::SHT_RELA => {
                     if let Ok(relocations) = section.data_as_array(endian, self.file.data) {
-                        self.relocations = Some(ElfRelaIterator::Rela(relocations.iter()));
+                        self.relocations = Some(ElfRelocationIterator::Rela(
+                            relocations.iter(),
+                            endian,
+                            self.file.header.is_mips64el(endian),
+                        ));
                     }
                 }
                 elf::SHT_CREL => {
                     if let Ok(data) = section.data(endian, self.file.data) {
                         if let Ok(relocations) = CrelIterator::new(data) {
-                            self.relocations = Some(ElfRelaIterator::Crel(relocations));
+                            self.relocations = Some(ElfRelocationIterator::Crel(relocations));
                         }
                     }
                 }
@@ -204,7 +213,7 @@ where
     /// The current pointer in the chain of relocation sections.
     pub(super) section_index: SectionIndex,
     pub(super) file: &'file ElfFile<'data, Elf, R>,
-    pub(super) relocations: Option<ElfRelaIterator<'data, Elf>>,
+    pub(super) relocations: Option<ElfRelocationIterator<'data, Elf>>,
 }
 
 impl<'data, 'file, Elf, R> Iterator for ElfSectionRelocationIterator<'data, 'file, Elf, R>
@@ -221,7 +230,7 @@ where
                 if let Some(reloc) = relocations.next() {
                     let relocation =
                         parse_relocation(self.file.header, endian, reloc, relocations.is_rel());
-                    return Some((reloc.r_offset(endian).into(), relocation));
+                    return Some((reloc.r_offset, relocation));
                 }
                 self.relocations = None;
             }
@@ -231,18 +240,23 @@ where
             match section.sh_type(endian) {
                 elf::SHT_REL => {
                     if let Ok(relocations) = section.data_as_array(endian, self.file.data) {
-                        self.relocations = Some(ElfRelaIterator::Rel(relocations.iter()));
+                        self.relocations =
+                            Some(ElfRelocationIterator::Rel(relocations.iter(), endian));
                     }
                 }
                 elf::SHT_RELA => {
                     if let Ok(relocations) = section.data_as_array(endian, self.file.data) {
-                        self.relocations = Some(ElfRelaIterator::Rela(relocations.iter()));
+                        self.relocations = Some(ElfRelocationIterator::Rela(
+                            relocations.iter(),
+                            endian,
+                            self.file.header.is_mips64el(endian),
+                        ));
                     }
                 }
                 elf::SHT_CREL => {
                     if let Ok(data) = section.data(endian, self.file.data) {
                         if let Ok(relocations) = CrelIterator::new(data) {
-                            self.relocations = Some(ElfRelaIterator::Crel(relocations));
+                            self.relocations = Some(ElfRelocationIterator::Crel(relocations));
                         }
                     }
                 }
@@ -265,14 +279,13 @@ where
 fn parse_relocation<Elf: FileHeader>(
     header: &Elf,
     endian: Elf::Endian,
-    reloc: Elf::Rela,
+    reloc: Crel,
     implicit_addend: bool,
 ) -> Relocation {
     use RelocationEncoding as E;
     use RelocationKind as K;
 
-    let is_mips64el = header.is_mips64el(endian);
-    let r_type = reloc.r_type(endian, is_mips64el);
+    let r_type = reloc.r_type;
     let flags = RelocationFlags::Elf { r_type };
     let g = E::Generic;
     let unknown = (K::Unknown, E::Generic, 0);
@@ -467,7 +480,7 @@ fn parse_relocation<Elf: FileHeader>(
         },
         _ => unknown,
     };
-    let target = match reloc.symbol(endian, is_mips64el) {
+    let target = match reloc.symbol() {
         None => RelocationTarget::Absolute,
         Some(symbol) => RelocationTarget::Symbol(symbol),
     };
@@ -476,7 +489,7 @@ fn parse_relocation<Elf: FileHeader>(
         encoding,
         size,
         target,
-        addend: reloc.r_addend(endian).into(),
+        addend: reloc.r_addend,
         implicit_addend,
         flags,
     }
@@ -505,6 +518,8 @@ pub trait Rel: Debug + Pod + Clone {
             Some(SymbolIndex(sym as usize))
         }
     }
+
+    fn into_crel(self, endian: Self::Endian) -> Crel;
 }
 
 impl<Endian: endian::Endian> Rel for elf::Rel32<Endian> {
@@ -530,6 +545,15 @@ impl<Endian: endian::Endian> Rel for elf::Rel32<Endian> {
     #[inline]
     fn r_type(&self, endian: Self::Endian) -> u32 {
         self.r_type(endian)
+    }
+
+    fn into_crel(self, endian: Self::Endian) -> Crel {
+        Crel {
+            r_offset: self.r_offset(endian).into(),
+            r_sym: self.r_sym(endian),
+            r_type: self.r_type(endian),
+            r_addend: 0,
+        }
     }
 }
 
@@ -557,6 +581,15 @@ impl<Endian: endian::Endian> Rel for elf::Rel64<Endian> {
     fn r_type(&self, endian: Self::Endian) -> u32 {
         self.r_type(endian)
     }
+
+    fn into_crel(self, endian: Self::Endian) -> Crel {
+        Crel {
+            r_offset: self.r_offset(endian),
+            r_sym: self.r_sym(endian),
+            r_type: self.r_type(endian),
+            r_addend: 0,
+        }
+    }
 }
 
 /// A trait for generic access to [`elf::Rela32`] and [`elf::Rela64`].
@@ -583,6 +616,8 @@ pub trait Rela: Debug + Pod + Clone {
             Some(SymbolIndex(sym as usize))
         }
     }
+
+    fn into_crel(self, endian: Self::Endian, is_mips64el: bool) -> Crel;
 }
 
 impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
@@ -614,6 +649,15 @@ impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
     fn r_type(&self, endian: Self::Endian, _is_mips64el: bool) -> u32 {
         self.r_type(endian)
     }
+
+    fn into_crel(self, endian: Self::Endian, _is_mips64el: bool) -> Crel {
+        Crel {
+            r_offset: self.r_offset(endian).into(),
+            r_sym: self.r_sym(endian),
+            r_type: self.r_type(endian),
+            r_addend: self.r_addend(endian).into(),
+        }
+    }
 }
 
 impl<Endian: endian::Endian> Rela for elf::Rela64<Endian> {
@@ -644,6 +688,15 @@ impl<Endian: endian::Endian> Rela for elf::Rela64<Endian> {
     #[inline]
     fn r_type(&self, endian: Self::Endian, is_mips64el: bool) -> u32 {
         self.r_type(endian, is_mips64el)
+    }
+
+    fn into_crel(self, endian: Self::Endian, is_mips64el: bool) -> Crel {
+        Crel {
+            r_offset: self.r_offset(endian),
+            r_sym: self.r_sym(endian, is_mips64el),
+            r_type: self.r_type(endian, is_mips64el),
+            r_addend: self.r_addend(endian),
+        }
     }
 }
 
@@ -765,36 +818,25 @@ impl<Endian: endian::Endian> Relr for elf::Relr64<Endian> {
 pub struct Crel {
     /// Relocation offset.
     pub r_offset: u64,
-    /// Relocation symbolindex.
-    pub r_sym: i64,
+    /// Relocation symbol index.
+    pub r_sym: u32,
     /// Relocation type.
-    pub r_type: i64,
+    pub r_type: u32,
     /// Relocation addend.
+    ///
+    /// Only set if `CrelIterator::is_rela()` returns `true`.
     pub r_addend: i64,
 }
 
-impl<E: Endian> From<Crel> for elf::Rela64<E> {
-    fn from(crel: Crel) -> Self {
-        elf::Rela64 {
-            r_offset: U64::new(E::default(), crel.r_offset),
-            r_info: U64::new(
-                E::default(),
-                ((crel.r_sym as u64) << 32) | (crel.r_type as u64),
-            ),
-            r_addend: I64::new(E::default(), crel.r_addend),
-        }
-    }
-}
-
-impl<E: Endian> From<Crel> for elf::Rela32<E> {
-    fn from(crel: Crel) -> Self {
-        elf::Rela32 {
-            r_offset: U32::new(E::default(), crel.r_offset as u32),
-            r_info: U32::new(
-                E::default(),
-                (((crel.r_sym as u64) << 8) | ((crel.r_type as u64) & 0xff)) as u32,
-            ),
-            r_addend: I32::new(E::default(), crel.r_addend as i32),
+impl Crel {
+    /// Get the symbol index referenced by the relocation.
+    ///
+    /// Returns `None` for the null symbol index.
+    pub fn symbol(&self) -> Option<SymbolIndex> {
+        if self.r_sym == 0 {
+            None
+        } else {
+            Some(SymbolIndex(self.r_sym as usize))
         }
     }
 }
@@ -820,9 +862,9 @@ struct CrelIteratorState {
     /// Addend of the latest relocation.
     addend: i64,
     /// Symbol index of the latest relocation.
-    symidx: i64,
+    symidx: u32,
     /// Type of the latest relocation.
-    typ: i64,
+    typ: u32,
 }
 
 /// Compare relocation iterator.
@@ -843,9 +885,7 @@ impl<'data> CrelIterator<'data> {
         const HEADER_SHIFT_MASK: u64 = 0x3;
 
         let mut data = Bytes(data);
-        let header = data
-            .read_uleb128()
-            .map_err(|_| Error("Corrupted header of CREL"))?;
+        let header = data.read_uleb128().read_error("Invalid ELF CREL header")?;
         let count = header >> 3;
         let flag_bits = if header & HEADER_ADDEND_BIT_MASK != 0 {
             3
@@ -871,51 +911,73 @@ impl<'data> CrelIterator<'data> {
     pub fn is_rela(&self) -> bool {
         self.header.is_rela
     }
-}
 
-impl<'data> Iterator for CrelIterator<'data> {
-    type Item = Result<Crel, Error>;
+    fn parse(&mut self) -> read::Result<Crel> {
+        const DELTA_SYMBOL_INDEX_MASK: u8 = 1 << 0;
+        const DELTA_TYPE_MASK: u8 = 1 << 1;
+        const DELTA_ADDEND_MASK: u8 = 1 << 2;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        const DELTA_SYMBOL_INDEX_MASK: u64 = 1 << 0;
-        const DELTA_TYPE_MASK: u64 = 1 << 1;
-        const DELTA_ADDEND_MASK: u64 = 1 << 2;
-        const DELTA_ALL_MASK: u64 = DELTA_SYMBOL_INDEX_MASK | DELTA_TYPE_MASK | DELTA_ADDEND_MASK;
+        // The delta offset and flags combined may be larger than u64,
+        // so we handle the first byte separately.
+        let byte = *self
+            .data
+            .read::<u8>()
+            .read_error("Cannot read offset and flags of CREL relocation")?;
+        let flags = byte & ((1 << self.header.flag_bits) - 1);
 
-        if self.state.index >= self.header.count {
-            return None;
+        let mut delta_offset = u64::from(byte & 0x7f) >> self.header.flag_bits;
+        if byte & 0x80 != 0 {
+            delta_offset |= self
+                .data
+                .read_uleb128()
+                .read_error("Cannot read offset and flags of CREL relocation")?
+                << (7 - self.header.flag_bits);
         }
+        self.state.offset = self.state.offset.wrapping_add(delta_offset);
 
-        let Ok(value) = self.data.read_uleb128() else {
-            return Some(Err(Error("Cannot read value of CREL relocation")));
-        };
-        self.state.offset += value >> self.header.flag_bits;
-
-        let flags = value & DELTA_ALL_MASK;
         if flags & DELTA_SYMBOL_INDEX_MASK != 0 {
-            let Ok(symidx) = self.data.read_sleb128() else {
-                return Some(Err(Error("Cannot read symidx of CREL relocation")));
-            };
-            self.state.symidx += symidx;
+            let delta_symidx = self
+                .data
+                .read_sleb128()
+                .read_error("Cannot read symidx of CREL relocation")?;
+            self.state.symidx = self.state.symidx.wrapping_add(delta_symidx as u32);
         }
         if flags & DELTA_TYPE_MASK != 0 {
-            let Ok(typ) = self.data.read_sleb128() else {
-                return Some(Err(Error("Cannot read type of CREL relocation")));
-            };
-            self.state.typ += typ;
+            let delta_typ = self
+                .data
+                .read_sleb128()
+                .read_error("Cannot read type of CREL relocation")?;
+            self.state.typ = self.state.typ.wrapping_add(delta_typ as u32);
         }
         if self.header.is_rela && flags & DELTA_ADDEND_MASK != 0 {
-            let Ok(addend) = self.data.read_sleb128() else {
-                return Some(Err(Error("Cannot read addend of CREL relocation")));
-            };
-            self.state.addend += addend;
+            let delta_addend = self
+                .data
+                .read_sleb128()
+                .read_error("Cannot read addend of CREL relocation")?;
+            self.state.addend = self.state.addend.wrapping_add(delta_addend);
         }
         self.state.index += 1;
-        Some(Ok(Crel {
+        Ok(Crel {
             r_offset: self.state.offset << self.header.shift,
             r_sym: self.state.symidx,
             r_type: self.state.typ,
             r_addend: self.state.addend,
-        }))
+        })
+    }
+}
+
+impl<'data> Iterator for CrelIterator<'data> {
+    type Item = read::Result<Crel>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.state.index >= self.header.count {
+            return None;
+        }
+
+        let result = self.parse();
+        if result.is_err() {
+            self.state.index = self.header.count;
+        }
+        Some(result)
     }
 }

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -4,7 +4,6 @@ use core::{iter, slice, str};
 use crate::elf;
 use crate::endian::{self, Endianness, U32Bytes};
 use crate::pod::{self, Pod};
-use crate::read::elf::CrelIterator;
 use crate::read::{
     self, gnu_compression, CompressedData, CompressedFileRange, CompressionFormat, Error,
     ObjectSection, ReadError, ReadRef, RelocationMap, SectionFlags, SectionIndex, SectionKind,
@@ -12,9 +11,9 @@ use crate::read::{
 };
 
 use super::{
-    AttributesSection, CompressionHeader, ElfFile, ElfSectionRelocationIterator, FileHeader,
-    GnuHashTable, HashTable, NoteIterator, RelocationSections, RelrIterator, SymbolTable,
-    VerdefIterator, VerneedIterator, VersionTable,
+    AttributesSection, CompressionHeader, CrelIterator, ElfFile, ElfSectionRelocationIterator,
+    FileHeader, GnuHashTable, HashTable, NoteIterator, RelocationSections, RelrIterator,
+    SymbolTable, VerdefIterator, VerneedIterator, VersionTable,
 };
 
 /// The table of section headers in an ELF file.


### PR DESCRIPTION
- The delta offset and flags combined may be larger than u64, so handle the first byte separately.
- Use wrapping arithmetic.
- Change `Crel::r_sym` and `Crel::r_type` to `u32`.
- Add `Crel::symbol()`.
- Fuse `CrelIterator` on error.
- Replace `ElfRelaIterator` with `ElfRelocationIterator` which returns `Crel`. This avoids the need to byteswap the `Crel`, and thus avoids the use of `Endian::default` (which may not match the file).
- Add test outputs.

cc @marxin 