### PR TITLE
CREL: export from_rel,from_rela functions

### DIFF
--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -893,7 +893,7 @@ impl<'data> CrelIterator<'data> {
 
     /// Return the number of encoded relocations.
     pub fn len(&self) -> usize {
-        self.header.count
+        self.header.count - self.state.index
     }
 
     fn parse(&mut self) -> read::Result<Crel> {


### PR DESCRIPTION
I've got an integration branch for Wild (https://github.com/marxin/wild/tree/crel-integration) and I've realised that it would be useful to process all relocations in the new Crel type. For this purpose, the 'from_X' functions are useful.