### PR TITLE
Bare bones support for DEC Alpha

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -7,6 +7,7 @@ pub enum Architecture {
     Aarch64,
     #[allow(non_camel_case_types)]
     Aarch64_Ilp32,
+    Alpha,
     Arm,
     Avr,
     Bpf,
@@ -60,6 +61,7 @@ impl Architecture {
             Architecture::Unknown => None,
             Architecture::Aarch64 => Some(AddressSize::U64),
             Architecture::Aarch64_Ilp32 => Some(AddressSize::U32),
+            Architecture::Alpha => Some(AddressSize::U64),
             Architecture::Arm => Some(AddressSize::U32),
             Architecture::Avr => Some(AddressSize::U8),
             Architecture::Bpf => Some(AddressSize::U64),

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -245,6 +245,7 @@ where
         ) {
             (elf::EM_AARCH64, true) => Architecture::Aarch64,
             (elf::EM_AARCH64, false) => Architecture::Aarch64_Ilp32,
+            (elf::EM_ALPHA, true) => Architecture::Alpha,
             (elf::EM_ARM, _) => Architecture::Arm,
             (elf::EM_AVR, _) => Architecture::Avr,
             (elf::EM_BPF, _) => Architecture::Bpf,

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -308,6 +308,16 @@ fn parse_relocation<Elf: FileHeader>(
                 }
             }
         }
+        elf::EM_ALPHA => match r_type {
+            // Absolute
+            elf::R_ALPHA_REFLONG => (K::Absolute, g, 32),
+            elf::R_ALPHA_REFQUAD => (K::Absolute, g, 64),
+            // Relative to the PC
+            elf::R_ALPHA_SREL16 => (K::Relative, g, 16),
+            elf::R_ALPHA_SREL32 => (K::Relative, g, 32),
+            elf::R_ALPHA_SREL64 => (K::Relative, g, 64),
+            _ => unknown,
+        },
         elf::EM_ARM => match r_type {
             elf::R_ARM_ABS32 => (K::Absolute, g, 32),
             _ => unknown,

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -198,6 +198,7 @@ impl<'a> Object<'a> {
         Ok(match self.architecture {
             Architecture::Aarch64 => true,
             Architecture::Aarch64_Ilp32 => true,
+            Architecture::Alpha => true,
             Architecture::Arm => false,
             Architecture::Avr => true,
             Architecture::Bpf => false,
@@ -266,6 +267,16 @@ impl<'a> Object<'a> {
             },
             Architecture::Aarch64_Ilp32 => match (kind, encoding, size) {
                 (K::Absolute, E::Generic, 32) => elf::R_AARCH64_P32_ABS32,
+                _ => return unsupported_reloc(),
+            },
+            Architecture::Alpha => match (kind, encoding, size) {
+                // Absolute
+                (K::Absolute, _, 32) => elf::R_ALPHA_REFLONG,
+                (K::Absolute, _, 64) => elf::R_ALPHA_REFQUAD,
+                // Relative to the PC
+                (K::Relative, _, 16) => elf::R_ALPHA_SREL16,
+                (K::Relative, _, 32) => elf::R_ALPHA_SREL32,
+                (K::Relative, _, 64) => elf::R_ALPHA_SREL64,
                 _ => return unsupported_reloc(),
             },
             Architecture::Arm => match (kind, encoding, size) {
@@ -637,6 +648,7 @@ impl<'a> Object<'a> {
         let e_machine = match (self.architecture, self.sub_architecture) {
             (Architecture::Aarch64, None) => elf::EM_AARCH64,
             (Architecture::Aarch64_Ilp32, None) => elf::EM_AARCH64,
+            (Architecture::Alpha, None) => elf::EM_ALPHA,
             (Architecture::Arm, None) => elf::EM_ARM,
             (Architecture::Avr, None) => elf::EM_AVR,
             (Architecture::Bpf, None) => elf::EM_BPF,

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -261,6 +261,7 @@ fn elf_any() {
     for (arch, endian) in [
         (Architecture::Aarch64, Endianness::Little),
         (Architecture::Aarch64_Ilp32, Endianness::Little),
+        (Architecture::Alpha, Endianness::Little),
         (Architecture::Arm, Endianness::Little),
         (Architecture::Avr, Endianness::Little),
         (Architecture::Bpf, Endianness::Little),


### PR DESCRIPTION
[Dec Alpha](https://en.wikipedia.org/wiki/DEC_Alpha) is a 64 bit RISC architecture. 

Currently, I am working on adding support for this architecture to the upstream Rust compiler.

This PR contains some bare-bones support for this architecture. The code is complete enough to open some simple GCC-compiled executables, although I am not sure how to test a PR like this further. 