### PR TITLE
Add support for writing COFF auxiliary weak external symbols

### DIFF
--- a/src/write/coff/writer.rs
+++ b/src/write/coff/writer.rs
@@ -388,6 +388,29 @@ impl<'a> Writer<'a> {
         self.buffer.write(&aux);
     }
 
+    /// Reserve an auxiliary symbol for a weak external.
+    ///
+    /// Returns the number of auxiliary symbols required.
+    ///
+    /// This must be called before [`Self::reserve_symtab_strtab`].
+    pub fn reserve_aux_weak_external(&mut self) -> u8 {
+        debug_assert_eq!(self.symtab_offset, 0);
+        self.symtab_num += 1;
+        1
+    }
+
+    /// Write an auxiliary symbol for a weak external.
+    pub fn write_aux_weak_external(&mut self, weak: AuxSymbolWeak) {
+        let aux = pe::ImageAuxSymbolWeak {
+            weak_default_sym_index: U32Bytes::new(LE, weak.weak_default_sym_index),
+            weak_search_type: U32Bytes::new(LE, weak.weak_search_type),
+        };
+        self.buffer.write(&aux);
+        // write padding for the unused field
+        const PAD_LEN: usize = pe::IMAGE_SIZEOF_SYMBOL - mem::size_of::<pe::ImageAuxSymbolWeak>();
+        self.buffer.write_bytes(&[0u8; PAD_LEN]);
+    }
+
     /// Return the number of reserved symbol table entries.
     pub fn symbol_count(&self) -> u32 {
         self.symtab_num
@@ -508,6 +531,14 @@ pub struct AuxSymbolSection {
     pub check_sum: u32,
     pub number: u32,
     pub selection: u8,
+}
+
+/// Native endian version of [`pe::ImageAuxSymbolWeak`].
+#[allow(missing_docs)]
+#[derive(Debug, Default, Clone)]
+pub struct AuxSymbolWeak {
+    pub weak_default_sym_index: u32,
+    pub weak_search_type: u32,
 }
 
 /// Native endian version of [`pe::ImageRelocation`].

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -84,6 +84,8 @@ pub struct Object<'a> {
     pub mangling: Mangling,
     #[cfg(feature = "coff")]
     stub_symbols: HashMap<SymbolId, SymbolId>,
+    #[cfg(feature = "coff")]
+    weak_default_symbols: HashMap<SymbolId, SymbolId>,
     /// Mach-O "_tlv_bootstrap" symbol.
     #[cfg(feature = "macho")]
     tlv_bootstrap: Option<SymbolId>,
@@ -114,6 +116,8 @@ impl<'a> Object<'a> {
             mangling: Mangling::default(format, architecture),
             #[cfg(feature = "coff")]
             stub_symbols: HashMap::new(),
+            #[cfg(feature = "coff")]
+            weak_default_symbols: HashMap::new(),
             #[cfg(feature = "macho")]
             tlv_bootstrap: None,
             #[cfg(feature = "macho")]
@@ -434,10 +438,24 @@ impl<'a> Object<'a> {
             if let Some(prefix) = self.mangling.global_prefix() {
                 symbol.name.insert(0, prefix);
             }
+            #[cfg(feature = "coff")]
+            let symbol_id = if self.format == BinaryFormat::Coff && symbol.weak {
+                self.coff_add_weak_external(symbol)
+            } else {
+                self.add_raw_symbol(symbol)
+            };
+
+            #[cfg(not(feature = "coff"))]
             let symbol_id = self.add_raw_symbol(symbol);
+
             self.symbol_map.insert(unmangled_name, symbol_id);
             symbol_id
         } else {
+            #[cfg(feature = "coff")]
+            if self.format == BinaryFormat::Coff && symbol.weak {
+                return self.coff_add_weak_external(symbol);
+            }
+
             self.add_raw_symbol(symbol)
         }
     }


### PR DESCRIPTION
This adds support for writing out COFF weak external symbols using both the COFF low-level API and the unified write API.

### Low-level API (0fc5627e36655c3956197426f0921c16b57077b6)
- Adds a `reserve_aux_weak_external()` and `write_aux_weak_external()` method pair to `object::write::coff::Writer` for reserving the auxiliary symbol record and writing it.
- The [`object::pe::ImageAuxSymbolWeak`](https://github.com/gimli-rs/object/blob/cc6c428352334556ae3eec642d6cc80f94a7a752/src/pe.rs#L999) structure does not contain an `unused` field for padding out the auxiliary symbol data to 18 bytes. This padding is manually added during `write_aux_weak_external()`.

### Unified API (0a0a93903d3214a2e7265577c3b38e3f13f6e21d)
Weak externals in COFF require adding two symbols to the symbol table instead of only one symbol. One symbol contains the [auxiliary weak external](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#auxiliary-format-3-weak-externals) symbol record with `IMAGE_SYM_CLASS_WEAK_EXTERNAL` storage class, an `IMAGE_SYM_UNDEFINED (0)` section number and a value of 0. The other symbol is the default symbol that is referenced by the `TagIndex` field in the weak external auxiliary symbol table record.

The creation of both symbols follow what MinGW GCC and Clang will emit when compiling weak externals.

- Adds both the weak external symbol and the weak default symbol for each inserted weak symbol.
- Follows [LLVM's semantics](https://github.com/llvm/llvm-project/blob/d77ac81e93e5e2df5275b687b53049d9acfe1357/llvm/lib/MC/WinCOFFObjectWriter.cpp#L671) for deriving the name of the linked default symbol.
- Writes out the COFF weak external auxiliary symbol table record with the `TagIndex` referencing the default symbol.
- Makes the default symbol an absolute symbol with a value of 0 for undefined weak externals.

I believe the last point is relevant to the second part of #248. When MinGW GCC/Clang encounter an undefined weak external symbol, they will emit an `IMAGE_SYM_ABSOLUTE` symbol with the value set to 0 for the default implementation in the `TagIndex`.
```
matt@laptop ~/weak-symbols> cat weak-undefined.c
__attribute__((weak)) void weak_symbol(void);

void test() {
    weak_symbol();
}
matt@laptop ~/weak-symbols> x86_64-w64-mingw32-gcc -c weak-undefined.c
matt@laptop ~/weak-symbols> llvm-readobj -s weak-undefined.o
...
  Symbol {
    Name: .weak.weak_symbol.test
    Value: 0
    Section: IMAGE_SYM_ABSOLUTE (-1)
    BaseType: Null (0x0)
    ComplexType: Null (0x0)
    StorageClass: External (0x2)
    AuxSymbolCount: 0
  }
  Symbol {
    Name: weak_symbol
    Value: 0
    Section: IMAGE_SYM_UNDEFINED (0)
    BaseType: Null (0x0)
    ComplexType: Function (0x2)
    StorageClass: WeakExternal (0x69)
    AuxSymbolCount: 1
    AuxWeakExternal {
      Linked: .weak.weak_symbol.test (16)
      Search: NoLibrary (0x1)
    }
  }
...
```