### PR TITLE
Add WasmFile::parse_component_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be22e5a8f600afce671dd53c8d2dd26b4b7aa810fd18ae27dfc49737f3e02fc5"
 dependencies = [
  "bitflags",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = ['doc']
 crc32fast = { version = "1.2", default-features = false, optional = true }
 flate2 = { version = "1", optional = true }
 indexmap = { version = "2.0", default-features = false, optional = true }
-wasmparser = { version = "0.234.0", default-features = false, optional = true }
+wasmparser = { version = "0.234.0", features = ["component-model"], default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
 hashbrown = { version = "0.15.0", features = ["default-hasher"], default-features = false, optional = true }
 ruzstd = { version = "0.8.1", optional = true }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -268,6 +268,11 @@ pub enum FileKind {
     /// See [`wasm::WasmFile`].
     #[cfg(feature = "wasm")]
     Wasm,
+    /// A Wasm component file.
+    ///
+    /// See [`wasm::WasmFile::parse_component_file`].
+    #[cfg(feature = "wasm")]
+    WasmComponent,
     /// A 32-bit XCOFF file.
     ///
     /// See [`xcoff::XcoffFile32`].
@@ -317,6 +322,8 @@ impl FileKind {
             [0xca, 0xfe, 0xba, 0xbf, ..] => FileKind::MachOFat64,
             #[cfg(feature = "wasm")]
             [0x00, b'a', b's', b'm', _, _, 0x00, 0x00] => FileKind::Wasm,
+            #[cfg(feature = "wasm")]
+            [0x00, b'a', b's', b'm', _, _, 0x01, 0x00] => FileKind::WasmComponent,
             #[cfg(feature = "pe")]
             [b'M', b'Z', ..] if offset == 0 => {
                 // offset == 0 restriction is because optional_header_magic only looks at offset 0


### PR DESCRIPTION
I've used this with a patch to gimli's dwarfdump to view the DWARF in a Wasm component model file.