### PR TITLE
Add additional logic to support writing PPC COFFs

### DIFF
--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -608,7 +608,10 @@ impl<'a> Object<'a> {
                         coff::IMAGE_SYM_CLASS_SECTION
                     }
                 }
-                SymbolKind::Label => coff::IMAGE_SYM_CLASS_LABEL,
+                SymbolKind::Label => match symbol.section {
+                    SymbolSection::Undefined => coff::IMAGE_SYM_CLASS_EXTERNAL,
+                    _ => coff::IMAGE_SYM_CLASS_LABEL,
+                },
                 SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => {
                     match symbol.section {
                         SymbolSection::None => {
@@ -640,14 +643,11 @@ impl<'a> Object<'a> {
                     }
                 }
                 SymbolKind::Unknown => {
-                    match symbol.section {
-                        SymbolSection::Undefined => coff::IMAGE_SYM_CLASS_EXTERNAL,
-                        _ => return Err(Error(format!(
-                            "unimplemented symbol `{}` kind {:?}",
-                            symbol.name().unwrap_or(""),
-                            symbol.kind
-                        )))
-                    }
+                    return Err(Error(format!(
+                        "unimplemented symbol `{}` kind {:?}",
+                        symbol.name().unwrap_or(""),
+                        symbol.kind
+                    )))
                 }
             };
             let number_of_aux_symbols = symbol_offsets[index].aux_count;

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -469,14 +469,20 @@ impl<'a> Object<'a> {
 
         // Start writing.
         writer.write_file_header(writer::FileHeader {
-            machine: match (self.architecture, self.sub_architecture) {
-                (Architecture::Arm, None) => coff::IMAGE_FILE_MACHINE_ARMNT,
-                (Architecture::Aarch64, None) => coff::IMAGE_FILE_MACHINE_ARM64,
-                (Architecture::Aarch64, Some(SubArchitecture::Arm64EC)) => {
+            machine: match (self.architecture, self.sub_architecture, self.endian) {
+                (Architecture::Arm, None, _) => coff::IMAGE_FILE_MACHINE_ARMNT,
+                (Architecture::Aarch64, None, _) => coff::IMAGE_FILE_MACHINE_ARM64,
+                (Architecture::Aarch64, Some(SubArchitecture::Arm64EC), _) => {
                     coff::IMAGE_FILE_MACHINE_ARM64EC
                 }
-                (Architecture::I386, None) => coff::IMAGE_FILE_MACHINE_I386,
-                (Architecture::X86_64, None) => coff::IMAGE_FILE_MACHINE_AMD64,
+                (Architecture::I386, None, _) => coff::IMAGE_FILE_MACHINE_I386,
+                (Architecture::X86_64, None, _) => coff::IMAGE_FILE_MACHINE_AMD64,
+                (Architecture::PowerPc | Architecture::PowerPc64, None, Endian::Little) => {
+                    coff::IMAGE_FILE_MACHINE_POWERPC
+                },
+                (Architecture::PowerPc | Architecture::PowerPc64, None, Endian::Big) => {
+                    coff::IMAGE_FILE_MACHINE_POWERPCBE   
+                },
                 _ => {
                     return Err(Error(format!(
                         "unimplemented architecture {:?} with sub-architecture {:?}",

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -478,10 +478,10 @@ impl<'a> Object<'a> {
                 }
                 (Architecture::I386, None, _) => coff::IMAGE_FILE_MACHINE_I386,
                 (Architecture::X86_64, None, _) => coff::IMAGE_FILE_MACHINE_AMD64,
-                (Architecture::PowerPc | Architecture::PowerPc64, None, Endian::Little) => {
+                (Architecture::PowerPc | Architecture::PowerPc64, None, Endianness::Little) => {
                     coff::IMAGE_FILE_MACHINE_POWERPC
                 },
-                (Architecture::PowerPc | Architecture::PowerPc64, None, Endian::Big) => {
+                (Architecture::PowerPc | Architecture::PowerPc64, None, Endianness::Big) => {
                     coff::IMAGE_FILE_MACHINE_POWERPCBE   
                 },
                 _ => {

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -565,10 +565,10 @@ impl<'a> Object<'a> {
                 (Architecture::X86_64, None, _) => coff::IMAGE_FILE_MACHINE_AMD64,
                 (Architecture::PowerPc | Architecture::PowerPc64, None, Endianness::Little) => {
                     coff::IMAGE_FILE_MACHINE_POWERPC
-                },
+                }
                 (Architecture::PowerPc | Architecture::PowerPc64, None, Endianness::Big) => {
-                    coff::IMAGE_FILE_MACHINE_POWERPCBE   
-                },
+                    coff::IMAGE_FILE_MACHINE_POWERPCBE
+                }
                 _ => {
                     return Err(Error(format!(
                         "unimplemented architecture {:?} with sub-architecture {:?}",

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 
+use crate::endian::*;
 use crate::pe as coff;
 use crate::write::coff::writer;
 use crate::write::util::*;

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -646,8 +646,8 @@ impl<'a> Object<'a> {
                             "unimplemented symbol `{}` kind {:?}",
                             symbol.name().unwrap_or(""),
                             symbol.kind
-                        )))
-                    };
+                        )));
+                    }
                 }
             };
             let number_of_aux_symbols = symbol_offsets[index].aux_count;

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -696,10 +696,6 @@ impl<'a> Object<'a> {
                     }
                 }
                 SymbolKind::Label => coff::IMAGE_SYM_CLASS_LABEL,
-                SymbolKind::Label => match symbol.section {
-                    SymbolSection::Undefined => coff::IMAGE_SYM_CLASS_EXTERNAL,
-                    _ => coff::IMAGE_SYM_CLASS_LABEL,
-                },
                 SymbolKind::Text | SymbolKind::Data | SymbolKind::Tls => match symbol.section {
                     SymbolSection::None => {
                         return Err(Error(format!(

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -695,6 +695,7 @@ impl<'a> Object<'a> {
                         coff::IMAGE_SYM_CLASS_SECTION
                     }
                 }
+                SymbolKind::Label => coff::IMAGE_SYM_CLASS_LABEL,
                 SymbolKind::Label => match symbol.section {
                     SymbolSection::Undefined => coff::IMAGE_SYM_CLASS_EXTERNAL,
                     _ => coff::IMAGE_SYM_CLASS_LABEL,
@@ -723,13 +724,16 @@ impl<'a> Object<'a> {
                         }
                     },
                 },
-                SymbolKind::Unknown => {
-                    return Err(Error(format!(
-                        "unimplemented symbol `{}` kind {:?}",
-                        symbol.name().unwrap_or(""),
-                        symbol.kind
-                    )));
-                }
+                SymbolKind::Unknown => match symbol.section {
+                    SymbolSection::Undefined => coff::IMAGE_SYM_CLASS_EXTERNAL,
+                    _ => {
+                        return Err(Error(format!(
+                            "unimplemented symbol `{}` kind {:?}",
+                            symbol.name().unwrap_or(""),
+                            symbol.kind
+                        )))
+                    }
+                },
             };
             let number_of_aux_symbols = symbol_offsets[index].aux_count;
             let value = if symbol.weak {

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -640,11 +640,14 @@ impl<'a> Object<'a> {
                     }
                 }
                 SymbolKind::Unknown => {
-                    return Err(Error(format!(
-                        "unimplemented symbol `{}` kind {:?}",
-                        symbol.name().unwrap_or(""),
-                        symbol.kind
-                    )));
+                    match symbol.section {
+                        SymbolSection::Undefined => coff::IMAGE_SYM_CLASS_EXTERNAL,
+                        _ => return Err(Error(format!(
+                            "unimplemented symbol `{}` kind {:?}",
+                            symbol.name().unwrap_or(""),
+                            symbol.kind
+                        )))
+                    };
                 }
             };
             let number_of_aux_symbols = symbol_offsets[index].aux_count;

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -646,7 +646,7 @@ impl<'a> Object<'a> {
                             "unimplemented symbol `{}` kind {:?}",
                             symbol.name().unwrap_or(""),
                             symbol.kind
-                        )));
+                        )))
                     }
                 }
             };

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -255,6 +255,7 @@ impl<'a> Object<'a> {
                 coff::IMAGE_REL_AMD64_REL32_5 => 9,
                 _ => 0,
             },
+            Architecture::PowerPc | Architecture::PowerPc64 => 0,
             _ => return Err(Error(format!("unimplemented relocation {:?}", relocation))),
         };
         relocation.addend += offset;


### PR DESCRIPTION
For PPC COFFs:
- relocation addends will now always evaluate to 0
- the appropriate file header will now be handled - even checks for endianness
- when adding symbols, if the symbol kind is a Label and the section is Undefined, we have an external symbol