### PR TITLE
readobj: print mach-o integer fields as version strings as appropriate

### DIFF
--- a/crates/examples/testfiles/macho/base-aarch64-debug.o.readobj
+++ b/crates/examples/testfiles/macho/base-aarch64-debug.o.readobj
@@ -241,8 +241,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x18
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xD0000
-    Sdk: 0xD0300
+    MinOs: 13.0.0
+    Sdk: 13.3.0
     NumberOfTools: 0x0
 }
 SymtabCommand {

--- a/crates/examples/testfiles/macho/base-aarch64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-aarch64.o.objcopy
@@ -105,8 +105,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x18
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xD0000
-    Sdk: 0xD0300
+    MinOs: 13.0.0
+    Sdk: 13.3.0
     NumberOfTools: 0x0
 }
 SymtabCommand {

--- a/crates/examples/testfiles/macho/base-aarch64.o.readobj
+++ b/crates/examples/testfiles/macho/base-aarch64.o.readobj
@@ -105,8 +105,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x18
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xD0000
-    Sdk: 0xD0300
+    MinOs: 13.0.0
+    Sdk: 13.3.0
     NumberOfTools: 0x0
 }
 SymtabCommand {

--- a/crates/examples/testfiles/macho/base-aarch64.readobj
+++ b/crates/examples/testfiles/macho/base-aarch64.readobj
@@ -227,8 +227,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x20
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xD0000
-    Sdk: 0xD0300
+    MinOs: 13.0.0
+    Sdk: 13.3.0
     NumberOfTools: 0x1
 }
 SourceVersionCommand {
@@ -248,8 +248,8 @@ DylibCommand {
     Dylib {
         Name: "/usr/lib/libSystem.B.dylib" (0x18)
         Timestamp: 2
-        CurrentVersion: 0x5276403
-        CompatibilityVersion: 0x10000
+        CurrentVersion: 1319.100.3
+        CompatibilityVersion: 1.0.0
     }
 }
 LinkeditDataCommand {

--- a/crates/examples/testfiles/macho/base-x86_64-debug.o.readobj
+++ b/crates/examples/testfiles/macho/base-x86_64-debug.o.readobj
@@ -249,8 +249,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x18
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xC0000
-    Sdk: 0xD0100
+    MinOs: 12.0.0
+    Sdk: 13.1.0
     NumberOfTools: 0x0
 }
 SymtabCommand {

--- a/crates/examples/testfiles/macho/base-x86_64.o.objcopy
+++ b/crates/examples/testfiles/macho/base-x86_64.o.objcopy
@@ -113,8 +113,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x18
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xC0000
-    Sdk: 0xD0100
+    MinOs: 12.0.0
+    Sdk: 13.1.0
     NumberOfTools: 0x0
 }
 SymtabCommand {

--- a/crates/examples/testfiles/macho/base-x86_64.o.readobj
+++ b/crates/examples/testfiles/macho/base-x86_64.o.readobj
@@ -113,8 +113,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x18
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xC0000
-    Sdk: 0xD0100
+    MinOs: 12.0.0
+    Sdk: 13.1.0
     NumberOfTools: 0x0
 }
 SymtabCommand {

--- a/crates/examples/testfiles/macho/base-x86_64.readobj
+++ b/crates/examples/testfiles/macho/base-x86_64.readobj
@@ -305,8 +305,8 @@ BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
     CmdSize: 0x20
     Platform: PLATFORM_MACOS (0x1)
-    MinOs: 0xC0000
-    Sdk: 0xD0100
+    MinOs: 12.0.0
+    Sdk: 13.1.0
     NumberOfTools: 0x1
 }
 SourceVersionCommand {
@@ -326,8 +326,8 @@ DylibCommand {
     Dylib {
         Name: "/usr/lib/libSystem.B.dylib" (0x18)
         Timestamp: 2
-        CurrentVersion: 0x5270000
-        CompatibilityVersion: 0x10000
+        CurrentVersion: 1319.0.0
+        CompatibilityVersion: 1.0.0
     }
 }
 LinkeditDataCommand {


### PR DESCRIPTION
This matches the output of `llvm-readobj`.