### PR TITLE
macho: Implement parsing of LC_FUNCTION_STARTS data

### DIFF
--- a/crates/examples/src/bin/readobj.rs
+++ b/crates/examples/src/bin/readobj.rs
@@ -83,6 +83,12 @@ fn main() {
                 .help("Print the Mach-O load commands"),
         )
         .arg(
+            Arg::new("macho-function-starts")
+                .long("macho-function-starts")
+                .action(ArgAction::SetTrue)
+                .help("Print the Mach-O function start addresses"),
+        )
+        .arg(
             Arg::new("pe-rich")
                 .long("pe-rich")
                 .action(ArgAction::SetTrue)
@@ -130,6 +136,7 @@ fn main() {
         elf_notes: matches.get_flag("elf-notes"),
         elf_versions: matches.get_flag("elf-version-info"),
         elf_attributes: matches.get_flag("elf-attributes"),
+        macho_function_starts: matches.get_flag("macho-function-starts"),
         macho_load_commands: matches.get_flag("macho-load-commands"),
         pe_rich: matches.get_flag("pe-rich"),
         pe_base_relocs: matches.get_flag("pe-base-relocs"),

--- a/crates/examples/src/readobj/mod.rs
+++ b/crates/examples/src/readobj/mod.rs
@@ -23,6 +23,7 @@ pub struct PrintOptions {
 
     // Mach-O specific selectors
     pub macho_load_commands: bool,
+    pub macho_function_starts: bool,
 
     // PE specific selectors
     pub pe_rich: bool,
@@ -50,6 +51,7 @@ impl PrintOptions {
             elf_versions: true,
             elf_attributes: true,
             macho_load_commands: true,
+            macho_function_starts: true,
             pe_rich: true,
             pe_base_relocs: true,
             pe_imports: true,
@@ -73,6 +75,7 @@ impl PrintOptions {
             elf_versions: false,
             elf_attributes: false,
             macho_load_commands: false,
+            macho_function_starts: false,
             pe_rich: false,
             pe_base_relocs: false,
             pe_imports: false,

--- a/crates/examples/testfiles/macho/base-aarch64.readobj
+++ b/crates/examples/testfiles/macho/base-aarch64.readobj
@@ -257,6 +257,9 @@ LinkeditDataCommand {
     CmdSize: 0x10
     DataOffset: 0x8090
     DataSize: 0x8
+    FunctionStarts {
+        Address: 0x100003F68
+    }
 }
 LinkeditDataCommand {
     Cmd: LC_DATA_IN_CODE (0x29)

--- a/crates/examples/testfiles/macho/base-x86_64.readobj
+++ b/crates/examples/testfiles/macho/base-x86_64.readobj
@@ -335,6 +335,9 @@ LinkeditDataCommand {
     CmdSize: 0x10
     DataOffset: 0xC060
     DataSize: 0x8
+    FunctionStarts {
+        Address: 0x100003F60
+    }
 }
 LinkeditDataCommand {
     Cmd: LC_DATA_IN_CODE (0x29)

--- a/src/read/macho/function_starts.rs
+++ b/src/read/macho/function_starts.rs
@@ -1,0 +1,46 @@
+use crate::read::{Bytes, Error, Result};
+
+/// Iterator over the function starts in a `LC_FUNCTION_STARTS` load command.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FunctionStartsIterator<'data> {
+    data: Bytes<'data>,
+    addr: u64,
+}
+
+impl<'data> FunctionStartsIterator<'data> {
+    pub(super) fn new(data: &'data [u8], addr: u64) -> Self {
+        FunctionStartsIterator {
+            data: Bytes(data),
+            addr,
+        }
+    }
+}
+
+impl<'data> Iterator for FunctionStartsIterator<'data> {
+    type Item = Result<u64>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        let delta = match self.data.read_uleb128() {
+            Ok(0) => return None,
+            Ok(delta) => delta,
+            Err(()) => {
+                self.data = Bytes(&[]);
+                return Some(Err(Error("Invalid ULEB128 in LC_FUNCTION_STARTS")));
+            }
+        };
+
+        self.addr = match self.addr.checked_add(delta) {
+            Some(addr) => addr,
+            None => {
+                self.data = Bytes(&[]);
+                return Some(Err(Error("Address overflow in LC_FUNCTION_STARTS")));
+            }
+        };
+
+        Some(Ok(self.addr))
+    }
+}

--- a/src/read/macho/mod.rs
+++ b/src/read/macho/mod.rs
@@ -56,6 +56,9 @@ pub use fat::*;
 mod file;
 pub use file::*;
 
+mod function_starts;
+pub use function_starts::*;
+
 mod load_command;
 pub use load_command::*;
 


### PR DESCRIPTION
The data consists entirely of a list of uleb128 address deltas.

Fixes #510.