### PR TITLE
macho: LC_FUNCTION_STARTS style changes

### DIFF
--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -444,8 +444,8 @@ mod tests {
         let mut iter = cmd.function_starts(LittleEndian, &data[..], 0).unwrap();
 
         // First call returns error
-        assert!(iter.next().unwrap().is_err());
+        assert!(iter.next().is_err());
         // Second call returns None (iterator exhausted)
-        assert!(iter.next().is_none());
+        assert!(iter.next().transpose().is_none());
     }
 }


### PR DESCRIPTION
Use the same iterator error handling pattern as other parts of this crate.

Also change the --macho-function-starts option for readobj so that it doesn't require --macho-load-commands.

cc @int3 