### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # `object`
 
 The `object` crate provides a unified interface to working with object files
-across platforms. It supports reading relocatable object files and executable files,
-and writing COFF/ELF/Mach-O/XCOFF relocatable object files and ELF/PE executable files.
+across platforms. It supports reading relocatable object files and executable
+files, and writing COFF/ELF/Mach-O/XCOFF relocatable object files and ELF/PE
+executable files.
 
 For reading files, it provides multiple levels of support:
 
 * raw struct definitions suitable for zero copy access
-* low level APIs for accessing the raw structs ([example](crates/examples/src/readobj/))
+* low level APIs for accessing the raw structs
+  ([example](crates/examples/src/readobj))
 * a higher level unified API for accessing common features of object files, such
   as sections and symbols ([example](crates/examples/src/objdump.rs))
 
-Supported file formats for reading: ELF, Mach-O, Windows PE/COFF, Wasm, XCOFF, and Unix archive.
+Supported file formats for reading: ELF, Mach-O, Windows PE/COFF, Wasm, XCOFF,
+and Unix archive.
 
 For writing files, it provides:
 
@@ -21,6 +24,7 @@ For writing files, it provides:
   ([example](crates/examples/src/bin/simple_write.rs))
 
 ## Example for unified read API
+
 ```rust
 use object::{Object, ObjectSection};
 use std::error::Error;
@@ -39,18 +43,21 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 See [`crates/examples`](crates/examples) for more examples.
 
-## Minimum Supported Rust Version (MSRV)
+## Minimum supported Rust version (MSRV)
 
-Changes to MSRV are not considered changes. We are conservative about changing the MSRV,
-but sometimes are required to due to dependencies. The MSRV with all features enabled is 1.87.0.
-The MSRV with some features disabled is 1.65.0.
+Changes to MSRV are not considered breaking changes. We are conservative about
+changing the MSRV, but sometimes are required to due to dependencies. The MSRV
+with all features enabled is 1.87.0. The MSRV with some features disabled is
+1.65.0.
 
 ## License
 
 Licensed under either of
 
-  * Apache License, Version 2.0 ([`LICENSE-APACHE`](./LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
-  * MIT license ([`LICENSE-MIT`](./LICENSE-MIT) or https://opensource.org/licenses/MIT)
+  * Apache License, Version 2.0 ([`LICENSE-APACHE`](./LICENSE-APACHE) or
+    https://www.apache.org/licenses/LICENSE-2.0)
+  * MIT license ([`LICENSE-MIT`](./LICENSE-MIT) or
+    https://opensource.org/license/mit)
 
 at your option.
 


### PR DESCRIPTION
Changes MSRV wording to say "breaking changes" instead of just "changes" which I assume was a mistake in #822. Also edit Readme to use consistent formatting throughout and update MIT license URL.