### PR TITLE
Add `RelocationKind::None`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -343,6 +343,8 @@ pub enum SymbolScope {
 pub enum RelocationKind {
     /// The operation is unknown.
     Unknown,
+    /// No relocation.
+    None,
     /// S + A
     Absolute,
     /// S + A - P

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -4210,6 +4210,8 @@ pub const R_AVR_32_PCREL: u32 = 36;
 
 // MSP430 values for `Rel*::r_type`.
 
+/// No reloc
+pub const R_MSP430_NONE: u32 = 0;
 /// Direct 32 bit
 pub const R_MSP430_32: u32 = 1;
 /// Direct 16 bit
@@ -4217,6 +4219,8 @@ pub const R_MSP430_16_BYTE: u32 = 5;
 
 // Hexagon values for `Rel*::r_type`.
 
+/// No reloc
+pub const R_HEX_NONE: u32 = 0;
 /// Direct 32 bit
 pub const R_HEX_32: u32 = 6;
 

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -292,6 +292,7 @@ fn parse_relocation<Elf: FileHeader>(
         elf::EM_AARCH64 => {
             if header.is_type_64() {
                 match r_type {
+                    elf::R_AARCH64_NONE => (K::None, g, 0),
                     elf::R_AARCH64_ABS64 => (K::Absolute, g, 64),
                     elf::R_AARCH64_ABS32 => (K::Absolute, g, 32),
                     elf::R_AARCH64_ABS16 => (K::Absolute, g, 16),
@@ -303,12 +304,14 @@ fn parse_relocation<Elf: FileHeader>(
                 }
             } else {
                 match r_type {
+                    elf::R_AARCH64_NONE => (K::None, g, 0),
                     elf::R_AARCH64_P32_ABS32 => (K::Absolute, g, 32),
                     _ => unknown,
                 }
             }
         }
         elf::EM_ALPHA => match r_type {
+            elf::R_ALPHA_NONE => (K::None, g, 0),
             // Absolute
             elf::R_ALPHA_REFLONG => (K::Absolute, g, 32),
             elf::R_ALPHA_REFQUAD => (K::Absolute, g, 64),
@@ -319,25 +322,30 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_ARM => match r_type {
+            elf::R_ARM_NONE => (K::None, g, 0),
             elf::R_ARM_ABS32 => (K::Absolute, g, 32),
             _ => unknown,
         },
         elf::EM_AVR => match r_type {
+            elf::R_AVR_NONE => (K::None, g, 0),
             elf::R_AVR_32 => (K::Absolute, g, 32),
             elf::R_AVR_16 => (K::Absolute, g, 16),
             _ => unknown,
         },
         elf::EM_BPF => match r_type {
+            elf::R_BPF_NONE => (K::None, g, 0),
             elf::R_BPF_64_64 => (K::Absolute, g, 64),
             elf::R_BPF_64_32 => (K::Absolute, g, 32),
             _ => unknown,
         },
         elf::EM_CSKY => match r_type {
+            elf::R_CKCORE_NONE => (K::None, g, 0),
             elf::R_CKCORE_ADDR32 => (K::Absolute, g, 32),
             elf::R_CKCORE_PCREL32 => (K::Relative, g, 32),
             _ => unknown,
         },
         elf::EM_MCST_ELBRUS => match r_type {
+            elf::R_E2K_NONE => (K::None, g, 0),
             elf::R_E2K_32_ABS => (K::Absolute, g, 32),
             elf::R_E2K_64_ABS => (K::Absolute, g, 64),
             elf::R_E2K_64_ABS_LIT => (K::Absolute, E::E2KLit, 64),
@@ -346,6 +354,7 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_386 => match r_type {
+            elf::R_386_NONE => (K::None, g, 0),
             elf::R_386_32 => (K::Absolute, g, 32),
             elf::R_386_PC32 => (K::Relative, g, 32),
             elf::R_386_GOT32 => (K::Got, g, 32),
@@ -359,6 +368,7 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_X86_64 => match r_type {
+            elf::R_X86_64_NONE => (K::None, g, 0),
             elf::R_X86_64_64 => (K::Absolute, g, 64),
             elf::R_X86_64_PC32 => (K::Relative, g, 32),
             elf::R_X86_64_GOT32 => (K::Got, g, 32),
@@ -373,10 +383,12 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_HEXAGON => match r_type {
+            elf::R_HEX_NONE => (K::None, g, 0),
             elf::R_HEX_32 => (K::Absolute, g, 32),
             _ => unknown,
         },
         elf::EM_LOONGARCH => match r_type {
+            elf::R_LARCH_NONE => (K::None, g, 0),
             elf::R_LARCH_32 => (K::Absolute, g, 32),
             elf::R_LARCH_64 => (K::Absolute, g, 64),
             elf::R_LARCH_32_PCREL => (K::Relative, g, 32),
@@ -387,6 +399,7 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_68K => match r_type {
+            elf::R_68K_NONE => (K::None, g, 0),
             elf::R_68K_32 => (K::Absolute, g, 32),
             elf::R_68K_16 => (K::Absolute, g, 16),
             elf::R_68K_8 => (K::Absolute, g, 8),
@@ -405,36 +418,43 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_MIPS => match r_type {
+            elf::R_MIPS_NONE => (K::None, g, 0),
             elf::R_MIPS_16 => (K::Absolute, g, 16),
             elf::R_MIPS_32 => (K::Absolute, g, 32),
             elf::R_MIPS_64 => (K::Absolute, g, 64),
             _ => unknown,
         },
         elf::EM_MSP430 => match r_type {
+            elf::R_MSP430_NONE => (K::None, g, 0),
             elf::R_MSP430_32 => (K::Absolute, g, 32),
             elf::R_MSP430_16_BYTE => (K::Absolute, g, 16),
             _ => unknown,
         },
         elf::EM_PARISC => match r_type {
+            elf::R_PARISC_NONE => (K::None, g, 0),
             elf::R_PARISC_DIR32 => (K::Absolute, g, 32),
             elf::R_PARISC_PCREL32 => (K::Relative, g, 32),
             _ => unknown,
         },
         elf::EM_PPC => match r_type {
+            elf::R_PPC_NONE => (K::None, g, 0),
             elf::R_PPC_ADDR32 => (K::Absolute, g, 32),
             _ => unknown,
         },
         elf::EM_PPC64 => match r_type {
+            elf::R_PPC64_NONE => (K::None, g, 0),
             elf::R_PPC64_ADDR32 => (K::Absolute, g, 32),
             elf::R_PPC64_ADDR64 => (K::Absolute, g, 64),
             _ => unknown,
         },
         elf::EM_RISCV => match r_type {
+            elf::R_RISCV_NONE => (K::None, g, 0),
             elf::R_RISCV_32 => (K::Absolute, g, 32),
             elf::R_RISCV_64 => (K::Absolute, g, 64),
             _ => unknown,
         },
         elf::EM_S390 => match r_type {
+            elf::R_390_NONE => (K::None, g, 0),
             elf::R_390_8 => (K::Absolute, g, 8),
             elf::R_390_16 => (K::Absolute, g, 16),
             elf::R_390_32 => (K::Absolute, g, 32),
@@ -458,6 +478,7 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_SBF => match r_type {
+            elf::R_SBF_NONE => (K::None, g, 0),
             elf::R_SBF_64_64 => (K::Absolute, g, 64),
             elf::R_SBF_64_32 => (K::Absolute, g, 32),
             _ => unknown,
@@ -478,16 +499,19 @@ fn parse_relocation<Elf: FileHeader>(
             _ => unknown,
         },
         elf::EM_SPARC | elf::EM_SPARC32PLUS | elf::EM_SPARCV9 => match r_type {
+            elf::R_SPARC_NONE => (K::None, g, 0),
             elf::R_SPARC_32 | elf::R_SPARC_UA32 => (K::Absolute, g, 32),
             elf::R_SPARC_64 | elf::R_SPARC_UA64 => (K::Absolute, g, 64),
             _ => unknown,
         },
         elf::EM_SH => match r_type {
+            elf::R_SH_NONE => (K::None, g, 0),
             elf::R_SH_DIR32 => (K::Absolute, g, 32),
             elf::R_SH_REL32 => (K::Relative, g, 32),
             _ => unknown,
         },
         elf::EM_XTENSA => match r_type {
+            elf::R_XTENSA_NONE => (K::None, g, 0),
             elf::R_XTENSA_32 => (K::Absolute, g, 32),
             elf::R_XTENSA_32_PCREL => (K::Relative, g, 32),
             _ => unknown,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -821,6 +821,7 @@ impl RelocationMap {
             addend: relocation.addend() as u64,
         };
         match relocation.kind() {
+            RelocationKind::None => {}
             RelocationKind::Absolute => match relocation.target() {
                 RelocationTarget::Symbol(symbol_idx) => {
                     let symbol = file

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -256,6 +256,7 @@ impl<'a> Object<'a> {
         let unsupported_reloc = || Err(Error(format!("unimplemented ELF relocation {:?}", reloc)));
         let r_type = match self.architecture {
             Architecture::Aarch64 => match (kind, encoding, size) {
+                (K::None, E::Generic, 0) => elf::R_AARCH64_NONE,
                 (K::Absolute, E::Generic, 64) => elf::R_AARCH64_ABS64,
                 (K::Absolute, E::Generic, 32) => elf::R_AARCH64_ABS32,
                 (K::Absolute, E::Generic, 16) => elf::R_AARCH64_ABS16,
@@ -267,10 +268,12 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::Aarch64_Ilp32 => match (kind, encoding, size) {
+                (K::None, E::Generic, 0) => elf::R_AARCH64_NONE,
                 (K::Absolute, E::Generic, 32) => elf::R_AARCH64_P32_ABS32,
                 _ => return unsupported_reloc(),
             },
             Architecture::Alpha => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_ALPHA_NONE,
                 // Absolute
                 (K::Absolute, _, 32) => elf::R_ALPHA_REFLONG,
                 (K::Absolute, _, 64) => elf::R_ALPHA_REFQUAD,
@@ -281,25 +284,30 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::Arm => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_ARM_NONE,
                 (K::Absolute, _, 32) => elf::R_ARM_ABS32,
                 _ => return unsupported_reloc(),
             },
             Architecture::Avr => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_AVR_NONE,
                 (K::Absolute, _, 32) => elf::R_AVR_32,
                 (K::Absolute, _, 16) => elf::R_AVR_16,
                 _ => return unsupported_reloc(),
             },
             Architecture::Bpf => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_BPF_NONE,
                 (K::Absolute, _, 64) => elf::R_BPF_64_64,
                 (K::Absolute, _, 32) => elf::R_BPF_64_32,
                 _ => return unsupported_reloc(),
             },
             Architecture::Csky => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_CKCORE_NONE,
                 (K::Absolute, _, 32) => elf::R_CKCORE_ADDR32,
                 (K::Relative, E::Generic, 32) => elf::R_CKCORE_PCREL32,
                 _ => return unsupported_reloc(),
             },
             Architecture::I386 => match (kind, size) {
+                (K::None, 0) => elf::R_386_NONE,
                 (K::Absolute, 32) => elf::R_386_32,
                 (K::Relative, 32) => elf::R_386_PC32,
                 (K::Got, 32) => elf::R_386_GOT32,
@@ -313,6 +321,7 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::E2K32 | Architecture::E2K64 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_E2K_NONE,
                 (K::Absolute, E::Generic, 32) => elf::R_E2K_32_ABS,
                 (K::Absolute, E::E2KLit, 64) => elf::R_E2K_64_ABS_LIT,
                 (K::Absolute, E::Generic, 64) => elf::R_E2K_64_ABS,
@@ -321,6 +330,7 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::X86_64 | Architecture::X86_64_X32 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_X86_64_NONE,
                 (K::Absolute, E::Generic, 64) => elf::R_X86_64_64,
                 (K::Relative, E::X86Branch, 32) => elf::R_X86_64_PLT32,
                 (K::Relative, _, 32) => elf::R_X86_64_PC32,
@@ -336,15 +346,18 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::Hppa => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_PARISC_NONE,
                 (K::Absolute, _, 32) => elf::R_PARISC_DIR32,
                 (K::Relative, _, 32) => elf::R_PARISC_PCREL32,
                 _ => return unsupported_reloc(),
             },
             Architecture::Hexagon => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_HEX_NONE,
                 (K::Absolute, _, 32) => elf::R_HEX_32,
                 _ => return unsupported_reloc(),
             },
             Architecture::LoongArch32 | Architecture::LoongArch64 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_LARCH_NONE,
                 (K::Absolute, _, 32) => elf::R_LARCH_32,
                 (K::Absolute, _, 64) => elf::R_LARCH_64,
                 (K::Relative, _, 32) => elf::R_LARCH_32_PCREL,
@@ -358,6 +371,7 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::M68k => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_68K_NONE,
                 (K::Absolute, _, 8) => elf::R_68K_8,
                 (K::Absolute, _, 16) => elf::R_68K_16,
                 (K::Absolute, _, 32) => elf::R_68K_32,
@@ -377,6 +391,7 @@ impl<'a> Object<'a> {
             },
             Architecture::Mips | Architecture::Mips64 | Architecture::Mips64_N32 => {
                 match (kind, encoding, size) {
+                    (K::None, _, 0) => elf::R_MIPS_NONE,
                     (K::Absolute, _, 16) => elf::R_MIPS_16,
                     (K::Absolute, _, 32) => elf::R_MIPS_32,
                     (K::Absolute, _, 64) => elf::R_MIPS_64,
@@ -384,26 +399,31 @@ impl<'a> Object<'a> {
                 }
             }
             Architecture::Msp430 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_MSP430_NONE,
                 (K::Absolute, _, 32) => elf::R_MSP430_32,
                 (K::Absolute, _, 16) => elf::R_MSP430_16_BYTE,
                 _ => return unsupported_reloc(),
             },
             Architecture::PowerPc => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_PPC_NONE,
                 (K::Absolute, _, 32) => elf::R_PPC_ADDR32,
                 _ => return unsupported_reloc(),
             },
             Architecture::PowerPc64 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_PPC64_NONE,
                 (K::Absolute, _, 32) => elf::R_PPC64_ADDR32,
                 (K::Absolute, _, 64) => elf::R_PPC64_ADDR64,
                 _ => return unsupported_reloc(),
             },
             Architecture::Riscv32 | Architecture::Riscv64 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_RISCV_NONE,
                 (K::Absolute, _, 32) => elf::R_RISCV_32,
                 (K::Absolute, _, 64) => elf::R_RISCV_64,
                 (K::Relative, E::Generic, 32) => elf::R_RISCV_32_PCREL,
                 _ => return unsupported_reloc(),
             },
             Architecture::S390x => match (kind, encoding, size) {
+                (K::None, E::Generic, 0) => elf::R_390_NONE,
                 (K::Absolute, E::Generic, 8) => elf::R_390_8,
                 (K::Absolute, E::Generic, 16) => elf::R_390_16,
                 (K::Absolute, E::Generic, 32) => elf::R_390_32,
@@ -427,6 +447,7 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::Sbf => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_SBF_NONE,
                 (K::Absolute, _, 64) => elf::R_SBF_64_64,
                 (K::Absolute, _, 32) => elf::R_SBF_64_32,
                 _ => return unsupported_reloc(),
@@ -447,22 +468,26 @@ impl<'a> Object<'a> {
                 _ => return unsupported_reloc(),
             },
             Architecture::Sparc | Architecture::Sparc32Plus => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_SPARC_NONE,
                 // TODO: use R_SPARC_32 if aligned.
                 (K::Absolute, _, 32) => elf::R_SPARC_UA32,
                 _ => return unsupported_reloc(),
             },
             Architecture::Sparc64 => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_SPARC_NONE,
                 // TODO: use R_SPARC_32/R_SPARC_64 if aligned.
                 (K::Absolute, _, 32) => elf::R_SPARC_UA32,
                 (K::Absolute, _, 64) => elf::R_SPARC_UA64,
                 _ => return unsupported_reloc(),
             },
             Architecture::SuperH => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_SH_NONE,
                 (K::Absolute, _, 32) => elf::R_SH_DIR32,
                 (K::Relative, _, 32) => elf::R_SH_REL32,
                 _ => return unsupported_reloc(),
             },
             Architecture::Xtensa => match (kind, encoding, size) {
+                (K::None, _, 0) => elf::R_XTENSA_NONE,
                 (K::Absolute, _, 32) => elf::R_XTENSA_32,
                 (K::Relative, E::Generic, 32) => elf::R_XTENSA_32_PCREL,
                 _ => return unsupported_reloc(),

--- a/tests/round_trip/mod.rs
+++ b/tests/round_trip/mod.rs
@@ -333,6 +333,21 @@ fn elf_any() {
                 )
                 .unwrap();
         }
+        object
+            .add_relocation(
+                section,
+                write::Relocation {
+                    offset: 24,
+                    symbol,
+                    addend: 0,
+                    flags: RelocationFlags::Generic {
+                        kind: RelocationKind::None,
+                        encoding: RelocationEncoding::Generic,
+                        size: 0,
+                    },
+                },
+            )
+            .unwrap();
 
         let bytes = object.write().unwrap();
         let object = read::File::parse(&*bytes).unwrap();
@@ -367,6 +382,14 @@ fn elf_any() {
             assert_eq!(relocation.size(), 64);
             assert_eq!(relocation.addend(), 0);
         }
+
+        let (offset, relocation) = relocations.next().unwrap();
+        println!("{:?}", relocation);
+        assert_eq!(offset, 24);
+        assert_eq!(relocation.kind(), RelocationKind::None);
+        assert_eq!(relocation.encoding(), RelocationEncoding::Generic);
+        assert_eq!(relocation.size(), 0);
+        assert_eq!(relocation.addend(), 0);
     }
 }
 


### PR DESCRIPTION
Also ignore these relocations for `RelocationMap`.