### PR TITLE
Fix missing license files in published object-rewrite crate

### DIFF
--- a/crates/rewrite/Cargo.toml
+++ b/crates/rewrite/Cargo.toml
@@ -9,6 +9,8 @@ include = [
   "/Cargo.lock",
   "/Cargo.toml",
   "/src",
+  "/LICENSE-APACHE",
+  "/LICENSE-MIT",
 ]
 
 [package.metadata.docs.rs]

--- a/crates/rewrite/LICENSE-APACHE
+++ b/crates/rewrite/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/rewrite/LICENSE-MIT
+++ b/crates/rewrite/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
Both chosen licenses require the text to be included with source and binary distributions.

Before this PR:

```
$ cargo publish --dry-run
$ tar -tzvf ../../target/package/object-rewrite-0.1.1.crate
-rw-r--r-- 0/0             108 1970-01-01 01:00 object-rewrite-0.1.1/.cargo_vcs_info.json
-rw-r--r-- 0/0            6562 1970-01-01 01:00 object-rewrite-0.1.1/Cargo.lock
-rw-r--r-- 0/0            1765 1970-01-01 01:00 object-rewrite-0.1.1/Cargo.toml
-rw-r--r-- 0/0            1128 2006-07-24 02:21 object-rewrite-0.1.1/Cargo.toml.orig
-rw-r--r-- 0/0           32161 2006-07-24 02:21 object-rewrite-0.1.1/src/elf.rs
-rw-r--r-- 0/0            2010 2006-07-24 02:21 object-rewrite-0.1.1/src/error.rs
-rw-r--r-- 0/0            1102 2006-07-24 02:21 object-rewrite-0.1.1/src/lib.rs
-rw-r--r-- 0/0           15035 2006-07-24 02:21 object-rewrite-0.1.1/src/main.rs
-rw-r--r-- 0/0            3585 2006-07-24 02:21 object-rewrite-0.1.1/src/rewriter.rs
```

After this PR:

```
$ cargo publish --dry-run
$ tar -tzvf ../../target/package/object-rewrite-0.1.1.crate
-rw-r--r-- 0/0             108 1970-01-01 01:00 object-rewrite-0.1.1/.cargo_vcs_info.json
-rw-r--r-- 0/0            6562 1970-01-01 01:00 object-rewrite-0.1.1/Cargo.lock
-rw-r--r-- 0/0            1808 1970-01-01 01:00 object-rewrite-0.1.1/Cargo.toml
-rw-r--r-- 0/0            1167 2006-07-24 02:21 object-rewrite-0.1.1/Cargo.toml.orig
-rw-r--r-- 0/0           10847 2006-07-24 02:21 object-rewrite-0.1.1/LICENSE-APACHE
-rw-r--r-- 0/0            1064 2006-07-24 02:21 object-rewrite-0.1.1/LICENSE-MIT
-rw-r--r-- 0/0           32161 2006-07-24 02:21 object-rewrite-0.1.1/src/elf.rs
-rw-r--r-- 0/0            2010 2006-07-24 02:21 object-rewrite-0.1.1/src/error.rs
-rw-r--r-- 0/0            1102 2006-07-24 02:21 object-rewrite-0.1.1/src/lib.rs
-rw-r--r-- 0/0           15035 2006-07-24 02:21 object-rewrite-0.1.1/src/main.rs
-rw-r--r-- 0/0            3585 2006-07-24 02:21 object-rewrite-0.1.1/src/rewriter.rs
```