### PR TITLE
expose `reserved{1,2}` in Mach-O

### DIFF
--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -295,6 +295,8 @@ pub trait Section: Debug + Pod {
     fn reloff(&self, endian: Self::Endian) -> u32;
     fn nreloc(&self, endian: Self::Endian) -> u32;
     fn flags(&self, endian: Self::Endian) -> u32;
+    fn reserved1(&self, endian: Self::Endian) -> u32;
+    fn reserved2(&self, endian: Self::Endian) -> u32;
 
     /// Return the `sectname` bytes up until the null terminator.
     fn name(&self) -> &[u8] {
@@ -384,6 +386,12 @@ impl<Endian: endian::Endian> Section for macho::Section32<Endian> {
     fn flags(&self, endian: Self::Endian) -> u32 {
         self.flags.get(endian)
     }
+    fn reserved1(&self, endian: Self::Endian) -> u32 {
+        self.reserved1.get(endian)
+    }
+    fn reserved2(&self, endian: Self::Endian) -> u32 {
+        self.reserved2.get(endian)
+    }
 }
 
 impl<Endian: endian::Endian> Section for macho::Section64<Endian> {
@@ -416,5 +424,11 @@ impl<Endian: endian::Endian> Section for macho::Section64<Endian> {
     }
     fn flags(&self, endian: Self::Endian) -> u32 {
         self.flags.get(endian)
+    }
+    fn reserved1(&self, endian: Self::Endian) -> u32 {
+        self.reserved1.get(endian)
+    }
+    fn reserved2(&self, endian: Self::Endian) -> u32 {
+        self.reserved2.get(endian)
     }
 }


### PR DESCRIPTION
Expose section's `reserved{1,2}`.

From `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/mach-o/loader.h` on recent MacOS or https://github.com/gimli-rs/object/blob/6cfe4693641f237d92fe44aea34e8eb2d6806deb/src/macho.rs#L1285-L1296

```c
/*
 * For the two types of symbol pointers sections and the symbol stubs section
 * they have indirect symbol table entries.  For each of the entries in the
 * section the indirect symbol table entries, in corresponding order in the
 * indirect symbol table, start at the index stored in the reserved1 field
 * of the section structure.  Since the indirect symbol table entries
 * correspond to the entries in the section the number of indirect symbol table
 * entries is inferred from the size of the section divided by the size of the
 * entries in the section.  For symbol pointers sections the size of the entries
 * in the section is 4 bytes and for symbol stubs sections the byte size of the
 * stubs is stored in the reserved2 field of the section structure.
 */
```

Concretely, the existing API seems to be insufficient in order to be able to determine the GOT symbol mapping (e.g., https://github.com/rvolosatovs/wasmify/blob/57ad866047225537c5464ae8ef86b42a300bf6ed/src/mach.rs#L68-L72)