### PR TITLE
elf: Add Android-specific REL,RELA and RELR constants

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -717,8 +717,14 @@ pub const SHT_RELR: u32 = 19;
 pub const SHT_CREL: u32 = 0x40000014;
 /// Start of OS-specific section types.
 pub const SHT_LOOS: u32 = 0x6000_0000;
+/// Android-specific compressed version of `SHT_REL`.
+pub const SHT_ANDROID_REL: u32 = 0x60000001;
+/// Android-specific compressed version of `SHT_RELA`.
+pub const SHT_ANDROID_RELA: u32 = 0x60000002;
 /// LLVM-style dependent libraries.
 pub const SHT_LLVM_DEPENDENT_LIBRARIES: u32 = 0x6fff4c04;
+/// Android-specific precursor of `SHT_RELR`; differs only by constants and required API level.
+pub const SHT_ANDROID_RELR: u32 = 0x6fff_ff00;
 /// GNU SFrame stack trace format.
 pub const SHT_GNU_SFRAME: u32 = 0x6fff_fff4;
 /// Object attributes.
@@ -1576,6 +1582,20 @@ pub const DT_RELRSZ: i64 = 35;
 pub const DT_RELRENT: i64 = 37;
 /// Start of OS-specific
 pub const DT_LOOS: i64 = 0x6000_000d;
+/// Address of Android-specific compressed Rel relocs
+pub const DT_ANDROID_REL: i64 = 0x6000000f;
+/// Total size of Android-specific compressed Rel relocs
+pub const DT_ANDROID_RELSZ: i64 = 0x60000010;
+/// Address of Android-specific compressed Rela relocs
+pub const DT_ANDROID_RELA: i64 = 0x60000011;
+/// Total size of Android-specific compressed Rela relocs
+pub const DT_ANDROID_RELASZ: i64 = 0x60000012;
+/// Address of Android-specific Relr relocs
+pub const DT_ANDROID_RELR: i64 = 0x6fff_e000;
+/// Total size of Android-specific Relr relocs
+pub const DT_ANDROID_RELRSZ: i64 = 0x6fff_e001;
+/// Size of one Android-specific Relr reloc
+pub const DT_ANDROID_RELRENT: i64 = 0x6fff_e003;
 /// End of OS-specific
 pub const DT_HIOS: i64 = 0x6fff_f000;
 /// Start of processor-specific


### PR DESCRIPTION
For the context, RELR constants would be useful for https://github.com/wild-linker/wild/pull/1805. While at it, I went further and added also REL/RELA constants.

I think a test would be useful, but I don't know how to add one. Probably dissecting real Android binary would be the best, but to test most the relocations added in this PR, even regular Linux binary would be fine.
To achieve that one needs to link using LLD and `--pack-dyn-relocs=android+relr --use-android-relr-tags`, but there is a catch: to have both variants of relative relocations (RELA and RELR) at the same time you need relocations with even and odd offsets.
For example, using Wild's test:
```
❯ gcc ~/Projects/wild/wild/tests/sources/elf/pack-relative-relocs/pack-relative-relocs.c -I ~/Projects/wild/wild/tests/sources/elf/common/ -nostdlib ~/Projects/wild/wild/tests/sources/elf/common/init.c ~/Projects/wild/wild/tests/sources/elf/common/runtime.c -o /tmp/bin.lld -fuse-ld=lld -Wl,--pack-dyn-relocs=android+relr,--use-android-relr-tags

❯ llvm-readelf -Wr /tmp/bin.lld
Relocation section '.rela.dyn' at offset 0x320 contains 1 entries:
    Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
00000000000037c1  0000000000000008 R_X86_64_RELATIVE                 37b0

Relocation section '.relr.dyn' at offset 0x330 contains 6 entries:
Index: Entry            Address           Symbolic Address
0000:  0000000000002670 0000000000002670  __init_array_start
0001:  000000000000000f 0000000000002678  __init_array_start + 0x8
                        0000000000002680  __init_array_start + 0x10
                        0000000000002688  __init_array_end
0002:  00000000000037b8 00000000000037b8  aligned_ptr
0003:  00000000000037d2 00000000000037d2  unaligned_ptr_even + 0x2

❯ llvm-readelf -Wd /tmp/bin.lld | rg ANDROID
  0x0000000060000011 (ANDROID_RELA)    0x320
  0x0000000060000012 (ANDROID_RELASZ)  15 (bytes)
  0x000000006fffe000 (ANDROID_RELR)    0x330
  0x000000006fffe001 (ANDROID_RELRSZ)  0x20
  0x000000006fffe003 (ANDROID_RELRENT) 0x8
```