### PR TITLE
Upgrade to hashbrown v0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,18 +161,18 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ features = ['doc']
 [dependencies]
 crc32fast = { version = "1.2", default-features = false, optional = true }
 flate2 = { version = "1", optional = true }
-indexmap = { version = "2.0", default-features = false, optional = true }
+indexmap = { version = "2.14", default-features = false, optional = true }
 wasmparser = { version = "0.245.1", default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
-hashbrown = { version = "0.16.0", features = ["default-hasher"], default-features = false, optional = true }
+hashbrown = { version = "0.17.0", features = ["default-hasher"], default-features = false, optional = true }
 ruzstd = { version = "0.8.1", optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -191,7 +191,7 @@ fn cmd_msrv() -> Result<(), DynError> {
             cmd.env("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
         },
     )?;
-    // wasmparser needs 1.76.0, ruzstd needs 1.87.0, indexmap needs 1.82.0
+    // wasmparser needs 1.76.0, ruzstd needs 1.87.0, hashbrown and indexmap need 1.85.0
     cmd_with(
         "cargo",
         &["+1.87.0", "test", "-p", "object", "--features", "all"],


### PR DESCRIPTION
... plus indexmap v2.14 to depend on the same.

I'm following up on behalf of the Rust compiler, https://github.com/rust-lang/rust/pull/155256#issuecomment-4240494425, trying to eventually sync up the dependencies.