### PR TITLE
read/wasm: Classify all `reloc.*` custom sections as `Linker`

### DIFF
--- a/crates/examples/testfiles/wasm/base.o.objdump
+++ b/crates/examples/testfiles/wasm/base.o.objdump
@@ -11,7 +11,7 @@ Entry Address: 0
 10: Section { name: "<code>", address: 0, size: 6d, align: 1, kind: Text, flags: None }
 11: Section { name: "<data>", address: 0, size: 13, align: 1, kind: Data, flags: None }
 0: Section { name: "linking", address: 0, size: 5d, align: 1, kind: Linker, flags: None }
-0: Section { name: "reloc.CODE", address: 0, size: 15, align: 1, kind: Other, flags: None }
+0: Section { name: "reloc.CODE", address: 0, size: 15, align: 1, kind: Linker, flags: None }
 0: Section { name: "producers", address: 0, size: 6c, align: 1, kind: Other, flags: None }
 
 Symbols

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -928,7 +928,8 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSection<'data> for WasmSection<'data
     fn kind(&self) -> SectionKind {
         match self.section.id {
             SectionId::Custom => match self.section.name {
-                "reloc." | "linking" => SectionKind::Linker,
+                "linking" => SectionKind::Linker,
+                name if name.starts_with("reloc.") => SectionKind::Linker,
                 _ => SectionKind::Other,
             },
             SectionId::Type => SectionKind::Metadata,


### PR DESCRIPTION
Previously the `match` arm in `WasmSection::kind` only matched the literal name `"reloc."`, which never occurs in practice. As a result real relocation custom sections such as `reloc.CODE` and `reloc.DATA` were reported as `SectionKind::Other`.