### PR TITLE
Change relocation name statics to public

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -46,7 +46,7 @@ fn print_file_header<Elf: FileHeader>(p: &mut Printer<'_>, endian: Elf::Endian, 
         p.field_hex("Entry", elf.e_entry(endian).into());
         p.field_hex("ProgramHeaderOffset", elf.e_phoff(endian).into());
         p.field_hex("SectionHeaderOffset", elf.e_shoff(endian).into());
-        p.field_flags("Flags", elf.e_flags(endian), constants(endian, elf).ef);
+        p.field_flags("Flags", elf.e_flags(endian), names(endian, elf).ef);
         p.field_hex("HeaderSize", elf.e_ehsize(endian));
         p.field_hex("ProgramHeaderEntrySize", elf.e_phentsize(endian));
         p.field("ProgramHeaderCount", elf.e_phnum(endian));
@@ -82,7 +82,7 @@ fn print_program_headers<Elf: FileHeader>(
     elf: &Elf,
     segments: &[Elf::ProgramHeader],
 ) {
-    let constants = constants(endian, elf);
+    let names = names(endian, elf);
     for segment in segments {
         let p_type = segment.p_type(endian);
         if !p.options.segments
@@ -92,13 +92,13 @@ fn print_program_headers<Elf: FileHeader>(
             continue;
         }
         p.group("ProgramHeader", |p| {
-            p.field_consts("Type", segment.p_type(endian), constants.pt);
+            p.field_consts("Type", segment.p_type(endian), names.pt);
             p.field_hex("Offset", segment.p_offset(endian).into());
             p.field_hex("VirtualAddress", segment.p_vaddr(endian).into());
             p.field_hex("PhysicalAddress", segment.p_paddr(endian).into());
             p.field_hex("FileSize", segment.p_filesz(endian).into());
             p.field_hex("MemorySize", segment.p_memsz(endian).into());
-            p.field_flags("Flags", segment.p_flags(endian), constants.pf);
+            p.field_flags("Flags", segment.p_flags(endian), names.pf);
             p.field_hex("Align", segment.p_align(endian).into());
 
             match segment.p_type(endian) {
@@ -181,7 +181,7 @@ fn print_section_headers<Elf: FileHeader>(
     elf: &Elf,
     sections: &SectionTable<Elf>,
 ) {
-    let constants = constants(endian, elf);
+    let names = names(endian, elf);
     for (index, section) in sections.enumerate() {
         let sh_type = section.sh_type(endian);
         if !p.options.sections
@@ -207,8 +207,8 @@ fn print_section_headers<Elf: FileHeader>(
                 sections.section_name(endian, section),
             );
 
-            p.field_consts("Type", section.sh_type(endian), constants.sht);
-            p.field_flags("Flags", section.sh_flags(endian), constants.shf);
+            p.field_consts("Type", section.sh_type(endian), names.sht);
+            p.field_flags("Flags", section.sh_flags(endian), names.shf);
             p.field_hex("Address", section.sh_addr(endian).into());
             p.field_hex("Offset", section.sh_offset(endian).into());
             p.field_hex("Size", section.sh_size(endian).into());
@@ -284,7 +284,7 @@ fn print_section_symbols<Elf: FileHeader>(
     section_index: SectionIndex,
     section: &Elf::SectionHeader,
 ) {
-    let constants = constants(endian, elf);
+    let names = names(endian, elf);
     if let Some(Some(symbols)) = section
         .symbols(endian, data, sections, section_index)
         .print_err(p)
@@ -312,15 +312,15 @@ fn print_section_symbols<Elf: FileHeader>(
                 }
                 p.field_hex("Value", symbol.st_value(endian).into());
                 p.field_hex("Size", symbol.st_size(endian).into());
-                p.field_consts("Type", symbol.st_type(), constants.stt);
-                p.field_consts("Bind", symbol.st_bind(), constants.stb);
-                p.field_flags("Other", symbol.st_other(), constants.sto);
+                p.field_consts("Type", symbol.st_type(), names.stt);
+                p.field_consts("Bind", symbol.st_bind(), names.stb);
+                p.field_flags("Other", symbol.st_other(), names.sto);
 
                 let shndx = symbol.st_shndx(endian);
                 if let Some(index) = shndx.index() {
                     p.field("SectionIndex", index);
                 } else {
-                    p.field_consts("SectionIndex", shndx, constants.shn);
+                    p.field_consts("SectionIndex", shndx, names.shn);
                 }
                 if let Some(shndx) = symbols.shndx(endian, index) {
                     p.field("ExtendedSectionIndex", shndx);
@@ -349,11 +349,11 @@ fn print_section_rel<Elf: FileHeader>(
         } else {
             None
         };
-        let consts = constants(endian, elf).r;
+        let names = names(endian, elf).r;
         for relocation in relocations {
             p.group("Relocation", |p| {
                 p.field_hex("Offset", relocation.r_offset(endian).into());
-                p.field_consts("Type", relocation.r_type(endian), consts);
+                p.field_consts("Type", relocation.r_type(endian), names);
                 let sym = relocation.symbol(endian);
                 print_rel_symbol(p, endian, symbols, sym);
             });
@@ -380,14 +380,14 @@ fn print_section_rela<Elf: FileHeader>(
         } else {
             None
         };
-        let consts = constants(endian, elf).r;
+        let names = names(endian, elf).r;
         for relocation in relocations {
             p.group("Relocation", |p| {
                 p.field_hex("Offset", relocation.r_offset(endian).into());
                 p.field_consts(
                     "Type",
                     relocation.r_type(endian, elf.is_mips64el(endian)),
-                    consts,
+                    names,
                 );
                 let sym = relocation.symbol(endian, elf.is_mips64el(endian));
                 print_rel_symbol(p, endian, symbols, sym);
@@ -456,7 +456,7 @@ fn print_section_crel<Elf: FileHeader>(
         } else {
             None
         };
-        let consts = constants(endian, elf).r;
+        let names = names(endian, elf).r;
         for relocation_result in relocations {
             let Some(relocation) = relocation_result.print_err(p) else {
                 return;
@@ -464,7 +464,7 @@ fn print_section_crel<Elf: FileHeader>(
 
             p.group("Relocation", |p| {
                 p.field_hex("Offset", relocation.r_offset);
-                p.field_consts("Type", relocation.r_type, consts);
+                p.field_consts("Type", relocation.r_type, names);
                 print_rel_symbol(p, endian, symbols, relocation.symbol());
                 let addend = relocation.r_addend;
                 if addend != 0 {
@@ -574,12 +574,12 @@ fn print_dynamic<Elf: FileHeader>(
     dynamic: &[Elf::Dyn],
     dynstr: StringTable,
 ) {
-    let constants = constants(endian, elf);
+    let names = names(endian, elf);
     for d in dynamic {
         let tag = d.d_tag(endian);
         let val = d.d_val(endian).into();
         p.group("Dynamic", |p| {
-            p.field_consts("Tag", tag, constants.dt);
+            p.field_consts("Tag", tag, names.dt);
             if d.is_string(endian) {
                 p.field_string("Value", val, d.string(endian, dynstr));
             } else {
@@ -832,6 +832,6 @@ fn print_version<Elf: FileHeader>(
     }
 }
 
-fn constants<Elf: FileHeader>(endian: Elf::Endian, elf: &Elf) -> &'static Constants {
-    machine_constants(elf.e_machine(endian))
+fn names<Elf: FileHeader>(endian: Elf::Endian, elf: &Elf) -> &'static Names {
+    machine_names(elf.e_machine(endian))
 }

--- a/crates/examples/src/readobj/macho.rs
+++ b/crates/examples/src/readobj/macho.rs
@@ -812,7 +812,7 @@ fn print_section_relocations<S: Section>(
         return;
     }
     if let Some(relocations) = section.relocations(endian, data).print_err(p) {
-        let constants = macho::machine_constants(state.cputype);
+        let names = macho::machine_names(state.cputype);
         for relocation in relocations {
             if relocation.r_scattered(endian, state.cputype) {
                 let info = relocation.scattered_info(endian);
@@ -820,7 +820,7 @@ fn print_section_relocations<S: Section>(
                     p.field_hex("Address", info.r_address);
                     p.field("PcRel", if info.r_pcrel { "yes" } else { "no" });
                     p.field("Length", info.r_length);
-                    p.field_consts("Type", info.r_type, constants.reloc);
+                    p.field_consts("Type", info.r_type, names.reloc);
                     p.field_hex("Value", info.r_value);
                 });
             } else {
@@ -844,7 +844,7 @@ fn print_section_relocations<S: Section>(
                     }
                     p.field("PcRel", if info.r_pcrel { "yes" } else { "no" });
                     p.field("Length", info.r_length);
-                    p.field_consts("Type", info.r_type, constants.reloc);
+                    p.field_consts("Type", info.r_type, names.reloc);
                 });
             }
         }
@@ -1011,7 +1011,7 @@ fn print_exports_trie<Mach: MachHeader>(
 }
 
 fn print_cputype(p: &mut Printer<'_>, cputype: CpuType, cpusubtype: CpuSubtype) {
-    let constants = macho::machine_constants(cputype);
+    let names = macho::machine_names(cputype);
     p.field_consts("CpuType", cputype, macho::CpuType::NAMES);
-    p.field_flags("CpuSubtype", cpusubtype, constants.cpusubtype);
+    p.field_flags("CpuSubtype", cpusubtype, names.cpusubtype);
 }

--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -642,7 +642,7 @@ fn print_relocations<'data, Coff: CoffHeader>(
         return;
     }
     if let Some(relocations) = section.coff_relocations(data).print_err(p) {
-        let constants = pe::machine_constants(machine);
+        let names = pe::machine_names(machine);
         for relocation in relocations {
             p.group("ImageRelocation", |p| {
                 p.field_hex("VirtualAddress", relocation.virtual_address.get(LE));
@@ -655,7 +655,7 @@ fn print_relocations<'data, Coff: CoffHeader>(
                 });
                 p.field_string_option("Symbol", index.0, name);
                 let typ = relocation.typ.get(LE);
-                p.field_flags("Type", typ, constants.rel);
+                p.field_flags("Type", typ, names.rel);
             });
         }
     }
@@ -769,7 +769,7 @@ fn print_reloc_dir(
     if !p.options.pe_base_relocs {
         return Some(());
     }
-    let constants = pe::machine_constants(machine);
+    let names = pe::machine_names(machine);
     let mut blocks = data_directories
         .relocation_blocks(data, sections)
         .print_err(p)??;
@@ -779,7 +779,7 @@ fn print_reloc_dir(
         for reloc in block {
             p.group("ImageBaseRelocation", |p| {
                 p.field_hex("VirtualAddress", reloc.virtual_address);
-                p.field_consts("Type", reloc.typ, constants.rel_based);
+                p.field_consts("Type", reloc.typ, names.rel_based);
                 let offset = (reloc.virtual_address - block_address) as usize;
                 if let Some(addend) = match reloc.typ {
                     IMAGE_REL_BASED_HIGHLOW => block_data

--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -244,7 +244,7 @@ fn print_data_directories(p: &mut Printer<'_>, data_directories: &DataDirectorie
     }
     for (index, dir) in data_directories.iter().enumerate() {
         p.group("ImageDataDirectory", |p| {
-            p.field_consts("Index", index, NAMES_DIRECTORY_ENTRY);
+            p.field_consts("Index", index, &NAMES_DIRECTORY_ENTRY);
             p.field_hex("VirtualAddress", dir.virtual_address.get(LE));
             p.field_hex("Size", dir.size.get(LE));
         });

--- a/crates/examples/src/readobj/xcoff.rs
+++ b/crates/examples/src/readobj/xcoff.rs
@@ -133,7 +133,7 @@ fn print_sections<'data, Xcoff: FileHeader>(
                         });
                         p.field_string_option("Symbol", index.0, name);
                         p.field_hex("Size", relocation.r_rsize());
-                        p.field_consts("Type", relocation.r_rtype(), NAMES_REL_TYPE);
+                        p.field_consts("Type", relocation.r_rtype(), &NAMES_REL_TYPE);
                     });
                 }
             }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -327,17 +327,26 @@ where
 /// ```text
 /// names! {
 ///     struct Base;             // or: struct Arch(Base);
-///     // Expands using constant_names!()
-///     consts name: type = { ... };
-///     // Expands using flag_names!()
-///     flags name: type = { ... };
+///     // Anonymous inline definitions.
+///     consts name: type = { ... }; // Uses constant_names!()
+///     flags name: type = { ... }; // Uses flag_names!()
 ///     // Reference constants defined elsewhere.
-///     consts name: type = VAR;
+///     consts name = VAR;
+///     flags name = VAR;
+///     // Define module-level VAR and reference it. Optional doc comments and visibility.
+///     /// Doc comment.
+///     consts name = pub VAR: type = { ... };
+///     flags name = VAR: type = { ... };
 /// }
 /// ```
 macro_rules! names {
     ($(#[$meta:meta])* struct $struct:ident$(($parent:ident))?;
-        $($kind:ident $method:ident: $outer:ident$(($inner:ident))? = $body:tt;)*
+        $(
+            $(#[$varname_meta:meta])*
+            $kind:ident $method:ident
+                $(= $vis:vis $varname:ident)?
+                $(: $outer:ident$(($inner:ident))? = $body:tt)?;
+        )*
     ) => {
         #[cfg(feature = "names")]
         $(#[$meta])*
@@ -349,7 +358,7 @@ macro_rules! names {
             const fn names_value() -> Names {
                 #[allow(clippy::needless_update)]
                 Names {
-                    $($method: names!(@ref $method $body),)*
+                    $($method: names!(@ref $method ($($varname)?) ($($body)?)),)*
                     $(..$parent::names_value())?
                 }
             }
@@ -361,36 +370,50 @@ macro_rules! names {
                 &C
             }
 
-            // This converts $parent into a tt so that the method repetition can use it.
-            names! { @impl_methods ($($parent)?) $($kind $method ($outer $($inner)?) $body)* }
+            // Emit struct methods for anonymous inlines.
+            names! { @impl_methods ($($parent)?) $(
+                $kind $method ($($varname)?) ($($outer $($inner)?)?) ($($body)?)
+            )* }
         }
 
-        $(names! { @consts $kind ($outer $($inner)?) $body })*
+        // Emit module-level statics for named inlines.
+        names! { @statics ($($parent)?) $(
+            $kind $method ($(#[$varname_meta])*) ($($vis $varname)?) ($($outer $($inner)?)?) ($($body)?)
+        )* }
+
+        // Emit module-level constants.
+        $(names! { @consts $kind ($($outer $($inner)?)?) ($($body)?) })*
     };
 
-    (@impl_methods $parent:tt $($kind:ident $method:ident $type:tt $body:tt)*) => {
-        $(names! { @impl_method $kind $method $type $parent $body })*
+    // Struct methods returning anonymous ConstantNames/FlagNames static.
+    (@impl_methods $parent:tt $($kind:ident $method:ident $varname:tt $type:tt $body:tt)*) => {
+        $(names! { @impl_method $kind $method $varname $type (names!(@impl_next $method $parent)) $body })*
     };
-
-    // Struct method returning ConstantNames/FlagNames static.
-    // These methods exist only to give a place to define the statics,
-    // so not needed for delegation.
-    (@impl_method $kind:ident $method:ident $type:tt $parent:tt $fn:ident) => {};
-    (@impl_method consts $method:ident $type:tt $parent:tt $body:tt) => {
+    (@impl_method $kind:ident $method:ident ($varname:ident) $type:tt $next:tt $body:tt) => {};
+    (@impl_method consts $method:ident () $type:tt $next:tt ($body:tt)) => {
         const fn $method() -> &'static crate::constants::ConstantNames<newtype!(@type $type)> {
-            constant_names!(
-                @static NAMES $type (names!(@impl_next $method $parent)) $body
-            );
+            constant_names! { @static () NAMES $type $next $body }
             &NAMES
         }
     };
-    (@impl_method flags $method:ident $type:tt $parent:tt $body:tt) => {
-        const fn $method() -> &'static flag_names!(@flagnames $type) {
-            flag_names!(
-                @static NAMES $type (names!(@impl_next $method $parent)) $body
-            );
+    (@impl_method flags $method:ident () $type:tt $next:tt ($body:tt)) => {
+        const fn $method() -> &'static crate::constants::FlagNames<newtype!(@type $type)> {
+            flag_names! { @static () NAMES $type $next $body }
             &NAMES
         }
+    };
+
+    // Module-level ConstantNames/FlagNames statics.
+    (@statics $parent:tt $($kind:ident $method:ident $meta:tt $varname:tt $type:tt $body:tt)*) => {
+        $(names! { @static $kind $meta $varname $type (names!(@impl_next $method $parent)) $body })*
+    };
+    (@static $kind:ident () () $type:tt $next:tt $body:tt) => {};
+    (@static $kind:ident () $varname:tt $type:tt $next:tt ()) => {};
+    (@static consts $meta:tt ($vis:vis $varname:ident) $type:tt $next:tt ($body:tt)) => {
+        constant_names! { @static $meta $vis $varname $type $next $body }
+    };
+    (@static flags $meta:tt ($vis:vis $varname:ident) $type:tt $next:tt ($body:tt)) => {
+        flag_names! { @static $meta $vis $varname $type $next $body }
     };
 
     // Value of `ConstantNames::next` or `FlagNames::next`.
@@ -398,13 +421,22 @@ macro_rules! names {
     (@impl_next $method:ident ($parent:ident)) => { Some($parent::names_value().$method) };
 
     // Value of a field in `Names`.
-    (@ref $method:ident $fn:ident) => { &$fn };
-    (@ref $method:ident $body:tt) => { Self::$method() };
+    // - Named (reference or inline): use the module-level static directly.
+    // - Anonymous inline: call the const fn that hides the local NAMES static.
+    // - Neither varname nor body: invalid.
+    (@ref $method:ident ($varname:ident) $body:tt) => { &$varname };
+    (@ref $method:ident () ($body:tt)) => { Self::$method() };
+    (@ref $method:ident () ()) => {
+        compile_error!(concat!(
+            "`names!`: `", stringify!($method),
+            "` must specify either a body `= { ... }` or a reference `= NAME`"
+        ))
+    };
 
     // `pub const` values if required.
-    (@consts $kind:tt $type:tt $fn:ident) => {};
-    (@consts consts $type:tt $body:tt) => { constant_names! { @consts $type $body } };
-    (@consts flags $type:tt $body:tt) => { flag_names! { @consts $type $body } };
+    (@consts $kind:tt $type:tt ()) => {};
+    (@consts consts $type:tt ($body:tt)) => { constant_names! { @consts $type $body } };
+    (@consts flags $type:tt ($body:tt)) => { flag_names! { @consts $type $body } };
 }
 
 /// Create a static `ConstantNames` definition, and `pub const` definitions for the values.
@@ -419,17 +451,18 @@ macro_rules! names {
 /// constant_names!(varname: type = NAMES + { NAME = value, ... });
 /// ```
 macro_rules! constant_names {
-    ($varname:ident: $outer:ident$(($inner:ident))? = $($next:ident +)? { $($body:tt)* }) => {
-        constant_names! { @static $varname ($outer $($inner)?) (constant_names!(@next $($next)?)) { $($body)* } }
+    ($(#[$meta:meta])* $vis:vis $varname:ident: $outer:ident$(($inner:ident))? = $($next:ident +)? { $($body:tt)* }) => {
+        constant_names! { @static ($(#[$meta])*) $vis $varname ($outer $($inner)?) (constant_names!(@next $($next)?)) { $($body)* } }
         constant_names! { @consts ($outer $($inner)?) { $($body)* } }
     };
     (@next) => { None };
     (@next $next:ident) => { Some(&$next) };
-    (@static $varname:ident $type:tt ($next:expr) {
-        $($(#[$meta:meta])* $name:ident = $value:expr),* $(,)?
+    (@static ($(#[$meta:meta])*) $vis:vis $varname:ident $type:tt ($next:expr) {
+        $($(#[$entry_meta:meta])* $name:ident = $value:expr),* $(,)?
     }) => {
+        $(#[$meta])*
         #[cfg(feature = "names")]
-        static $varname: crate::constants::ConstantNames<newtype!(@type $type)> = crate::constants::ConstantNames {
+        $vis static $varname: crate::constants::ConstantNames<newtype!(@type $type)> = crate::constants::ConstantNames {
             next: $next,
             entries: &[$(($value, stringify!($name)),)*],
         };
@@ -464,15 +497,16 @@ macro_rules! constant_names {
 /// _ = mask_value => NAMES,
 /// ```
 macro_rules! flag_names {
-    ($varname:ident: $outer:ident$(($inner:ident))? = $($next:ident +)? { $($body:tt)* }) => {
-        flag_names! { @static $varname ($outer $($inner)?) (flag_names!(@next $($next)?)) { $($body)* } }
+    ($(#[$meta:meta])* $vis:vis $varname:ident: $outer:ident$(($inner:ident))? = $($next:ident +)? { $($body:tt)* }) => {
+        flag_names! { @static ($(#[$meta])*) $vis $varname ($outer $($inner)?) (flag_names!(@next $($next)?)) { $($body)* } }
         flag_names! { @consts ($outer $($inner)?) { $($body)* } }
     };
     (@next) => { None };
     (@next $next:ident) => { Some(&$next) };
-    (@static $varname:ident $type:tt ($next:expr) { $($body:tt)* }) => {
+    (@static ($(#[$meta:meta])*) $vis:vis $varname:ident $type:tt ($next:expr) { $($body:tt)* }) => {
+        $(#[$meta])*
         #[cfg(feature = "names")]
-        static $varname: flag_names!(@flagnames $type) = flag_names! {
+        $vis static $varname: crate::constants::FlagNames<newtype!(@type $type)> = flag_names! {
             @build_static ($type $next) [] [] $($body)*
         };
     };
@@ -551,7 +585,7 @@ macro_rules! flag_names {
         $(#[$meta:meta])* $name:ident = $value:expr => $entry:expr,
         $($rest:tt)*
     ) => {
-        $(#[$meta])* pub const $name: flag_names!(@mask $type) = $value;
+        $(#[$meta])* pub const $name: newtype!(@inner $type) = $value;
         flag_names! { @build_consts $type $($rest)* }
     };
 
@@ -562,11 +596,6 @@ macro_rules! flag_names {
     ) => {
         flag_names! { @build_consts $type $($rest)* }
     };
-
-    (@mask ($outer:ident $inner:ident)) => { $inner };
-    (@mask ($type:ident)) => { $type };
-    (@flagnames ($outer:ident $inner:ident)) => { crate::constants::FlagNames<$outer> };
-    (@flagnames ($outer:ident)) => { crate::constants::FlagNames<$outer> };
 }
 
 macro_rules! newtype {
@@ -601,6 +630,8 @@ macro_rules! newtype {
     // Newtype helpers for other macros.
     (@type ($outer:ident $inner:ident)) => { $outer };
     (@type ($type:ident)) => { $type };
+    (@inner ($outer:ident $inner:ident)) => { $inner };
+    (@inner ($type:ident)) => { $type };
     (@value ($outer:ident $inner:ident) $value:expr) => { $outer($value) };
     (@value ($type:ident) $value:expr) => { $value };
 }
@@ -858,8 +889,8 @@ mod tests {
         }
         names! {
             struct Base;
-            consts foo: Foo(u32) = FOO;
-            flags bar: Bar(u32) = BAR;
+            consts foo = FOO;
+            flags bar = BAR;
             // Inline constant definitions.
             consts quux: u64 = {
                 QUUX_A = 1,
@@ -870,9 +901,9 @@ mod tests {
             struct Arch(Base);
             // Does not inherit from Base::foo directly
             // (but the FOO_ARCH definition below does inherit FOO).
-            consts foo: Foo(u32) = FOO_ARCH;
-            // Inherits names from Base::bar.
-            flags bar: Bar(u32) = {
+            consts foo = FOO_ARCH;
+            // BAR_ARCH is a module-level static that inherits names from Base::bar.
+            flags bar = BAR_ARCH: Bar(u32) = {
                 BIT_4 = 0x8,
             };
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -314,18 +314,18 @@ where
 
 /// Define a set of related constant definitions, such as for an architecture.
 ///
-/// Defines a struct with method `constants` that returns a `struct Constants` containing
-/// fields set to the given definitions. The caller should have defined `struct Constants`
+/// Defines a struct with method `names` that returns a `struct Names` containing
+/// fields set to the given definitions. The caller should have defined `struct Names`
 /// with matching fields.
 ///
 /// An optional parent struct can be specified to inherit definitions via `next` chaining.
 /// For example, if `Base` is the parent then `consts name: type = { ... };` is expanded
-/// similar to `constant_names!(name: type = Base::constants_value().name + { ... })`.
+/// similar to `constant_names!(name: type = Base::names_value().name + { ... })`.
 /// The parent is often a set of constant definitions that are common to all architectures.
 ///
 /// Usage:
 /// ```text
-/// constants! {
+/// names! {
 ///     struct Base;             // or: struct Arch(Base);
 ///     // Expands using constant_names!()
 ///     consts name: type = { ... };
@@ -335,7 +335,7 @@ where
 ///     consts name: type = VAR;
 /// }
 /// ```
-macro_rules! constants {
+macro_rules! names {
     ($(#[$meta:meta])* struct $struct:ident$(($parent:ident))?;
         $($kind:ident $method:ident: $outer:ident$(($inner:ident))? = $body:tt;)*
     ) => {
@@ -346,30 +346,30 @@ macro_rules! constants {
 
         #[cfg(feature = "names")]
         impl $struct {
-            const fn constants_value() -> Constants {
+            const fn names_value() -> Names {
                 #[allow(clippy::needless_update)]
-                Constants {
-                    $($method: constants!(@ref $method $body),)*
-                    $(..$parent::constants_value())?
+                Names {
+                    $($method: names!(@ref $method $body),)*
+                    $(..$parent::names_value())?
                 }
             }
 
             // Not used for inheritance-only structs.
             #[allow(unused)]
-            const fn constants() -> &'static Constants {
-                static C: Constants = $struct::constants_value();
+            const fn names() -> &'static Names {
+                static C: Names = $struct::names_value();
                 &C
             }
 
             // This converts $parent into a tt so that the method repetition can use it.
-            constants! { @impl_methods ($($parent)?) $($kind $method ($outer $($inner)?) $body)* }
+            names! { @impl_methods ($($parent)?) $($kind $method ($outer $($inner)?) $body)* }
         }
 
-        $(constants! { @consts $kind ($outer $($inner)?) $body })*
+        $(names! { @consts $kind ($outer $($inner)?) $body })*
     };
 
     (@impl_methods $parent:tt $($kind:ident $method:ident $type:tt $body:tt)*) => {
-        $(constants! { @impl_method $kind $method $type $parent $body })*
+        $(names! { @impl_method $kind $method $type $parent $body })*
     };
 
     // Struct method returning ConstantNames/FlagNames static.
@@ -379,7 +379,7 @@ macro_rules! constants {
     (@impl_method consts $method:ident $type:tt $parent:tt $body:tt) => {
         const fn $method() -> &'static crate::constants::ConstantNames<newtype!(@type $type)> {
             constant_names!(
-                @static NAMES $type (constants!(@impl_next $method $parent)) $body
+                @static NAMES $type (names!(@impl_next $method $parent)) $body
             );
             &NAMES
         }
@@ -387,7 +387,7 @@ macro_rules! constants {
     (@impl_method flags $method:ident $type:tt $parent:tt $body:tt) => {
         const fn $method() -> &'static flag_names!(@flagnames $type) {
             flag_names!(
-                @static NAMES $type (constants!(@impl_next $method $parent)) $body
+                @static NAMES $type (names!(@impl_next $method $parent)) $body
             );
             &NAMES
         }
@@ -395,9 +395,9 @@ macro_rules! constants {
 
     // Value of `ConstantNames::next` or `FlagNames::next`.
     (@impl_next $method:ident ()) => { None };
-    (@impl_next $method:ident ($parent:ident)) => { Some($parent::constants_value().$method) };
+    (@impl_next $method:ident ($parent:ident)) => { Some($parent::names_value().$method) };
 
-    // Value of a field in `Constants`.
+    // Value of a field in `Names`.
     (@ref $method:ident $fn:ident) => { &$fn };
     (@ref $method:ident $body:tt) => { Self::$method() };
 
@@ -851,12 +851,12 @@ mod tests {
             }
         }
         #[cfg(feature = "names")]
-        struct Constants {
+        struct Names {
             foo: &'static ConstantNames<Foo>,
             bar: &'static FlagNames<Bar>,
             quux: &'static ConstantNames<u64>,
         }
-        constants! {
+        names! {
             struct Base;
             consts foo: Foo(u32) = FOO;
             flags bar: Bar(u32) = BAR;
@@ -866,7 +866,7 @@ mod tests {
                 QUUX_B = 1,
             };
         }
-        constants! {
+        names! {
             struct Arch(Base);
             // Does not inherit from Base::foo directly
             // (but the FOO_ARCH definition below does inherit FOO).
@@ -882,18 +882,15 @@ mod tests {
 
         #[cfg(feature = "names")]
         {
-            let constants = Arch::constants();
-            assert_eq!(constants.foo.name(FOO_A), Some("FOO_A"));
-            assert_eq!(constants.foo.name(FOO_ARCH_A), Some("FOO_ARCH_A"));
-            assert_eq!(constants.bar.name(BIT_1), Some((BIT_1, "BIT_1")));
-            assert_eq!(constants.bar.name(BIT_4), Some((BIT_4, "BIT_4")));
-            assert_eq!(constants.bar.name(BIT_1 | BIT_4), Some((BIT_4, "BIT_4")));
-            assert_eq!(constants.bar.name(BAR_B), Some((BAR_B, "BAR_B")));
-            assert_eq!(constants.bar.name(BAR_D), Some((BAR_D, "BAR_D")));
-            assert_eq!(
-                constants.bar.name(BAZ_B.into()),
-                Some((BAZ_B.into(), "BAZ_B"))
-            );
+            let names = Arch::names();
+            assert_eq!(names.foo.name(FOO_A), Some("FOO_A"));
+            assert_eq!(names.foo.name(FOO_ARCH_A), Some("FOO_ARCH_A"));
+            assert_eq!(names.bar.name(BIT_1), Some((BIT_1, "BIT_1")));
+            assert_eq!(names.bar.name(BIT_4), Some((BIT_4, "BIT_4")));
+            assert_eq!(names.bar.name(BIT_1 | BIT_4), Some((BIT_4, "BIT_4")));
+            assert_eq!(names.bar.name(BAR_B), Some((BAR_B, "BAR_B")));
+            assert_eq!(names.bar.name(BAR_D), Some((BAR_D, "BAR_D")));
+            assert_eq!(names.bar.name(BAZ_B.into()), Some((BAZ_B.into(), "BAZ_B")));
         }
     }
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -3021,7 +3021,8 @@ pub fn gnu_hash(name: &[u8]) -> u32 {
 
 names! {
     struct M68k(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_68K`.
+    consts r = pub NAMES_R_68K: u32 = {
         /// No reloc
         R_68K_NONE = 0,
         /// Direct 32 bit
@@ -3111,7 +3112,8 @@ names! {
 
 names! {
     struct I386(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_386`.
+    consts r = pub NAMES_R_386: u32 = {
         /// No reloc
         R_386_NONE = 0,
         /// Direct 32 bit
@@ -3203,7 +3205,8 @@ names! {
 
 names! {
     struct Sharc(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_SHARC`.
+    consts r = pub NAMES_R_SHARC: u32 = {
         /// 24-bit absolute address in bits 23:0 of a 48-bit instr
         ///
         /// Targets:
@@ -3329,7 +3332,8 @@ names! {
         /// Sun UltraSPARCIII extensions
         EF_SPARC_SUN_US3 = 0x00_0800,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_SPARC` and `EM_SPARC32PLUS`.
+    consts r = pub NAMES_R_SPARC: u32 = {
         /// No reloc
         R_SPARC_NONE = 0,
         /// Direct 8 bit
@@ -3605,7 +3609,8 @@ names! {
     consts stb: SymbolBind(u8) = {
         STB_MIPS_SPLIT_COMMON = 13,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_MIPS`.
+    consts r = pub NAMES_R_MIPS: u32 = {
         /// No reloc
         R_MIPS_NONE = 0,
         /// Direct 16 bit
@@ -3985,7 +3990,8 @@ names! {
         STT_HP_OPAQUE = STT_LOOS + 0x1,
         STT_HP_STUB = STT_LOOS + 0x2,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_PARISC`.
+    consts r = pub NAMES_R_PARISC: u32 = {
         /// No reloc.
         R_PARISC_NONE = 0,
         /// Direct 32-bit reference.
@@ -4263,7 +4269,8 @@ names! {
         /// PV only used for initial ldgp.
         STO_ALPHA_STD_GPLOAD = 0x88,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_ALPHA`.
+    consts r = pub NAMES_R_ALPHA: u32 = {
         /// No reloc
         R_ALPHA_NONE = 0,
         /// Direct 32 bit
@@ -4344,7 +4351,8 @@ names! {
         /// PowerPC -mrelocatable-lib flag
         EF_PPC_RELOCATABLE_LIB = 0x0000_8000,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_PPC`.
+    consts r = pub NAMES_R_PPC: u32 = {
         // PowerPC values for `Rel*::r_type` defined by the ABIs.
         R_PPC_NONE = 0,
         /// 32bit absolute address
@@ -4517,7 +4525,8 @@ pub const PPC_OPT_TLS: u32 = 1;
 
 names! {
     struct Ppc64(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_PPC64`.
+    consts r = pub NAMES_R_PPC64: u32 = {
         // PowerPC64 values for `Rel*::r_type` defined by the ABIs.
         R_PPC64_NONE = R_PPC_NONE,
         /// 32bit absolute address
@@ -4817,7 +4826,8 @@ names! {
         /// ARM attributes section.
         SHT_ARM_ATTRIBUTES = SHT_LOPROC + 3,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_ARM`.
+    consts r = pub NAMES_R_ARM: u32 = {
         /// No reloc
         R_ARM_NONE = 0,
         /// Deprecated PC relative 26 bit branch.
@@ -5084,7 +5094,8 @@ names! {
         DT_AARCH64_PAC_PLT = DT_LOPROC + 3,
         DT_AARCH64_VARIANT_PCS = DT_LOPROC + 5,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_AARCH64`.
+    consts r = pub NAMES_R_AARCH64: u32 = {
         /// No relocation.
         R_AARCH64_NONE = 0,
 
@@ -5374,7 +5385,8 @@ names! {
         /// Bitmask for `EF_AVR_ARCH_*`.
         EF_AVR_ARCH = 0x7F => NAMES_EF_AVR_ARCH,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_AVR`.
+    consts r = pub NAMES_R_AVR: u32 = {
         R_AVR_NONE = 0,
         /// Direct 32 bit
         R_AVR_32 = 1,
@@ -5440,7 +5452,8 @@ constant_names!(NAMES_EF_AVR_ARCH: FileFlags(u32) = {
 
 names! {
     struct Msp430(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_MSP430`.
+    consts r = pub NAMES_R_MSP430: u32 = {
         /// No reloc
         R_MSP430_NONE = 0,
         /// Direct 32 bit
@@ -5452,7 +5465,8 @@ names! {
 
 names! {
     struct Hex(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_HEXAGON`.
+    consts r = pub NAMES_R_HEX: u32 = {
         /// No reloc
         R_HEX_NONE = 0,
         /// Direct 32 bit
@@ -5462,7 +5476,8 @@ names! {
 
 names! {
     struct Csky(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_CSKY`.
+    consts r = pub NAMES_R_CKCORE: u32 = {
         /// no reloc
         R_CKCORE_NONE = 0,
         /// direct 32 bit (S + A)
@@ -5621,7 +5636,8 @@ names! {
     consts dt: DynamicTag(i64) = {
         DT_IA_64_PLT_RESERVE = DT_LOPROC + 0,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_IA_64`.
+    consts r = pub NAMES_R_IA64: u32 = {
         /// none
         R_IA64_NONE = 0x00,
         /// symbol + addend, add imm14
@@ -5799,7 +5815,8 @@ names! {
     flags ef: FileFlags(u32) = {
         EF_SH_MACH_MASK = 0x1f => NAMES_EF_SH_MACH,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_SH`.
+    consts r = pub NAMES_R_SH: u32 = {
         R_SH_NONE = 0,
         R_SH_DIR32 = 1,
         R_SH_REL32 = 2,
@@ -5848,7 +5865,8 @@ names! {
         /// High GPRs kernel facility needed.
         EF_S390_HIGH_GPRS = 0x0000_0001,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_S390`.
+    consts r = pub NAMES_R_390: u32 = {
         /// No reloc.
         R_390_NONE = 0,
         /// Direct 8 bit.
@@ -6002,7 +6020,8 @@ constant_names!(NAMES_EF_SH_MACH: FileFlags(u32) = {
 
 names! {
     struct Cris(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_CRIS`.
+    consts r = pub NAMES_R_CRIS: u32 = {
         R_CRIS_NONE = 0,
         R_CRIS_8 = 1,
         R_CRIS_16 = 2,
@@ -6028,7 +6047,8 @@ names! {
 
 names! {
     struct X86_64(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_X86_64`.
+    consts r = pub NAMES_R_X86_64: u32 = {
         /// No reloc
         R_X86_64_NONE = 0,
         /// Direct 64 bit
@@ -6140,7 +6160,8 @@ names! {
 
 names! {
     struct Mn10300(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_MN10300`.
+    consts r = pub NAMES_R_MN10300: u32 = {
         /// No reloc.
         R_MN10300_NONE = 0,
         /// Direct 32 bit.
@@ -6216,7 +6237,8 @@ names! {
 
 names! {
     struct M32r(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_M32R`.
+    consts r = pub NAMES_R_M32R: u32 = {
         /// No reloc.
         R_M32R_NONE = 0,
         /// Direct 16 bit.
@@ -6308,7 +6330,8 @@ names! {
 
 names! {
     struct Microblaze(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_MICROBLAZE`.
+    consts r = pub NAMES_R_MICROBLAZE: u32 = {
         /// No reloc.
         R_MICROBLAZE_NONE = 0,
         /// Direct 32 bit.
@@ -6379,7 +6402,8 @@ names! {
         /// Address of _gp.
         DT_NIOS2_GP = 0x7000_0002,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_ALTERA_NIOS2`.
+    consts r = pub NAMES_R_NIOS2: u32 = {
         /// No reloc.
         R_NIOS2_NONE = 0,
         /// Direct signed 16 bit.
@@ -6478,7 +6502,8 @@ names! {
 // TILEPro
 names! {
     struct Tilepro(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_TILEPRO`.
+    consts r = pub NAMES_R_TILEPRO: u32 = {
         /// No reloc
         R_TILEPRO_NONE = 0,
         /// Direct 32 bit
@@ -6669,7 +6694,8 @@ names! {
 // TILE-Gx
 names! {
     struct Tilegx(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_TILEGX`.
+    consts r = pub NAMES_R_TILEGX: u32 = {
         /// No reloc
         R_TILEGX_NONE = 0,
         /// Direct 64 bit
@@ -6939,7 +6965,8 @@ names! {
     consts dt: DynamicTag(i64) = {
         DT_RISCV_VARIANT_CC = DT_LOPROC + 1,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_RISCV`.
+    consts r = pub NAMES_R_RISCV: u32 = {
         R_RISCV_NONE = 0,
         R_RISCV_32 = 1,
         R_RISCV_64 = 2,
@@ -7015,7 +7042,8 @@ constant_names!(NAMES_EF_RISCV_FLOAT_ABI: FileFlags(u32) = {
 
 names! {
     struct Bpf(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_BPF`.
+    consts r = pub NAMES_R_BPF: u32 = {
         /// No reloc
         R_BPF_NONE = 0,
         R_BPF_64_64 = 1,
@@ -7025,7 +7053,8 @@ names! {
 
 names! {
     struct Sbf(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_SBF`.
+    consts r = pub NAMES_R_SBF: u32 = {
         /// No reloc
         R_SBF_NONE = 0,
         R_SBF_64_64 = 1,
@@ -7037,7 +7066,8 @@ names! {
 
 names! {
     struct Metag(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_METAG`.
+    consts r = pub NAMES_R_METAG: u32 = {
         R_METAG_HIADDR16 = 0,
         R_METAG_LOADDR16 = 1,
         /// 32bit absolute address
@@ -7103,7 +7133,8 @@ names! {
 
 names! {
     struct Nds32(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_NDS32`.
+    consts r = pub NAMES_R_NDS32: u32 = {
         R_NDS32_NONE = 0,
         R_NDS32_32_RELA = 20,
         R_NDS32_COPY = 39,
@@ -7124,7 +7155,8 @@ names! {
         /// Uses relocation types directly writing to immediate slots
         EF_LARCH_OBJABI_V1 = 0x40,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_LOONGARCH`.
+    consts r = pub NAMES_R_LARCH: u32 = {
         /// No reloc
         R_LARCH_NONE = 0,
         /// Runtime address resolving
@@ -7460,7 +7492,8 @@ constant_names!(NAMES_EF_LARCH_ABI: FileFlags(u32) = {
 
 names! {
     struct Xtensa(Base);
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_XTENSA`.
+    consts r = pub NAMES_R_XTENSA: u32 = {
         R_XTENSA_NONE = 0,
         R_XTENSA_32 = 1,
         R_XTENSA_RTLD = 2,
@@ -7582,7 +7615,8 @@ names! {
         EF_E2K_PM = 32,
         EF_E2K_PACK_SEGMENTS = 64,
     };
-    consts r: u32 = {
+    /// `Rel*::r_type` values for `EM_MCST_ELBRUS`.
+    consts r = pub NAMES_R_E2K: u32 = {
         /// Direct 32 bit.
         R_E2K_32_ABS = 0,
         /// PC relative 32 bit.

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -48,17 +48,17 @@ pub struct Names {
 
 names! {
     struct Base;
-    consts et: FileType = NAMES_ET;
+    consts et = NAMES_ET;
     flags ef: FileFlags(u32) = {};
-    consts shn: SymbolSection = NAMES_SHN;
-    consts sht: SectionType = NAMES_SHT;
-    flags shf: SectionFlags = NAMES_SHF;
-    consts stb: SymbolBind = NAMES_STB;
-    consts stt: SymbolType = NAMES_STT;
-    flags sto: SymbolFlags = NAMES_STO;
-    consts pt: ProgramType = NAMES_PT;
-    flags pf: ProgramFlags = NAMES_PF;
-    consts dt: DynamicTag = NAMES_DT;
+    consts shn = NAMES_SHN;
+    consts sht = NAMES_SHT;
+    flags shf = NAMES_SHF;
+    consts stb = NAMES_STB;
+    consts stt = NAMES_STT;
+    flags sto = NAMES_STO;
+    consts pt = NAMES_PT;
+    flags pf = NAMES_PF;
+    consts dt = NAMES_DT;
     consts r: u32 = {};
 }
 

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -13,13 +13,13 @@ use crate::constants::{ConstantNames, FlagNames};
 use crate::endian::{Endian, I32, I64, U16, U32, U64};
 use crate::pod::Pod;
 
-/// Platform-specific constants for an ELF file.
+/// Platform-specific constant names for an ELF file.
 ///
-/// Returned by [`constants`] and [`machine_constants`].
+/// Returned by [`names`] and [`machine_names`].
 #[cfg(feature = "names")]
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct Constants {
+pub struct Names {
     /// Values for `FileHeader*::e_type`.
     pub et: &'static ConstantNames<FileType>,
     /// Values for `FileHeader*::e_flags`.
@@ -46,7 +46,7 @@ pub struct Constants {
     pub r: &'static ConstantNames<u32>,
 }
 
-constants! {
+names! {
     struct Base;
     consts et: FileType = NAMES_ET;
     flags ef: FileFlags(u32) = {};
@@ -62,57 +62,57 @@ constants! {
     consts r: u32 = {};
 }
 
-/// Return the platform independent constants.
+/// Return the platform independent names for constants.
 #[cfg(feature = "names")]
-pub const fn constants() -> &'static Constants {
-    Base::constants()
+pub const fn names() -> &'static Names {
+    Base::names()
 }
 
-/// Return the platform specific constants.
+/// Return the platform specific names for constants.
 ///
-/// Note that these also include the values returned by [`constants`].
+/// Note that these also include the values returned by [`names`].
 ///
 /// `machine` corresponds to the `FileHeader*::e_machine` field.
 #[cfg(feature = "names")]
-pub const fn machine_constants(machine: Machine) -> &'static Constants {
+pub const fn machine_names(machine: Machine) -> &'static Names {
     match machine {
-        EM_386 => I386::constants(),
-        EM_68K => M68k::constants(),
-        EM_AARCH64 => Aarch64::constants(),
-        EM_ALPHA => Alpha::constants(),
-        EM_ALTERA_NIOS2 => Nios2::constants(),
-        EM_ARM => Arm::constants(),
-        EM_AVR => Avr::constants(),
-        EM_BPF => Bpf::constants(),
-        EM_CRIS => Cris::constants(),
-        EM_CSKY => Csky::constants(),
-        EM_HEXAGON => Hex::constants(),
-        EM_MCST_ELBRUS => E2k::constants(),
-        EM_IA_64 => Ia64::constants(),
-        EM_LOONGARCH => Larch::constants(),
-        EM_M32R => M32r::constants(),
-        EM_METAG => Metag::constants(),
-        EM_MICROBLAZE => Microblaze::constants(),
-        EM_MIPS => Mips::constants(),
-        EM_MN10300 => Mn10300::constants(),
-        EM_MSP430 => Msp430::constants(),
-        EM_NDS32 => Nds32::constants(),
-        EM_PARISC => Parisc::constants(),
-        EM_PPC => Ppc::constants(),
-        EM_PPC64 => Ppc64::constants(),
-        EM_RISCV => Riscv::constants(),
-        EM_S390 => S390::constants(),
-        EM_SBF => Sbf::constants(),
-        EM_SH => Sh::constants(),
-        EM_SHARC => Sharc::constants(),
+        EM_386 => I386::names(),
+        EM_68K => M68k::names(),
+        EM_AARCH64 => Aarch64::names(),
+        EM_ALPHA => Alpha::names(),
+        EM_ALTERA_NIOS2 => Nios2::names(),
+        EM_ARM => Arm::names(),
+        EM_AVR => Avr::names(),
+        EM_BPF => Bpf::names(),
+        EM_CRIS => Cris::names(),
+        EM_CSKY => Csky::names(),
+        EM_HEXAGON => Hex::names(),
+        EM_MCST_ELBRUS => E2k::names(),
+        EM_IA_64 => Ia64::names(),
+        EM_LOONGARCH => Larch::names(),
+        EM_M32R => M32r::names(),
+        EM_METAG => Metag::names(),
+        EM_MICROBLAZE => Microblaze::names(),
+        EM_MIPS => Mips::names(),
+        EM_MN10300 => Mn10300::names(),
+        EM_MSP430 => Msp430::names(),
+        EM_NDS32 => Nds32::names(),
+        EM_PARISC => Parisc::names(),
+        EM_PPC => Ppc::names(),
+        EM_PPC64 => Ppc64::names(),
+        EM_RISCV => Riscv::names(),
+        EM_S390 => S390::names(),
+        EM_SBF => Sbf::names(),
+        EM_SH => Sh::names(),
+        EM_SHARC => Sharc::names(),
         // TODO: might need to be separated
-        EM_SPARC | EM_SPARC32PLUS => Sparc::constants(),
-        EM_SPARCV9 => SparcV9::constants(),
-        EM_TILEGX => Tilegx::constants(),
-        EM_TILEPRO => Tilepro::constants(),
-        EM_X86_64 => X86_64::constants(),
-        EM_XTENSA => Xtensa::constants(),
-        _ => Base::constants(),
+        EM_SPARC | EM_SPARC32PLUS => Sparc::names(),
+        EM_SPARCV9 => SparcV9::names(),
+        EM_TILEGX => Tilegx::names(),
+        EM_TILEPRO => Tilepro::names(),
+        EM_X86_64 => X86_64::names(),
+        EM_XTENSA => Xtensa::names(),
+        _ => Base::names(),
     }
 }
 
@@ -3019,7 +3019,7 @@ pub fn gnu_hash(name: &[u8]) -> u32 {
 
 // Motorola 68k specific definitions.
 
-constants! {
+names! {
     struct M68k(Base);
     consts r: u32 = {
         /// No reloc
@@ -3109,7 +3109,7 @@ constants! {
 
 // Intel 80386 specific definitions.
 
-constants! {
+names! {
     struct I386(Base);
     consts r: u32 = {
         /// No reloc
@@ -3201,7 +3201,7 @@ constants! {
 
 // ADI SHARC specific definitions
 
-constants! {
+names! {
     struct Sharc(Base);
     consts r: u32 = {
         /// 24-bit absolute address in bits 23:0 of a 48-bit instr
@@ -3311,7 +3311,7 @@ constants! {
 
 // SUN SPARC specific definitions.
 
-constants! {
+names! {
     struct Sparc(Base);
     consts stt: SymbolType(u8) = {
         /// Global register reserved to app.
@@ -3489,7 +3489,7 @@ constants! {
 
 pub const EF_SPARC_EXT_MASK: u32 = 0xFF_FF00;
 
-constants! {
+names! {
     struct SparcV9(Sparc);
     flags ef: FileFlags(u32) = {
         EF_SPARCV9_MM = 3 => NAMES_EF_SPARC_MM,
@@ -3504,7 +3504,7 @@ constant_names!(NAMES_EF_SPARC_MM: FileFlags(u32) = {
 
 // MIPS R3000 specific definitions.
 
-constants! {
+names! {
     struct Mips(Base);
     flags ef: FileFlags(u32) = {
         /// A .noreorder directive was used.
@@ -3939,7 +3939,7 @@ pub const LL_DELTA: u32 = 1 << 5;
 
 // PA-RISC specific definitions.
 
-constants! {
+names! {
     struct Parisc(Base);
     flags ef: FileFlags(u32) = {
         /// Trap nil pointer dereference.
@@ -4241,7 +4241,7 @@ constant_names!(NAMES_EFA_PARISC: FileFlags(u32) = {
 
 // Alpha specific definitions.
 
-constants! {
+names! {
     struct Alpha(Base);
     flags ef: FileFlags(u32) = {
         /// All addresses must be < 2GB.
@@ -4332,7 +4332,7 @@ pub const LITUSE_ALPHA_TLS_LDM: u32 = 5;
 
 // PowerPC specific declarations.
 
-constants! {
+names! {
     struct Ppc(Base);
     flags ef: FileFlags(u32) = {
         /// PowerPC embedded flag
@@ -4515,7 +4515,7 @@ constants! {
 // PowerPC specific values for the `DT_PPC_OPT` entry.
 pub const PPC_OPT_TLS: u32 = 1;
 
-constants! {
+names! {
     struct Ppc64(Base);
     consts r: u32 = {
         // PowerPC64 values for `Rel*::r_type` defined by the ABIs.
@@ -4762,7 +4762,7 @@ pub const STO_PPC64_LOCAL_MASK: u8 = 7 << STO_PPC64_LOCAL_BIT;
 
 // ARM specific declarations.
 
-constants! {
+names! {
     struct Arm(Base);
     flags ef: FileFlags(u32) = {
         EF_ARM_RELEXEC = 0x01,
@@ -5069,7 +5069,7 @@ pub const EF_ARM_SYMSARESORTED: u32 = 0x04;
 pub const EF_ARM_DYNSYMSUSESEGIDX: u32 = 0x08;
 pub const EF_ARM_MAPSYMSFIRST: u32 = 0x10;
 
-constants! {
+names! {
     struct Aarch64(Base);
     consts sht: SectionType(u32) = {
         /// AArch64 attributes section.
@@ -5364,7 +5364,7 @@ constants! {
 
 pub const DT_AARCH64_NUM: i64 = 6;
 
-constants! {
+names! {
     struct Avr(Base);
     flags ef: FileFlags(u32) = {
         /// If set, it is assumed that the elf file uses local symbols as reference
@@ -5438,7 +5438,7 @@ constant_names!(NAMES_EF_AVR_ARCH: FileFlags(u32) = {
     EF_AVR_ARCH_XMEGA7 = 107,
 });
 
-constants! {
+names! {
     struct Msp430(Base);
     consts r: u32 = {
         /// No reloc
@@ -5450,7 +5450,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Hex(Base);
     consts r: u32 = {
         /// No reloc
@@ -5460,7 +5460,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Csky(Base);
     consts r: u32 = {
         /// no reloc
@@ -5587,7 +5587,7 @@ constant_names!(NAMES_EF_CSKY_ABI: FileFlags(u32) = {
 
 // IA-64 specific declarations.
 
-constants! {
+names! {
     struct Ia64(Base);
     flags ef: FileFlags(u32) = {
         /// 64-bit ABI
@@ -5794,7 +5794,7 @@ pub const EF_IA_64_ARCH: u32 = 0xff00_0000;
 
 // SH specific declarations.
 
-constants! {
+names! {
     struct Sh(Base);
     flags ef: FileFlags(u32) = {
         EF_SH_MACH_MASK = 0x1f => NAMES_EF_SH_MACH,
@@ -5842,7 +5842,7 @@ constants! {
 
 // S/390 specific definitions.
 
-constants! {
+names! {
     struct S390(Base);
     flags ef: FileFlags(u32) = {
         /// High GPRs kernel facility needed.
@@ -6000,7 +6000,7 @@ constant_names!(NAMES_EF_SH_MACH: FileFlags(u32) = {
     EF_SH2A_SH3E = 0x18,
 });
 
-constants! {
+names! {
     struct Cris(Base);
     consts r: u32 = {
         R_CRIS_NONE = 0,
@@ -6026,7 +6026,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct X86_64(Base);
     consts r: u32 = {
         /// No reloc
@@ -6138,7 +6138,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Mn10300(Base);
     consts r: u32 = {
         /// No reloc.
@@ -6214,7 +6214,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct M32r(Base);
     consts r: u32 = {
         /// No reloc.
@@ -6306,7 +6306,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Microblaze(Base);
     consts r: u32 = {
         /// No reloc.
@@ -6373,7 +6373,7 @@ constants! {
 }
 
 // Nios II
-constants! {
+names! {
     struct Nios2(Base);
     consts dt: DynamicTag(i64) = {
         /// Address of _gp.
@@ -6476,7 +6476,7 @@ constants! {
 }
 
 // TILEPro
-constants! {
+names! {
     struct Tilepro(Base);
     consts r: u32 = {
         /// No reloc
@@ -6667,7 +6667,7 @@ constants! {
 }
 
 // TILE-Gx
-constants! {
+names! {
     struct Tilegx(Base);
     consts r: u32 = {
         /// No reloc
@@ -6916,7 +6916,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Riscv(Base);
     flags ef: FileFlags(u32) = {
         EF_RISCV_RVC = 0x0001,
@@ -7013,7 +7013,7 @@ constant_names!(NAMES_EF_RISCV_FLOAT_ABI: FileFlags(u32) = {
     EF_RISCV_FLOAT_ABI_QUAD = 0x0006,
 });
 
-constants! {
+names! {
     struct Bpf(Base);
     consts r: u32 = {
         /// No reloc
@@ -7023,7 +7023,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Sbf(Base);
     consts r: u32 = {
         /// No reloc
@@ -7035,7 +7035,7 @@ constants! {
 
 // Imagination Meta
 
-constants! {
+names! {
     struct Metag(Base);
     consts r: u32 = {
         R_METAG_HIADDR16 = 0,
@@ -7101,7 +7101,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Nds32(Base);
     consts r: u32 = {
         R_NDS32_NONE = 0,
@@ -7115,7 +7115,7 @@ constants! {
     };
 }
 
-constants! {
+names! {
     struct Larch(Base);
     flags ef: FileFlags(u32) = {
         /// Additional properties of the base ABI type, including the FP calling
@@ -7458,7 +7458,7 @@ constant_names!(NAMES_EF_LARCH_ABI: FileFlags(u32) = {
     EF_LARCH_ABI_DOUBLE_FLOAT = 0x3,
 });
 
-constants! {
+names! {
     struct Xtensa(Base);
     consts r: u32 = {
         R_XTENSA_NONE = 0,
@@ -7572,7 +7572,7 @@ pub const E_E2K_MACH_48C: u32 = 24;
 /// -mtune=elbrus-8v7 code.
 pub const E_E2K_MACH_8V7: u32 = 25;
 
-constants! {
+names! {
     struct E2k(Base);
     flags ef: FileFlags(u32) = {
         EF_E2K_IPD = 3,

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -4005,7 +4005,9 @@ impl ScatteredRelocationInfo {
  * using the GENERIC_RELOC_PB_LA_PTR r_type.  This is a scattered relocation
  * entry where the r_value feild is the value of the lazy pointer not prebound.
  */
-constant_names!(NAMES_GENERIC_RELOC: u8 = {
+constant_names!(
+/// Values for `Relocation::r_type` for generic Mach-O architectures.
+pub NAMES_GENERIC_RELOC: u8 = {
     /// generic relocation as described above
     GENERIC_RELOC_VANILLA = 0,
     /// Only follows a GENERIC_RELOC_SECTDIFF
@@ -4028,7 +4030,9 @@ constant_names!(NAMES_GENERIC_RELOC: u8 = {
  * for instructions.  Since they are for instructions the r_address field
  * indicates the 32 bit instruction that the relocation is to be performed on.
  */
-constant_names!(NAMES_ARM_RELOC: u8 = {
+constant_names!(
+/// Values for `Relocation::r_type` on ARM.
+pub NAMES_ARM_RELOC: u8 = {
     /// generic relocation as described above
     ARM_RELOC_VANILLA = 0,
     /// the second relocation entry of a pair
@@ -4068,7 +4072,9 @@ constant_names!(NAMES_ARM_RELOC: u8 = {
 /*
  * Relocation types used in the arm64 implementation.
  */
-constant_names!(NAMES_ARM64_RELOC: u8 = {
+constant_names!(
+/// Values for `Relocation::r_type` on ARM64.
+pub NAMES_ARM64_RELOC: u8 = {
     /// for pointers
     ARM64_RELOC_UNSIGNED = 0,
     /// must be followed by a ARM64_RELOC_UNSIGNED
@@ -4131,7 +4137,9 @@ constant_names!(NAMES_ARM64_RELOC: u8 = {
  * the value of the Y-bit if the sign of the displacement changes for non-branch
  * always conditions.
  */
-constant_names!(NAMES_PPC_RELOC: u8 = {
+constant_names!(
+/// Values for `Relocation::r_type` on PowerPC.
+pub NAMES_PPC_RELOC: u8 = {
     /// generic relocation as described above
     PPC_RELOC_VANILLA = 0,
     /// the second relocation entry of a pair
@@ -4318,7 +4326,9 @@ constant_names!(NAMES_PPC_RELOC: u8 = {
  * the containing image was loaded from its base address (e.g. slide).
  *
  */
-constant_names!(NAMES_X86_64_RELOC: u8 = {
+constant_names!(
+/// Values for `Relocation::r_type` on x86_64.
+pub NAMES_X86_64_RELOC: u8 = {
     /// for absolute addresses
     X86_64_RELOC_UNSIGNED = 0,
     /// for signed 32-bit displacement

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -12,78 +12,78 @@ use crate::constants::{ConstantNames, FlagNames};
 use crate::endian::{BigEndian, Endian, U16, U32, U64};
 use crate::pod::Pod;
 
-/// Platform-specific constants for a Mach-O file.
+/// Platform-specific constant names for a Mach-O file.
 ///
-/// Returned by [`constants`] and [`machine_constants`].
+/// Returned by [`names`] and [`machine_names`].
 #[cfg(feature = "names")]
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct Constants {
+pub struct Names {
     /// Values for `cpusubtype` fields.
     pub cpusubtype: &'static FlagNames<CpuSubtype>,
     /// Values for `r_type` field of `Rel*::r_info`.
     pub reloc: &'static ConstantNames<u8>,
 }
 
-/// Return the platform independent constants.
+/// Return the platform independent names for constants.
 #[cfg(feature = "names")]
-pub const fn constants() -> &'static Constants {
-    Base::constants()
+pub const fn names() -> &'static Names {
+    Base::names()
 }
 
-/// Return the platform specific constants.
+/// Return the platform specific names for constants.
 ///
-/// Note that these also include the values returned by [`constants`].
+/// Note that these also include the values returned by [`names`].
 #[cfg(feature = "names")]
-pub const fn machine_constants(cputype: CpuType) -> &'static Constants {
+pub const fn machine_names(cputype: CpuType) -> &'static Names {
     match cputype {
-        CPU_TYPE_X86 => X86::constants(),
-        CPU_TYPE_X86_64 => X86_64::constants(),
-        CPU_TYPE_ARM => Arm::constants(),
-        CPU_TYPE_ARM64 => Arm64::constants(),
-        CPU_TYPE_ARM64_32 => Arm64_32::constants(),
-        CPU_TYPE_POWERPC | CPU_TYPE_POWERPC64 => Ppc::constants(),
-        _ => Base::constants(),
+        CPU_TYPE_X86 => X86::names(),
+        CPU_TYPE_X86_64 => X86_64::names(),
+        CPU_TYPE_ARM => Arm::names(),
+        CPU_TYPE_ARM64 => Arm64::names(),
+        CPU_TYPE_ARM64_32 => Arm64_32::names(),
+        CPU_TYPE_POWERPC | CPU_TYPE_POWERPC64 => Ppc::names(),
+        _ => Base::names(),
     }
 }
 
-constants! {
+names! {
     struct Base;
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE;
     consts reloc: u8 = {};
 }
 
-constants! {
+names! {
     struct X86(Base);
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_X86;
     consts reloc: u8 = NAMES_GENERIC_RELOC;
 }
 
-constants! {
+names! {
     struct X86_64(Base);
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_X86_64;
     consts reloc: u8 = NAMES_X86_64_RELOC;
 }
 
-constants! {
+names! {
     struct Arm(Base);
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_ARM;
     consts reloc: u8 = NAMES_ARM_RELOC;
 }
 
-constants! {
+names! {
     struct Arm64(Base);
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_ARM64;
     consts reloc: u8 = NAMES_ARM64_RELOC;
 }
 
-constants! {
+names! {
     struct Arm64_32(Base);
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_ARM64_32;
     consts reloc: u8 = NAMES_ARM64_RELOC;
 }
 
-constants! {
+names! {
     struct Ppc(Base);
     flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_POWERPC;
     consts reloc: u8 = NAMES_PPC_RELOC;

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -49,44 +49,44 @@ pub const fn machine_names(cputype: CpuType) -> &'static Names {
 
 names! {
     struct Base;
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE;
+    flags cpusubtype = NAMES_CPU_SUBTYPE;
     consts reloc: u8 = {};
 }
 
 names! {
     struct X86(Base);
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_X86;
-    consts reloc: u8 = NAMES_GENERIC_RELOC;
+    flags cpusubtype = NAMES_CPU_SUBTYPE_X86;
+    consts reloc = NAMES_GENERIC_RELOC;
 }
 
 names! {
     struct X86_64(Base);
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_X86_64;
-    consts reloc: u8 = NAMES_X86_64_RELOC;
+    flags cpusubtype = NAMES_CPU_SUBTYPE_X86_64;
+    consts reloc = NAMES_X86_64_RELOC;
 }
 
 names! {
     struct Arm(Base);
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_ARM;
-    consts reloc: u8 = NAMES_ARM_RELOC;
+    flags cpusubtype = NAMES_CPU_SUBTYPE_ARM;
+    consts reloc = NAMES_ARM_RELOC;
 }
 
 names! {
     struct Arm64(Base);
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_ARM64;
-    consts reloc: u8 = NAMES_ARM64_RELOC;
+    flags cpusubtype = NAMES_CPU_SUBTYPE_ARM64;
+    consts reloc = NAMES_ARM64_RELOC;
 }
 
 names! {
     struct Arm64_32(Base);
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_ARM64_32;
-    consts reloc: u8 = NAMES_ARM64_RELOC;
+    flags cpusubtype = NAMES_CPU_SUBTYPE_ARM64_32;
+    consts reloc = NAMES_ARM64_RELOC;
 }
 
 names! {
     struct Ppc(Base);
-    flags cpusubtype: CpuSubtype = NAMES_CPU_SUBTYPE_POWERPC;
-    consts reloc: u8 = NAMES_PPC_RELOC;
+    flags cpusubtype = NAMES_CPU_SUBTYPE_POWERPC;
+    consts reloc = NAMES_PPC_RELOC;
 }
 
 // Definitions from "/usr/include/mach/machine.h".

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -71,7 +71,7 @@ pub const fn machine_names(machine: Machine) -> &'static Names {
 names! {
     struct Base;
     flags rel: u16 = {};
-    consts rel_based: u16 = NAMES_REL_BASED;
+    consts rel_based = NAMES_REL_BASED;
 }
 
 /// MZ
@@ -651,11 +651,9 @@ newtype_flag_names!(NAMES_DLL_FLAGS: DllFlags(u16) = {
     IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE = 0x8000,
 });
 
+constant_names!(
 /// Indices for `ImageOptionalHeader*::data_directory`.
-#[cfg(feature = "names")]
-pub const NAMES_DIRECTORY_ENTRY: &ConstantNames<usize> = &_NAMES_DIRECTORY_ENTRY;
-
-constant_names!(_NAMES_DIRECTORY_ENTRY: usize = {
+pub NAMES_DIRECTORY_ENTRY: usize = {
     /// Export Directory
     IMAGE_DIRECTORY_ENTRY_EXPORT = 0,
     /// Import Directory
@@ -1317,7 +1315,7 @@ names! {
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_MIPS,
     };
-    consts rel_based: u16 = NAMES_REL_BASED_MIPS;
+    consts rel_based = NAMES_REL_BASED_MIPS;
 }
 
 constant_names!(NAMES_IMAGE_REL_MIPS: u16 = {
@@ -1522,7 +1520,7 @@ names! {
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_ARM,
     };
-    consts rel_based: u16 = NAMES_REL_BASED_ARM;
+    consts rel_based = NAMES_REL_BASED_ARM;
 }
 
 constant_names!(NAMES_IMAGE_REL_ARM: u16 = {
@@ -1716,7 +1714,7 @@ names! {
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_IA64,
     };
-    consts rel_based: u16 = NAMES_REL_BASED_IA64;
+    consts rel_based = NAMES_REL_BASED_IA64;
 }
 
 constant_names!(NAMES_IMAGE_REL_IA64: u16 = {
@@ -1874,7 +1872,7 @@ constant_names!(NAMES_IMAGE_REL_EBC: u16 = {
 
 names! {
     struct Riscv(Base);
-    consts rel_based: u16 = NAMES_REL_BASED_RISCV;
+    consts rel_based = NAMES_REL_BASED_RISCV;
 }
 
 /*

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -14,61 +14,61 @@ use crate::constants::{ConstantNames, FlagNames};
 use crate::endian::{I32, LittleEndian as LE, U16, U32, U64};
 use crate::pod::Pod;
 
-/// Platform-specific constants for a PE/COFF file.
+/// Platform-specific constant names for a PE/COFF file.
 ///
-/// Returned by [`constants`] and [`machine_constants`].
+/// Returned by [`names`] and [`machine_names`].
 #[cfg(feature = "names")]
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct Constants {
+pub struct Names {
     /// Values for `ImageRelocation::typ`.
     pub rel: &'static FlagNames<u16>,
     /// Values for the type in an `ImageBaseRelocation` block.
     pub rel_based: &'static ConstantNames<u16>,
 }
 
-/// Return the platform independent constants.
+/// Return the platform independent names for constants.
 #[cfg(feature = "names")]
-pub const fn constants() -> &'static Constants {
-    Base::constants()
+pub const fn names() -> &'static Names {
+    Base::names()
 }
 
-/// Return the platform specific constants.
+/// Return the platform specific names for constants.
 ///
-/// Note that these also include the values returned by [`constants`].
+/// Note that these also include the values returned by [`names`].
 #[cfg(feature = "names")]
-pub const fn machine_constants(machine: Machine) -> &'static Constants {
+pub const fn machine_names(machine: Machine) -> &'static Names {
     match machine {
-        IMAGE_FILE_MACHINE_I386 => I386::constants(),
+        IMAGE_FILE_MACHINE_I386 => I386::names(),
         IMAGE_FILE_MACHINE_MIPS16 | IMAGE_FILE_MACHINE_MIPSFPU | IMAGE_FILE_MACHINE_MIPSFPU16 => {
-            Mips::constants()
+            Mips::names()
         }
-        IMAGE_FILE_MACHINE_ALPHA | IMAGE_FILE_MACHINE_ALPHA64 => Alpha::constants(),
+        IMAGE_FILE_MACHINE_ALPHA | IMAGE_FILE_MACHINE_ALPHA64 => Alpha::names(),
         IMAGE_FILE_MACHINE_POWERPC
         | IMAGE_FILE_MACHINE_POWERPCFP
-        | IMAGE_FILE_MACHINE_POWERPCBE => Ppc::constants(),
+        | IMAGE_FILE_MACHINE_POWERPCBE => Ppc::names(),
         IMAGE_FILE_MACHINE_SH3
         | IMAGE_FILE_MACHINE_SH3DSP
         | IMAGE_FILE_MACHINE_SH3E
         | IMAGE_FILE_MACHINE_SH4
-        | IMAGE_FILE_MACHINE_SH5 => Sh::constants(),
-        IMAGE_FILE_MACHINE_ARM => Arm::constants(),
-        IMAGE_FILE_MACHINE_AM33 => Am::constants(),
-        IMAGE_FILE_MACHINE_ARM64 => Arm64::constants(),
-        IMAGE_FILE_MACHINE_AMD64 => Amd64::constants(),
-        IMAGE_FILE_MACHINE_IA64 => Ia64::constants(),
-        IMAGE_FILE_MACHINE_CEF => Cef::constants(),
-        IMAGE_FILE_MACHINE_CEE => Cee::constants(),
-        IMAGE_FILE_MACHINE_M32R => M32r::constants(),
-        IMAGE_FILE_MACHINE_EBC => Ebc::constants(),
+        | IMAGE_FILE_MACHINE_SH5 => Sh::names(),
+        IMAGE_FILE_MACHINE_ARM => Arm::names(),
+        IMAGE_FILE_MACHINE_AM33 => Am::names(),
+        IMAGE_FILE_MACHINE_ARM64 => Arm64::names(),
+        IMAGE_FILE_MACHINE_AMD64 => Amd64::names(),
+        IMAGE_FILE_MACHINE_IA64 => Ia64::names(),
+        IMAGE_FILE_MACHINE_CEF => Cef::names(),
+        IMAGE_FILE_MACHINE_CEE => Cee::names(),
+        IMAGE_FILE_MACHINE_M32R => M32r::names(),
+        IMAGE_FILE_MACHINE_EBC => Ebc::names(),
         IMAGE_FILE_MACHINE_RISCV32 | IMAGE_FILE_MACHINE_RISCV64 | IMAGE_FILE_MACHINE_RISCV128 => {
-            Riscv::constants()
+            Riscv::names()
         }
-        _ => Base::constants(),
+        _ => Base::names(),
     }
 }
 
-constants! {
+names! {
     struct Base;
     flags rel: u16 = {};
     consts rel_based: u16 = NAMES_REL_BASED;
@@ -1279,7 +1279,7 @@ pub struct ImageRelocation {
 //
 // I386 relocation types.
 //
-constants! {
+names! {
     struct I386(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_I386,
@@ -1312,7 +1312,7 @@ constant_names!(NAMES_IMAGE_REL_I386: u16 = {
 //
 // MIPS relocation types.
 //
-constants! {
+names! {
     struct Mips(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_MIPS,
@@ -1346,7 +1346,7 @@ constant_names!(NAMES_IMAGE_REL_MIPS: u16 = {
 //
 // Alpha Relocation types.
 //
-constants! {
+names! {
     struct Alpha(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_ALPHA,
@@ -1390,7 +1390,7 @@ constant_names!(NAMES_IMAGE_REL_ALPHA: u16 = {
 //
 // IBM PowerPC relocation types.
 //
-constants! {
+names! {
     struct Ppc(Base);
     flags rel: u16 = {
         IMAGE_REL_PPC_TYPEMASK = 0x00FF => NAMES_IMAGE_REL_PPC,
@@ -1454,7 +1454,7 @@ constant_names!(NAMES_IMAGE_REL_PPC: u16 = {
 //
 // Hitachi SH3 relocation types.
 //
-constants! {
+names! {
     struct Sh(Base);
     flags rel: u16 = {
         _ = !IMAGE_REL_SH_NOMODE => NAMES_IMAGE_REL_SH,
@@ -1517,7 +1517,7 @@ constant_names!(NAMES_IMAGE_REL_SH: u16 = {
     IMAGE_REL_SHM_PAIR = 0x0018,
 });
 
-constants! {
+names! {
     struct Arm(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_ARM,
@@ -1572,7 +1572,7 @@ constant_names!(NAMES_IMAGE_REL_ARM: u16 = {
     IMAGE_REL_THUMB_BLX23 = 0x0015,
 });
 
-constants! {
+names! {
     struct Am(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_AM,
@@ -1596,7 +1596,7 @@ constant_names!(NAMES_IMAGE_REL_AM: u16 = {
 // ARM64 relocations types.
 //
 
-constants! {
+names! {
     struct Arm64(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_ARM64,
@@ -1644,7 +1644,7 @@ constant_names!(NAMES_IMAGE_REL_ARM64: u16 = {
 //
 // x64 relocations
 //
-constants! {
+names! {
     struct Amd64(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_AMD64,
@@ -1711,7 +1711,7 @@ constant_names!(NAMES_IMAGE_REL_AMD64: u16 = {
 //
 // IA64 relocation types.
 //
-constants! {
+names! {
     struct Ia64(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_IA64,
@@ -1761,7 +1761,7 @@ constant_names!(NAMES_IMAGE_REL_IA64: u16 = {
 //
 // CEF relocation types.
 //
-constants! {
+names! {
     struct Cef(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_CEF,
@@ -1788,7 +1788,7 @@ constant_names!(NAMES_IMAGE_REL_CEF: u16 = {
 //
 // clr relocation types.
 //
-constants! {
+names! {
     struct Cee(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_CEE,
@@ -1812,7 +1812,7 @@ constant_names!(NAMES_IMAGE_REL_CEE: u16 = {
     IMAGE_REL_CEE_TOKEN = 0x0006,
 });
 
-constants! {
+names! {
     struct M32r(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_M32R,
@@ -1852,7 +1852,7 @@ constant_names!(NAMES_IMAGE_REL_M32R: u16 = {
     IMAGE_REL_M32R_TOKEN = 0x000E,
 });
 
-constants! {
+names! {
     struct Ebc(Base);
     flags rel: u16 = {
         _ = !0 => NAMES_IMAGE_REL_EBC,
@@ -1872,7 +1872,7 @@ constant_names!(NAMES_IMAGE_REL_EBC: u16 = {
     IMAGE_REL_EBC_SECREL = 0x0004,
 });
 
-constants! {
+names! {
     struct Riscv(Base);
     consts rel_based: u16 = NAMES_REL_BASED_RISCV;
 }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1284,7 +1284,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_I386: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on I386.
+pub NAMES_IMAGE_REL_I386: u16 = {
     /// Reference is absolute, no relocation is necessary
     IMAGE_REL_I386_ABSOLUTE = 0x0000,
     /// Direct 16-bit reference to the symbols virtual address
@@ -1318,7 +1320,9 @@ names! {
     consts rel_based = NAMES_REL_BASED_MIPS;
 }
 
-constant_names!(NAMES_IMAGE_REL_MIPS: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on MIPS.
+pub NAMES_IMAGE_REL_MIPS: u16 = {
     /// Reference is absolute, no relocation is necessary
     IMAGE_REL_MIPS_ABSOLUTE = 0x0000,
     IMAGE_REL_MIPS_REFHALF = 0x0001,
@@ -1351,7 +1355,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_ALPHA: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on Alpha.
+pub NAMES_IMAGE_REL_ALPHA: u16 = {
     IMAGE_REL_ALPHA_ABSOLUTE = 0x0000,
     IMAGE_REL_ALPHA_REFLONG = 0x0001,
     IMAGE_REL_ALPHA_REFQUAD = 0x0002,
@@ -1403,7 +1409,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_PPC: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on PowerPC.
+pub NAMES_IMAGE_REL_PPC: u16 = {
     /// NOP
     IMAGE_REL_PPC_ABSOLUTE = 0x0000,
     /// 64-bit address
@@ -1461,7 +1469,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_SH: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on SH3.
+pub NAMES_IMAGE_REL_SH: u16 = {
     /// No relocation
     IMAGE_REL_SH3_ABSOLUTE = 0x0000,
     /// 16 bit direct
@@ -1523,7 +1533,9 @@ names! {
     consts rel_based = NAMES_REL_BASED_ARM;
 }
 
-constant_names!(NAMES_IMAGE_REL_ARM: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on ARM.
+pub NAMES_IMAGE_REL_ARM: u16 = {
     /// No relocation required
     IMAGE_REL_ARM_ABSOLUTE = 0x0000,
     /// 32 bit address
@@ -1577,7 +1589,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_AM: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on AM33.
+pub NAMES_IMAGE_REL_AM: u16 = {
     IMAGE_REL_AM_ABSOLUTE = 0x0000,
     IMAGE_REL_AM_ADDR32 = 0x0001,
     IMAGE_REL_AM_ADDR32NB = 0x0002,
@@ -1601,7 +1615,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_ARM64: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on ARM64.
+pub NAMES_IMAGE_REL_ARM64: u16 = {
     /// No relocation required
     IMAGE_REL_ARM64_ABSOLUTE = 0x0000,
     /// 32 bit address. Review! do we need it?
@@ -1649,7 +1665,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_AMD64: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on x64.
+pub NAMES_IMAGE_REL_AMD64: u16 = {
     /// Reference is absolute, no relocation is necessary
     IMAGE_REL_AMD64_ABSOLUTE = 0x0000,
     /// 64-bit address (VA).
@@ -1717,7 +1735,9 @@ names! {
     consts rel_based = NAMES_REL_BASED_IA64;
 }
 
-constant_names!(NAMES_IMAGE_REL_IA64: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on IA64.
+pub NAMES_IMAGE_REL_IA64: u16 = {
     IMAGE_REL_IA64_ABSOLUTE = 0x0000,
     IMAGE_REL_IA64_IMM14 = 0x0001,
     IMAGE_REL_IA64_IMM22 = 0x0002,
@@ -1766,7 +1786,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_CEF: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on CEF.
+pub NAMES_IMAGE_REL_CEF: u16 = {
     /// Reference is absolute, no relocation is necessary
     IMAGE_REL_CEF_ABSOLUTE = 0x0000,
     /// 32-bit address (VA).
@@ -1793,7 +1815,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_CEE: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on CLR.
+pub NAMES_IMAGE_REL_CEE: u16 = {
     /// Reference is absolute, no relocation is necessary
     IMAGE_REL_CEE_ABSOLUTE = 0x0000,
     /// 32-bit address (VA).
@@ -1817,7 +1841,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_M32R: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on M32R.
+pub NAMES_IMAGE_REL_M32R: u16 = {
     /// No relocation required
     IMAGE_REL_M32R_ABSOLUTE = 0x0000,
     /// 32 bit address
@@ -1857,7 +1883,9 @@ names! {
     };
 }
 
-constant_names!(NAMES_IMAGE_REL_EBC: u16 = {
+constant_names!(
+/// Values for `ImageRelocation::typ` on EBC.
+pub NAMES_IMAGE_REL_EBC: u16 = {
     /// No relocation required
     IMAGE_REL_EBC_ABSOLUTE = 0x0000,
     /// 32 bit address w/o image base
@@ -2078,7 +2106,9 @@ pub struct ImageBaseRelocation {
 // Based relocation types.
 //
 
-constant_names!(NAMES_REL_BASED: u16 = {
+constant_names!(
+/// Values for `ImageBaseRelocation` `type_offset` entries.
+pub NAMES_REL_BASED: u16 = {
     IMAGE_REL_BASED_ABSOLUTE = 0,
     IMAGE_REL_BASED_HIGH = 1,
     IMAGE_REL_BASED_LOW = 2,
@@ -2096,21 +2126,29 @@ constant_names!(NAMES_REL_BASED: u16 = {
 // Platform-specific based relocation types.
 //
 
-constant_names!(NAMES_REL_BASED_IA64: u16 = NAMES_REL_BASED + {
+constant_names!(
+/// Values for `ImageBaseRelocation` `type_offset` entries on IA64.
+pub NAMES_REL_BASED_IA64: u16 = NAMES_REL_BASED + {
     IMAGE_REL_BASED_IA64_IMM64 = 9,
 });
 
-constant_names!(NAMES_REL_BASED_MIPS: u16 = NAMES_REL_BASED + {
+constant_names!(
+/// Values for `ImageBaseRelocation` `type_offset` entries on MIPS.
+pub NAMES_REL_BASED_MIPS: u16 = NAMES_REL_BASED + {
     IMAGE_REL_BASED_MIPS_JMPADDR = 5,
     IMAGE_REL_BASED_MIPS_JMPADDR16 = 9,
 });
 
-constant_names!(NAMES_REL_BASED_ARM: u16 = NAMES_REL_BASED + {
+constant_names!(
+/// Values for `ImageBaseRelocation` `type_offset` entries on ARM.
+pub NAMES_REL_BASED_ARM: u16 = NAMES_REL_BASED + {
     IMAGE_REL_BASED_ARM_MOV32 = 5,
     IMAGE_REL_BASED_THUMB_MOV32 = 7,
 });
 
-constant_names!(NAMES_REL_BASED_RISCV: u16 = NAMES_REL_BASED + {
+constant_names!(
+/// Values for `ImageBaseRelocation` `type_offset` entries on RISC-V.
+pub NAMES_REL_BASED_RISCV: u16 = NAMES_REL_BASED + {
     IMAGE_REL_BASED_RISCV_HIGH20 = 5,
     IMAGE_REL_BASED_RISCV_LOW12I = 7,
     IMAGE_REL_BASED_RISCV_LOW12S = 8,

--- a/src/xcoff.rs
+++ b/src/xcoff.rs
@@ -1051,11 +1051,9 @@ pub struct Rel64 {
     pub r_rtype: u8,
 }
 
+constant_names!(
 /// Values for `Rel*::r_rtype`.
-#[cfg(feature = "names")]
-pub const NAMES_REL_TYPE: &ConstantNames<u8> = &NAMES_R;
-
-constant_names!(NAMES_R: u8 = {
+pub NAMES_REL_TYPE: u8 = {
     /// Positive relocation.
     R_POS = 0x00,
     /// Positive indirect load relocation.


### PR DESCRIPTION
This is more convenient than things like `machine_names` when the machine is not variable. Relocations are singled out for this because we haven't given them newtypes.