### PR TITLE
write/elf: improve .symtab_shndx writing

### DIFF
--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -852,9 +852,13 @@ impl<'a> Writer<'a> {
         }
 
         if self.need_symtab_shndx {
-            let section_index = sym.section.unwrap_or(SectionIndex(0));
+            let section_index = if st_shndx == elf::SHN_XINDEX {
+                sym.section.map_or(0, |s| s.0)
+            } else {
+                0
+            };
             self.symtab_shndx_data
-                .write_pod(&U32::new(self.endian, section_index.0));
+                .write_pod(&U32::new(self.endian, section_index));
         }
     }
 


### PR DESCRIPTION
Write 0 if st_shndx is not `SHN_XINDEX`.