### PR TITLE
write/elf: add SinglePhaseWriter

### DIFF
--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -27,6 +27,10 @@ name = "dyldcachedump"
 required-features = ["object/read"]
 
 [[bin]]
+name = "elfstub"
+required-features = ["object/read", "object/write"]
+
+[[bin]]
 name = "elftoefi"
 required-features = ["object/read_core", "object/write_core", "object/elf", "object/pe", "object/std"]
 

--- a/crates/examples/src/bin/elfstub.rs
+++ b/crates/examples/src/bin/elfstub.rs
@@ -1,0 +1,33 @@
+use std::{env, fs, process};
+
+fn main() {
+    let mut args = env::args_os().skip(1);
+    let (input_path, output_path) = match (args.next(), args.next(), args.next()) {
+        (Some(i), Some(o), None) => (i, o),
+        _ => {
+            eprintln!("Usage: elfstub <input.so> <output.so>");
+            process::exit(1);
+        }
+    };
+
+    let data = match fs::read(&input_path) {
+        Ok(data) => data,
+        Err(err) => {
+            eprintln!("Failed to read file '{}': {}", input_path.display(), err,);
+            process::exit(1);
+        }
+    };
+
+    let stub = match object_examples::elfstub::build_stub(&data) {
+        Ok(stub) => stub,
+        Err(err) => {
+            eprintln!("Failed to create stub: {}", err);
+            process::exit(1);
+        }
+    };
+
+    if let Err(err) = fs::write(&output_path, stub) {
+        eprintln!("Failed to write file '{}': {}", output_path.display(), err);
+        process::exit(1);
+    }
+}

--- a/crates/examples/src/elfstub.rs
+++ b/crates/examples/src/elfstub.rs
@@ -1,0 +1,304 @@
+use std::error::Error;
+
+use object::Endianness;
+use object::elf;
+use object::read::elf::{ElfFile64, FileHeader as _, Sym as _};
+use object::write::elf::{
+    FileHeader, ProgramHeader, SectionHeader, Sym, Verdef, Vernaux, Verneed, Writer,
+};
+
+/// Create a stub ELF shared library from a real one, using
+/// [`object::write::elf::Writer`] in single-phase mode.
+///
+/// The output preserves the SONAME, `DT_NEEDED` list, dynamic symbol
+/// table, and version information from the input, but replaces every
+/// defined symbol's code/data with a single placeholder byte.
+pub fn build_stub(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+    let elf = ElfFile64::<Endianness>::parse(data)?;
+    let endian = elf.endian();
+    let header = elf.elf_header();
+    if header.e_type(endian) != elf::ET_DYN {
+        return Err("input is not an ET_DYN shared object".into());
+    }
+
+    let sections = elf.elf_section_table();
+    let dynsyms = elf.elf_dynamic_symbol_table();
+    let in_dynstr = dynsyms.strings();
+    let in_syms = dynsyms.symbols();
+
+    // Build the output.
+    let mut buffer = Vec::new();
+    let mut writer = Writer::new_single_phase(endian, true, &mut buffer);
+
+    // Placeholder file header, filled in at the end via write_headers_to after table
+    // locations are known.
+    let ident = header.e_ident();
+    writer.write_file_header(&FileHeader {
+        os_abi: ident.os_abi,
+        abi_version: ident.abi_version,
+        e_type: header.e_type(endian),
+        e_machine: header.e_machine(endian),
+        e_entry: 0,
+        e_flags: header.e_flags(endian),
+    })?;
+
+    // Placeholder program headers (PT_PHDR for program headers, PT_LOAD for allocated
+    // sections, PT_DYNAMIC for .dynamic).
+    let (phdr_offset, phdr_size) = writer.write_program_headers_placeholder(3);
+
+    // .stub section, one byte per symbol (only really need one per defined symbol).
+    // This will be the first section header written (after the null section header).
+    let stub_section_index = object::write::elf::SectionIndex(1);
+    let stub_offset = writer.offset();
+    let stub_size = in_syms.len() as u64;
+    writer.pad_until(stub_offset + stub_size);
+
+    // .dynsym
+    let dynsym_offset = writer.write_null_dynamic_symbol();
+    let mut hashes = vec![None];
+    for (i, sym) in in_syms.iter().enumerate().skip(1) {
+        let name = if sym.st_name(endian) != 0 {
+            Some(sym.name(endian, in_dynstr)?)
+        } else {
+            None
+        };
+        let id = name.map(|name| writer.add_dynamic_string(name));
+        hashes.push(name.map(elf::hash));
+
+        let mut section = None;
+        let mut st_value = sym.st_value(endian);
+        let mut st_size = sym.st_size(endian);
+        let st_shndx = sym.st_shndx(endian);
+        if sym.st_shndx(endian).index().is_some() {
+            section = Some(stub_section_index);
+            st_value = stub_offset + i as u64;
+            st_size = 1;
+        }
+
+        writer.write_dynamic_symbol(&Sym {
+            name: id,
+            section,
+            st_info: sym.st_info(),
+            st_other: sym.st_other(),
+            st_shndx,
+            st_value,
+            st_size,
+        });
+    }
+    let num_local_dynsym = 1u32
+        + in_syms
+            .iter()
+            .skip(1)
+            .take_while(|s| s.st_bind() == elf::STB_LOCAL)
+            .count() as u32;
+
+    // .hash
+    let chain_count = in_syms.len() as u32;
+    let bucket_count = chain_count.div_ceil(4).max(1);
+    let hash_offset = writer.write_hash(bucket_count, chain_count, |i| hashes[i as usize]);
+
+    // .gnu.version
+    let mut versym_offset = 0;
+    if let Some((versyms, _link)) = sections.gnu_versym(endian, data)? {
+        if versyms.len() != in_syms.len() {
+            return Err("versym length mismatch".into());
+        }
+        versym_offset = writer.write_null_gnu_versym();
+        for versym in versyms.iter().skip(1) {
+            writer.write_gnu_versym(versym.0.get(endian));
+        }
+    }
+
+    // .gnu.version_d
+    let mut verdef_offset = 0;
+    let mut verdef_count = 0;
+    if let Some((mut verdefs, link)) = sections.gnu_verdef(endian, data)? {
+        let strings = sections.strings(endian, data, link)?;
+        verdef_offset = writer.write_align_gnu_verdef();
+        verdef_count = verdefs.clone().count() as u16;
+        writer.set_gnu_verdef_count(verdef_count);
+        while let Some((verdef, mut verdauxs)) = verdefs.next()? {
+            let aux_count = verdauxs.clone().count() as u16;
+            let Some(verdaux) = verdauxs.next()? else {
+                return Err("missing verdef name".into());
+            };
+            let name = writer.add_dynamic_string(verdaux.name(endian, strings)?);
+            writer.write_gnu_verdef(&Verdef {
+                version: verdef.vd_version.get(endian),
+                flags: verdef.vd_flags.get(endian),
+                index: verdef.vd_ndx.get(endian),
+                aux_count,
+                name,
+            });
+            while let Some(verdaux) = verdauxs.next()? {
+                let name = writer.add_dynamic_string(verdaux.name(endian, strings)?);
+                writer.write_gnu_verdaux(name);
+            }
+        }
+    }
+
+    // .gnu.version_r
+    let mut verneed_offset = 0;
+    let mut verneed_count = 0;
+    if let Some((mut verneeds, link)) = sections.gnu_verneed(endian, data)? {
+        let strings = sections.strings(endian, data, link)?;
+        verneed_offset = writer.write_align_gnu_verneed();
+        verneed_count = verneeds.clone().count() as u16;
+        writer.set_gnu_verneed_count(verneed_count);
+        while let Some((verneed, mut vernauxs)) = verneeds.next()? {
+            let aux_count = vernauxs.clone().count() as u16;
+            let file = writer.add_dynamic_string(verneed.file(endian, strings)?);
+            writer.write_gnu_verneed(&Verneed {
+                version: verneed.vn_version.get(endian),
+                aux_count,
+                file,
+            });
+            while let Some(vernaux) = vernauxs.next()? {
+                let name = writer.add_dynamic_string(vernaux.name(endian, strings)?);
+                writer.write_gnu_vernaux(&Vernaux {
+                    flags: vernaux.vna_flags.get(endian),
+                    index: vernaux.vna_other.get(endian),
+                    name,
+                });
+            }
+        }
+    }
+
+    // .dynamic references .dynstr, so we need to add .dynamic strings and write .dynstr first.
+    let dyn_table = elf.elf_dynamic_table()?;
+    let dyn_strs = dyn_table.strings();
+    let mut soname = None;
+    let mut needed = Vec::new();
+    let mut rpath = None;
+    let mut runpath = None;
+    let mut dt_flags = 0;
+    let mut dt_flags_1 = 0;
+    for d in dyn_table.iter() {
+        match d.tag {
+            elf::DT_SONAME => soname = Some(writer.add_dynamic_string(d.string(dyn_strs)?)),
+            elf::DT_NEEDED => needed.push(writer.add_dynamic_string(d.string(dyn_strs)?)),
+            elf::DT_RPATH => rpath = Some(writer.add_dynamic_string(d.string(dyn_strs)?)),
+            elf::DT_RUNPATH => runpath = Some(writer.add_dynamic_string(d.string(dyn_strs)?)),
+            elf::DT_FLAGS => dt_flags = d.val,
+            elf::DT_FLAGS_1 => dt_flags_1 = d.val,
+            _ => {}
+        }
+    }
+
+    // .dynstr
+    let (dynstr_offset, dynstr_size) = writer.write_dynstr()?;
+
+    // .dynamic
+    let dynamic_offset = writer.write_align_dynamic();
+    if let Some(id) = soname {
+        writer.write_dynamic_string(elf::DT_SONAME, id)?;
+    }
+    for id in needed {
+        writer.write_dynamic_string(elf::DT_NEEDED, id)?;
+    }
+    if let Some(id) = rpath {
+        writer.write_dynamic_string(elf::DT_RPATH, id)?;
+    }
+    if let Some(id) = runpath {
+        writer.write_dynamic_string(elf::DT_RUNPATH, id)?;
+    }
+    writer.write_dynamic(elf::DT_HASH, hash_offset)?;
+    writer.write_dynamic(elf::DT_STRTAB, dynstr_offset)?;
+    writer.write_dynamic(elf::DT_SYMTAB, dynsym_offset)?;
+    writer.write_dynamic(elf::DT_STRSZ, dynstr_size.into())?;
+    writer.write_dynamic(
+        elf::DT_SYMENT,
+        core::mem::size_of::<elf::Sym64<Endianness>>() as u64,
+    )?;
+    if versym_offset != 0 {
+        writer.write_dynamic(elf::DT_VERSYM, versym_offset)?;
+    }
+    if verdef_offset != 0 {
+        writer.write_dynamic(elf::DT_VERDEF, verdef_offset)?;
+        writer.write_dynamic(elf::DT_VERDEFNUM, verdef_count.into())?;
+    }
+    if verneed_offset != 0 {
+        writer.write_dynamic(elf::DT_VERNEED, verneed_offset)?;
+        writer.write_dynamic(elf::DT_VERNEEDNUM, verneed_count.into())?;
+    }
+    if dt_flags != 0 {
+        writer.write_dynamic(elf::DT_FLAGS, dt_flags)?;
+    }
+    if dt_flags_1 != 0 {
+        writer.write_dynamic(elf::DT_FLAGS_1, dt_flags_1)?;
+    }
+    writer.write_dynamic(elf::DT_NULL, 0)?;
+    let load_size = writer.offset();
+    let dynamic_size = load_size - dynamic_offset;
+
+    // .shstrtab
+    // Add the section name for our stub section. All other section names
+    // are added implicitly when their data is written.
+    let stub_name_id = writer.add_section_name(b".stub");
+    writer.write_shstrtab()?;
+
+    // Section header table.
+    // PT_LOAD maps p_vaddr == p_offset so all section addresses are equal to offsets.
+    writer.write_null_section_header();
+    let index = writer.write_section_header(&SectionHeader {
+        name: Some(stub_name_id),
+        sh_type: elf::SHT_PROGBITS,
+        sh_flags: elf::SHF_ALLOC,
+        sh_addr: stub_offset,
+        sh_offset: stub_offset,
+        sh_size: stub_size,
+        sh_link: 0,
+        sh_info: 0,
+        sh_addralign: 1,
+        sh_entsize: 0,
+    });
+    debug_assert_eq!(index, stub_section_index);
+    writer.write_dynstr_section_header(dynstr_offset);
+    writer.write_dynsym_section_header(dynsym_offset, num_local_dynsym);
+    writer.write_hash_section_header(hash_offset);
+    writer.write_gnu_versym_section_header(versym_offset);
+    writer.write_gnu_verdef_section_header(verdef_offset);
+    writer.write_gnu_verneed_section_header(verneed_offset);
+    writer.write_dynamic_section_header(dynamic_offset);
+    writer.write_shstrtab_section_header();
+
+    // Write the corrected file header and program headers.
+    let program_headers = [
+        ProgramHeader {
+            p_type: elf::PT_PHDR,
+            p_flags: elf::PF_R,
+            p_offset: phdr_offset,
+            p_vaddr: phdr_offset,
+            p_paddr: phdr_offset,
+            p_filesz: phdr_size,
+            p_memsz: phdr_size,
+            p_align: 0x1000,
+        },
+        ProgramHeader {
+            p_type: elf::PT_LOAD,
+            p_flags: elf::PF_R,
+            p_offset: 0,
+            p_vaddr: 0,
+            p_paddr: 0,
+            p_filesz: load_size,
+            p_memsz: load_size,
+            p_align: 0x1000,
+        },
+        ProgramHeader {
+            p_type: elf::PT_DYNAMIC,
+            p_flags: elf::PF_R,
+            p_offset: dynamic_offset,
+            p_vaddr: dynamic_offset,
+            p_paddr: dynamic_offset,
+            p_filesz: dynamic_size,
+            p_memsz: dynamic_size,
+            p_align: 8,
+        },
+    ];
+
+    let mut header_buf = Vec::new();
+    writer.write_headers_to(&mut header_buf, &program_headers)?;
+    buffer[..header_buf.len()].copy_from_slice(&header_buf);
+
+    Ok(buffer)
+}

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -6,3 +6,6 @@ pub mod objdump;
 
 #[cfg(all(feature = "read", feature = "names"))]
 pub mod readobj;
+
+#[cfg(all(feature = "read", feature = "write"))]
+pub mod elfstub;

--- a/crates/examples/testfiles/elf/base.elfstub
+++ b/crates/examples/testfiles/elf/base.elfstub
@@ -1,0 +1,397 @@
+Format: ELF 64-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS64 (0x2)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_DYN (0x3)
+    Machine: EM_X86_64 (0x3E)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x0
+    ProgramHeaderOffset: 0x40
+    SectionHeaderOffset: 0x388
+    Flags: 0x0
+    HeaderSize: 0x40
+    ProgramHeaderEntrySize: 0x38
+    ProgramHeaderCount: 3
+    SectionHeaderEntrySize: 0x40
+    SectionHeaderCount: 9
+    SectionHeaderStringTableIndex: 8
+}
+ProgramHeader {
+    Type: PT_PHDR (0x6)
+    Offset: 0x40
+    VirtualAddress: 0x40
+    PhysicalAddress: 0x40
+    FileSize: 0xA8
+    MemorySize: 0xA8
+    Flags: PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x338
+    MemorySize: 0x338
+    Flags: PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_DYNAMIC (0x2)
+    Offset: 0x278
+    VirtualAddress: 0x278
+    PhysicalAddress: 0x278
+    FileSize: 0xC0
+    MemorySize: 0xC0
+    Flags: PF_R (0x4)
+    Align: 0x8
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x6E)
+    }
+    Dynamic {
+        Tag: DT_HASH (0x4)
+        Value: 0x198
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x1F4
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0xF0
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0x84
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x1C4
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x1D4
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".stub" (0x3C)
+    Type: SHT_PROGBITS (0x1)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0xE8
+    Offset: 0xE8
+    Size: 0x7
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".dynstr" (0x2B)
+    Type: SHT_STRTAB (0x3)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x1F4
+    Offset: 0x1F4
+    Size: 0x84
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 3
+    Name: ".dynsym" (0x1)
+    Type: SHT_DYNSYM (0xB)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0xF0
+    Offset: 0xF0
+    Size: 0xA8
+    Link: 2
+    Info: 1
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "_ITM_deregisterTMCloneTable" (0x1)
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 2
+        Name: "printf" (0x1D)
+        Version: "GLIBC_2.2.5" (0x2)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 3
+        Name: "__libc_start_main" (0x24)
+        Version: "GLIBC_2.2.5" (0x2)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 4
+        Name: "__gmon_start__" (0x36)
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 5
+        Name: "_ITM_registerTMCloneTable" (0x45)
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 6
+        Name: "__cxa_finalize" (0x5F)
+        Version: "GLIBC_2.2.5" (0x2)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".hash" (0x9)
+    Type: SHT_HASH (0x5)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x198
+    Offset: 0x198
+    Size: 0x2C
+    Link: 3
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+    Hash {
+        BucketCount: 2
+        ChainCount: 7
+    }
+}
+SectionHeader {
+    Index: 5
+    Name: ".gnu.version" (0xF)
+    Type: SHT_GNU_VERSYM (0x6FFFFFFF)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x1C4
+    Offset: 0x1C4
+    Size: 0xE
+    Link: 3
+    Info: 0
+    AddressAlign: 0x2
+    EntrySize: 0x2
+    VersionSymbol {
+        Index: 0
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 1
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 2
+        Version: "GLIBC_2.2.5" (0x2)
+    }
+    VersionSymbol {
+        Index: 3
+        Version: "GLIBC_2.2.5" (0x2)
+    }
+    VersionSymbol {
+        Index: 4
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 5
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 6
+        Version: "GLIBC_2.2.5" (0x2)
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".gnu.version_r" (0x1C)
+    Type: SHT_GNU_VERNEED (0x6FFFFFFE)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x1D4
+    Offset: 0x1D4
+    Size: 0x20
+    Link: 2
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    VersionNeed {
+        Version: 1
+        AuxCount: 1
+        Filename: "libc.so.6" (0x6E)
+        AuxOffset: 16
+        NextOffset: 0
+        Aux {
+            Hash: 0x9691A75
+            Flags: 0x0
+            Index: 2
+            Name: "GLIBC_2.2.5" (0x78)
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 7
+    Name: ".dynamic" (0x33)
+    Type: SHT_DYNAMIC (0x6)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x278
+    Offset: 0x278
+    Size: 0xC0
+    Link: 2
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x10
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x6E)
+    }
+    Dynamic {
+        Tag: DT_HASH (0x4)
+        Value: 0x198
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x1F4
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0xF0
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0x84
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x1C4
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x1D4
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_FLAGS (0x1E)
+        Value: DF_BIND_NOW (0x8)
+    }
+    Dynamic {
+        Tag: DT_FLAGS_1 (0x6FFFFFFB)
+        Value: 0x8000001
+            DF_1_NOW (0x1)
+            DF_1_PIE (0x8000000)
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 8
+    Name: ".shstrtab" (0x42)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x338
+    Size: 0x4C
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/crates/examples/testfiles/elf/libbase.so.elfstub
+++ b/crates/examples/testfiles/elf/libbase.so.elfstub
@@ -1,0 +1,447 @@
+Format: ELF 64-bit
+FileHeader {
+    Ident {
+        Magic: [7F, 45, 4C, 46]
+        Class: ELFCLASS64 (0x2)
+        Data: ELFDATA2LSB (0x1)
+        Version: EV_CURRENT (0x1)
+        OsAbi: ELFOSABI_SYSV (0x0)
+        AbiVersion: 0x0
+        Unused: [0, 0, 0, 0, 0, 0, 0]
+    }
+    Type: ET_DYN (0x3)
+    Machine: EM_X86_64 (0x3E)
+    Version: EV_CURRENT (0x1)
+    Entry: 0x0
+    ProgramHeaderOffset: 0x40
+    SectionHeaderOffset: 0x3F0
+    Flags: 0x0
+    HeaderSize: 0x40
+    ProgramHeaderEntrySize: 0x38
+    ProgramHeaderCount: 3
+    SectionHeaderEntrySize: 0x40
+    SectionHeaderCount: 10
+    SectionHeaderStringTableIndex: 9
+}
+ProgramHeader {
+    Type: PT_PHDR (0x6)
+    Offset: 0x40
+    VirtualAddress: 0x40
+    PhysicalAddress: 0x40
+    FileSize: 0xA8
+    MemorySize: 0xA8
+    Flags: PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_LOAD (0x1)
+    Offset: 0x0
+    VirtualAddress: 0x0
+    PhysicalAddress: 0x0
+    FileSize: 0x390
+    MemorySize: 0x390
+    Flags: PF_R (0x4)
+    Align: 0x1000
+}
+ProgramHeader {
+    Type: PT_DYNAMIC (0x2)
+    Offset: 0x2D0
+    VirtualAddress: 0x2D0
+    PhysicalAddress: 0x2D0
+    FileSize: 0xC0
+    MemorySize: 0xC0
+    Flags: PF_R (0x4)
+    Align: 0x8
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x6C)
+    }
+    Dynamic {
+        Tag: DT_HASH (0x4)
+        Value: 0x1B0
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x248
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0xF0
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0x82
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x1E0
+    }
+    Dynamic {
+        Tag: DT_VERDEF (0x6FFFFFFC)
+        Value: 0x1F0
+    }
+    Dynamic {
+        Tag: DT_VERDEFNUM (0x6FFFFFFD)
+        Value: 0x2
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x228
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 0
+    Name: "" (0x0)
+    Type: SHT_NULL (0x0)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x0
+    Size: 0x0
+    Link: 0
+    Info: 0
+    AddressAlign: 0x0
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 1
+    Name: ".stub" (0x4B)
+    Type: SHT_PROGBITS (0x1)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0xE8
+    Offset: 0xE8
+    Size: 0x8
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 2
+    Name: ".dynstr" (0x3A)
+    Type: SHT_STRTAB (0x3)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x248
+    Offset: 0x248
+    Size: 0x82
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}
+SectionHeader {
+    Index: 3
+    Name: ".dynsym" (0x1)
+    Type: SHT_DYNSYM (0xB)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0xF0
+    Offset: 0xF0
+    Size: 0xC0
+    Link: 2
+    Info: 1
+    AddressAlign: 0x8
+    EntrySize: 0x18
+    Symbol {
+        Index: 0
+        Name: 0x0
+        Version: VER_NDX_LOCAL (0x0)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_LOCAL (0x0)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 1
+        Name: "_ITM_deregisterTMCloneTable" (0x1)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 2
+        Name: "printf" (0x1D)
+        Version: "GLIBC_2.2.5" (0x3)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 3
+        Name: "__gmon_start__" (0x24)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 4
+        Name: "_ITM_registerTMCloneTable" (0x33)
+        Version: VER_NDX_GLOBAL (0x1)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_NOTYPE (0x0)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 5
+        Name: "__cxa_finalize" (0x4D)
+        Version: "GLIBC_2.2.5" (0x3)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_FUNC (0x2)
+        Bind: STB_WEAK (0x2)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_UNDEF (0x0)
+    }
+    Symbol {
+        Index: 6
+        Name: "main" (0x5C)
+        Version: "libbase.so" (0x2)
+        Value: 0xEE
+        Size: 0x1
+        Type: STT_FUNC (0x2)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: 1
+    }
+    Symbol {
+        Index: 7
+        Name: "libbase.so" (0x61)
+        Version: "libbase.so" (0x2)
+        Value: 0x0
+        Size: 0x0
+        Type: STT_OBJECT (0x1)
+        Bind: STB_GLOBAL (0x1)
+        Other: STV_DEFAULT (0x0)
+        SectionIndex: SHN_ABS (0xFFF1)
+    }
+}
+SectionHeader {
+    Index: 4
+    Name: ".hash" (0x9)
+    Type: SHT_HASH (0x5)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x1B0
+    Offset: 0x1B0
+    Size: 0x30
+    Link: 3
+    Info: 0
+    AddressAlign: 0x4
+    EntrySize: 0x4
+    Hash {
+        BucketCount: 2
+        ChainCount: 8
+    }
+}
+SectionHeader {
+    Index: 5
+    Name: ".gnu.version" (0xF)
+    Type: SHT_GNU_VERSYM (0x6FFFFFFF)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x1E0
+    Offset: 0x1E0
+    Size: 0x10
+    Link: 3
+    Info: 0
+    AddressAlign: 0x2
+    EntrySize: 0x2
+    VersionSymbol {
+        Index: 0
+        Version: VER_NDX_LOCAL (0x0)
+    }
+    VersionSymbol {
+        Index: 1
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 2
+        Version: "GLIBC_2.2.5" (0x3)
+    }
+    VersionSymbol {
+        Index: 3
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 4
+        Version: VER_NDX_GLOBAL (0x1)
+    }
+    VersionSymbol {
+        Index: 5
+        Version: "GLIBC_2.2.5" (0x3)
+    }
+    VersionSymbol {
+        Index: 6
+        Version: "libbase.so" (0x2)
+    }
+    VersionSymbol {
+        Index: 7
+        Version: "libbase.so" (0x2)
+    }
+}
+SectionHeader {
+    Index: 6
+    Name: ".gnu.version_d" (0x1C)
+    Type: SHT_GNU_VERDEF (0x6FFFFFFD)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x1F0
+    Offset: 0x1F0
+    Size: 0x38
+    Link: 2
+    Info: 2
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    VersionDefinition {
+        Version: 1
+        Flags: VER_FLG_BASE (0x1)
+        Index: VER_NDX_GLOBAL (1)
+        AuxCount: 1
+        Hash: 0x88E6A1F
+        AuxOffset: 20
+        NextOffset: 28
+        Aux {
+            Name: "libbase.so" (0x61)
+            NextOffset: 0
+        }
+    }
+    VersionDefinition {
+        Version: 1
+        Flags: 0x0
+        Index: 2
+        AuxCount: 1
+        Hash: 0x88E6A1F
+        AuxOffset: 20
+        NextOffset: 0
+        Aux {
+            Name: "libbase.so" (0x61)
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 7
+    Name: ".gnu.version_r" (0x2B)
+    Type: SHT_GNU_VERNEED (0x6FFFFFFE)
+    Flags: SHF_ALLOC (0x2)
+    Address: 0x228
+    Offset: 0x228
+    Size: 0x20
+    Link: 2
+    Info: 1
+    AddressAlign: 0x4
+    EntrySize: 0x0
+    VersionNeed {
+        Version: 1
+        AuxCount: 1
+        Filename: "libc.so.6" (0x6C)
+        AuxOffset: 16
+        NextOffset: 0
+        Aux {
+            Hash: 0x9691A75
+            Flags: 0x0
+            Index: 3
+            Name: "GLIBC_2.2.5" (0x76)
+            NextOffset: 0
+        }
+    }
+}
+SectionHeader {
+    Index: 8
+    Name: ".dynamic" (0x42)
+    Type: SHT_DYNAMIC (0x6)
+    Flags: 0x3
+        SHF_WRITE (0x1)
+        SHF_ALLOC (0x2)
+    Address: 0x2D0
+    Offset: 0x2D0
+    Size: 0xC0
+    Link: 2
+    Info: 0
+    AddressAlign: 0x8
+    EntrySize: 0x10
+    Dynamic {
+        Tag: DT_NEEDED (0x1)
+        Value: "libc.so.6" (0x6C)
+    }
+    Dynamic {
+        Tag: DT_HASH (0x4)
+        Value: 0x1B0
+    }
+    Dynamic {
+        Tag: DT_STRTAB (0x5)
+        Value: 0x248
+    }
+    Dynamic {
+        Tag: DT_SYMTAB (0x6)
+        Value: 0xF0
+    }
+    Dynamic {
+        Tag: DT_STRSZ (0xA)
+        Value: 0x82
+    }
+    Dynamic {
+        Tag: DT_SYMENT (0xB)
+        Value: 0x18
+    }
+    Dynamic {
+        Tag: DT_VERSYM (0x6FFFFFF0)
+        Value: 0x1E0
+    }
+    Dynamic {
+        Tag: DT_VERDEF (0x6FFFFFFC)
+        Value: 0x1F0
+    }
+    Dynamic {
+        Tag: DT_VERDEFNUM (0x6FFFFFFD)
+        Value: 0x2
+    }
+    Dynamic {
+        Tag: DT_VERNEED (0x6FFFFFFE)
+        Value: 0x228
+    }
+    Dynamic {
+        Tag: DT_VERNEEDNUM (0x6FFFFFFF)
+        Value: 0x1
+    }
+    Dynamic {
+        Tag: DT_NULL (0x0)
+        Value: 0x0
+    }
+}
+SectionHeader {
+    Index: 9
+    Name: ".shstrtab" (0x51)
+    Type: SHT_STRTAB (0x3)
+    Flags: 0x0
+    Address: 0x0
+    Offset: 0x390
+    Size: 0x5B
+    Link: 0
+    Info: 0
+    AddressAlign: 0x1
+    EntrySize: 0x0
+}

--- a/crates/examples/tests/testfiles.rs
+++ b/crates/examples/tests/testfiles.rs
@@ -1,7 +1,7 @@
 #![cfg(all(feature = "read", feature = "names"))]
 
 #[cfg(feature = "write")]
-use object_examples::objcopy;
+use object_examples::{elfstub, objcopy};
 use object_examples::{objdump, readobj};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -136,6 +136,14 @@ fn testfiles() {
                 {
                     fail |= testfile(&in_path, &out_path, err_path, |out, err, in_data| {
                         let copy_data = objcopy::copy(in_data);
+                        readobj::print(out, err, &copy_data, &[], &readobj::PrintOptions::all());
+                    });
+                }
+            } else if extension == "elfstub" {
+                #[cfg(feature = "write")]
+                {
+                    fail |= testfile(&in_path, &out_path, err_path, |out, err, in_data| {
+                        let copy_data = elfstub::build_stub(in_data).unwrap();
                         readobj::print(out, err, &copy_data, &[], &readobj::PrintOptions::all());
                     });
                 }

--- a/src/build/elf.rs
+++ b/src/build/elf.rs
@@ -730,7 +730,7 @@ impl<'data> Builder<'data> {
         struct SectionOut {
             id: SectionId,
             name: Option<write::StringId>,
-            offset: usize,
+            offset: u64,
             attributes: Vec<u8>,
         }
 
@@ -1163,7 +1163,7 @@ impl<'data> Builder<'data> {
                 if section.sh_type == elf::SHT_NOBITS {
                     // sh_offset is meaningless for SHT_NOBITS, so preserve the input
                     // value without checking it.
-                    out_section.offset = section.sh_offset as usize;
+                    out_section.offset = section.sh_offset;
                     continue;
                 }
 
@@ -1227,7 +1227,7 @@ impl<'data> Builder<'data> {
                         )));
                     }
                 };
-                if out_section.offset as u64 != section.sh_offset {
+                if out_section.offset != section.sh_offset {
                     return Err(Error(format!(
                         "Unaligned sh_offset value 0x{:x} for section '{}', expected 0x{:x}",
                         section.sh_offset, section.name, out_section.offset,
@@ -1246,7 +1246,7 @@ impl<'data> Builder<'data> {
                 SectionData::Data(data) => {
                     writer.reserve(data.len(), section.sh_addralign as usize)
                 }
-                SectionData::UninitializedData(_) => writer.reserved_len(),
+                SectionData::UninitializedData(_) => writer.reserved_len() as u64,
                 SectionData::Note(data) => {
                     writer.reserve(data.len(), section.sh_addralign as usize)
                 }
@@ -1364,7 +1364,7 @@ impl<'data> Builder<'data> {
                                         elf::DT_STRTAB => dynstr_addr.ok_or(Error::new(
                                             "Missing .dynstr section for DT_STRTAB",
                                         ))?,
-                                        elf::DT_STRSZ => writer.dynstr_len() as u64,
+                                        elf::DT_STRSZ => writer.dynstr_len().into(),
                                         elf::DT_HASH => hash_addr.ok_or(Error::new(
                                             "Missing .hash section for DT_HASH",
                                         ))?,
@@ -1540,7 +1540,7 @@ impl<'data> Builder<'data> {
             match &section.data {
                 SectionData::Data(data) => {
                     writer.write_align(section.sh_addralign as usize);
-                    debug_assert_eq!(out_section.offset, writer.len());
+                    debug_assert_eq!(out_section.offset, writer.offset());
                     writer.write(data);
                 }
                 SectionData::UninitializedData(_) => {
@@ -1548,12 +1548,12 @@ impl<'data> Builder<'data> {
                 }
                 SectionData::Note(data) => {
                     writer.write_align(section.sh_addralign as usize);
-                    debug_assert_eq!(out_section.offset, writer.len());
+                    debug_assert_eq!(out_section.offset, writer.offset());
                     writer.write(data);
                 }
                 SectionData::Attributes(_) => {
                     writer.write_align(section.sh_addralign as usize);
-                    debug_assert_eq!(out_section.offset, writer.len());
+                    debug_assert_eq!(out_section.offset, writer.offset());
                     writer.write(&out_section.attributes);
                 }
                 // These are handled elsewhere.
@@ -1684,7 +1684,7 @@ impl<'data> Builder<'data> {
                         sh_type: section.sh_type,
                         sh_flags: section.sh_flags,
                         sh_addr: section.sh_addr,
-                        sh_offset: out_section.offset as u64,
+                        sh_offset: out_section.offset,
                         sh_size,
                         sh_link,
                         sh_info,

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -7,16 +7,16 @@ use crate::{elf, pod};
 
 #[derive(Clone, Copy)]
 struct ComdatOffsets {
-    offset: usize,
+    offset: u64,
     str_id: StringId,
 }
 
 #[derive(Clone, Copy)]
 struct SectionOffsets {
     index: SectionIndex,
-    offset: usize,
+    offset: u64,
     str_id: StringId,
-    reloc_offset: usize,
+    reloc_offset: u64,
     reloc_str_id: Option<StringId>,
 }
 
@@ -776,7 +776,7 @@ impl<'a> Object<'a> {
         }
         for (index, section) in self.sections.iter().enumerate() {
             writer.write_align(section.align as usize);
-            debug_assert_eq!(section_offsets[index].offset, writer.len());
+            debug_assert_eq!(section_offsets[index].offset, writer.offset());
             writer.write(&section.data);
         }
 
@@ -830,7 +830,7 @@ impl<'a> Object<'a> {
         for (index, section) in self.sections.iter().enumerate() {
             if !section.relocations.is_empty() {
                 writer.write_align_relocation();
-                debug_assert_eq!(section_offsets[index].reloc_offset, writer.len());
+                debug_assert_eq!(section_offsets[index].reloc_offset, writer.offset());
                 for reloc in &section.relocations {
                     let r_type = if let RelocationFlags::Elf { r_type } = reloc.flags {
                         r_type
@@ -884,7 +884,7 @@ impl<'a> Object<'a> {
                 sh_type,
                 sh_flags,
                 sh_addr: 0,
-                sh_offset: section_offsets[index].offset as u64,
+                sh_offset: section_offsets[index].offset,
                 sh_size: section.size,
                 sh_link: 0,
                 sh_info: 0,

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -9,7 +9,7 @@ use crate::endian::*;
 use crate::pod;
 use crate::write::string::{StringId, StringTable};
 use crate::write::util;
-use crate::write::{Error, Result, WritableBuffer};
+use crate::write::{Error, GrowableBuffer, Result, WritableBuffer};
 
 const ALIGN_SYMTAB_SHNDX: usize = 4;
 const ALIGN_HASH: usize = 4;
@@ -25,56 +25,72 @@ pub struct SectionIndex(pub u32);
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SymbolIndex(pub u32);
 
+/// The writing mode of a [`Writer`].
+///
+/// This is a sealed trait with two implementors:
+/// - [`TwoPhase`]: reserve all file ranges, then write.
+/// - [`SinglePhase`]: write directly, discovering file offsets as you go.
+pub trait Mode: ModeSealed {}
+
+use private::ModeSealed;
+mod private {
+    use super::*;
+
+    #[allow(private_interfaces)]
+    pub trait ModeSealed {
+        fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()>;
+        fn need_offset(offset: usize) -> bool;
+        fn set_offset(dest: &mut usize, offset: usize);
+        fn set_size(dest: &mut usize, size: usize);
+        fn set_section_index(dest: &mut SectionIndex, index: SectionIndex);
+        fn set_section_name(
+            dest: &mut Option<StringId>,
+            shstrtab: &mut StringTable<'_>,
+            name: &'static [u8],
+        );
+        fn set_count<T: Copy + PartialOrd>(dest: &mut T, count: T);
+    }
+}
+
 /// A helper for writing ELF files.
 ///
-/// Writing uses a two phase approach. The first phase builds up all of the information
-/// that may need to be known ahead of time:
-/// - build string tables
-/// - reserve section indices
-/// - reserve symbol indices
-/// - reserve file ranges for headers and sections
+/// The writer supports two modes: [`TwoPhase`] or [`SinglePhase`].
+/// See the mode documentation for a description of the use of the writer.
 ///
-/// Some of the information has ordering requirements. For example, strings must be added
-/// to string tables before reserving the file range for the string table. Symbol indices
-/// must be reserved after reserving the section indices they reference. There are debug
-/// asserts to check some of these requirements.
-///
-/// The second phase writes everything out in order. Thus the caller must ensure writing
-/// is in the same order that file ranges were reserved. There are debug asserts to assist
-/// with checking this.
+/// The default mode is two-phase. Use [`Writer::new_single_phase`] to construct
+/// a single-phase writer; the [`SinglePhaseWriter`] type alias is also provided.
 #[allow(missing_debug_implementations)]
-pub struct Writer<'a> {
+pub struct Writer<'a, M: Mode = TwoPhase> {
+    mode: M,
     endian: Endianness,
     is_64: bool,
     is_mips64el: bool,
     elf_align: usize,
 
     buffer: &'a mut dyn WritableBuffer,
-    len: usize,
 
-    segment_offset: usize,
-    segment_num: u32,
-
-    section_offset: usize,
-    section_num: u32,
+    header: FileHeader,
+    layout: FileHeaderLayout,
+    written_segment_num: u32,
+    written_section_num: u32,
 
     shstrtab: StringTable<'a>,
     shstrtab_str_id: Option<StringId>,
-    shstrtab_index: SectionIndex,
     shstrtab_offset: usize,
-    shstrtab_data: Vec<u8>,
+    shstrtab_size: u32,
 
     need_strtab: bool,
     strtab: StringTable<'a>,
     strtab_str_id: Option<StringId>,
     strtab_index: SectionIndex,
     strtab_offset: usize,
-    strtab_data: Vec<u8>,
+    strtab_size: u32,
 
     symtab_str_id: Option<StringId>,
     symtab_index: SectionIndex,
     symtab_offset: usize,
     symtab_num: u32,
+    written_symtab_num: u32,
 
     need_symtab_shndx: bool,
     symtab_shndx_str_id: Option<StringId>,
@@ -86,16 +102,18 @@ pub struct Writer<'a> {
     dynstr_str_id: Option<StringId>,
     dynstr_index: SectionIndex,
     dynstr_offset: usize,
-    dynstr_data: Vec<u8>,
+    dynstr_size: u32,
 
     dynsym_str_id: Option<StringId>,
     dynsym_index: SectionIndex,
     dynsym_offset: usize,
     dynsym_num: u32,
+    written_dynsym_num: u32,
 
     dynamic_str_id: Option<StringId>,
     dynamic_offset: usize,
     dynamic_num: usize,
+    written_dynamic_num: usize,
 
     hash_str_id: Option<StringId>,
     hash_offset: usize,
@@ -110,15 +128,17 @@ pub struct Writer<'a> {
 
     gnu_verdef_str_id: Option<StringId>,
     gnu_verdef_offset: usize,
-    gnu_verdef_size: usize,
     gnu_verdef_count: u16,
+    gnu_verdaux_count: usize,
+    written_verdaux_count: usize,
     gnu_verdef_remaining: u16,
     gnu_verdaux_remaining: u16,
 
     gnu_verneed_str_id: Option<StringId>,
     gnu_verneed_offset: usize,
-    gnu_verneed_size: usize,
     gnu_verneed_count: u16,
+    gnu_vernaux_count: usize,
+    written_vernaux_count: usize,
     gnu_verneed_remaining: u16,
     gnu_vernaux_remaining: u16,
 
@@ -127,11 +147,17 @@ pub struct Writer<'a> {
     gnu_attributes_size: usize,
 }
 
-impl<'a> Writer<'a> {
+impl<'a, M: Mode> Writer<'a, M> {
     /// Create a new `Writer` for the given endianness and ELF class.
-    pub fn new(endian: Endianness, is_64: bool, buffer: &'a mut dyn WritableBuffer) -> Self {
+    fn new_with_mode(
+        endian: Endianness,
+        is_64: bool,
+        buffer: &'a mut dyn WritableBuffer,
+        mode: M,
+    ) -> Self {
         let elf_align = if is_64 { 8 } else { 4 };
         Writer {
+            mode,
             endian,
             is_64,
             // Determined later.
@@ -139,31 +165,29 @@ impl<'a> Writer<'a> {
             elf_align,
 
             buffer,
-            len: 0,
 
-            segment_offset: 0,
-            segment_num: 0,
-
-            section_offset: 0,
-            section_num: 0,
+            header: FileHeader::default(),
+            layout: FileHeaderLayout::default(),
+            written_segment_num: 0,
+            written_section_num: 0,
 
             shstrtab: StringTable::default(),
             shstrtab_str_id: None,
-            shstrtab_index: SectionIndex(0),
             shstrtab_offset: 0,
-            shstrtab_data: Vec::new(),
+            shstrtab_size: 0,
 
             need_strtab: false,
             strtab: StringTable::default(),
             strtab_str_id: None,
             strtab_index: SectionIndex(0),
             strtab_offset: 0,
-            strtab_data: Vec::new(),
+            strtab_size: 0,
 
             symtab_str_id: None,
             symtab_index: SectionIndex(0),
             symtab_offset: 0,
             symtab_num: 0,
+            written_symtab_num: 0,
 
             need_symtab_shndx: false,
             symtab_shndx_str_id: None,
@@ -175,16 +199,18 @@ impl<'a> Writer<'a> {
             dynstr_str_id: None,
             dynstr_index: SectionIndex(0),
             dynstr_offset: 0,
-            dynstr_data: Vec::new(),
+            dynstr_size: 0,
 
             dynsym_str_id: None,
             dynsym_index: SectionIndex(0),
             dynsym_offset: 0,
             dynsym_num: 0,
+            written_dynsym_num: 0,
 
             dynamic_str_id: None,
             dynamic_offset: 0,
             dynamic_num: 0,
+            written_dynamic_num: 0,
 
             hash_str_id: None,
             hash_offset: 0,
@@ -199,15 +225,17 @@ impl<'a> Writer<'a> {
 
             gnu_verdef_str_id: None,
             gnu_verdef_offset: 0,
-            gnu_verdef_size: 0,
             gnu_verdef_count: 0,
+            gnu_verdaux_count: 0,
+            written_verdaux_count: 0,
             gnu_verdef_remaining: 0,
             gnu_verdaux_remaining: 0,
 
             gnu_verneed_str_id: None,
             gnu_verneed_offset: 0,
-            gnu_verneed_size: 0,
             gnu_verneed_count: 0,
+            gnu_vernaux_count: 0,
+            written_vernaux_count: 0,
             gnu_verneed_remaining: 0,
             gnu_vernaux_remaining: 0,
 
@@ -259,20 +287,33 @@ impl<'a> Writer<'a> {
         self.is_mips64el =
             self.is_64 && self.endian.is_little_endian() && header.e_machine == elf::EM_MIPS;
 
-        // Start writing.
-        self.buffer
-            .reserve(self.len)
-            .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+        self.mode.reserve(self.buffer)?;
+        self.header = header.clone();
+        Self::write_file_header_impl(
+            self.buffer,
+            self.endian,
+            self.is_64,
+            &self.header,
+            &self.layout,
+        )
+    }
 
-        // Write file header.
+    fn write_file_header_impl(
+        buffer: &mut dyn WritableBuffer,
+        endian: Endianness,
+        is_64: bool,
+        header: &FileHeader,
+        layout: &FileHeaderLayout,
+    ) -> Result<()> {
+        let class = Class { is_64 };
         let e_ident = elf::Ident {
             magic: elf::ELFMAG,
-            class: if self.is_64 {
+            class: if class.is_64 {
                 elf::ELFCLASS64
             } else {
                 elf::ELFCLASS32
             },
-            data: if self.endian.is_little_endian() {
+            data: if endian.is_little_endian() {
                 elf::ELFDATA2LSB
             } else {
                 elf::ELFDATA2MSB
@@ -283,40 +324,39 @@ impl<'a> Writer<'a> {
             padding: [0; 7],
         };
 
-        let e_ehsize = self.class().file_header_size() as u16;
+        let e_ehsize = class.file_header_size() as u16;
 
-        let e_phoff = self.segment_offset as u64;
-        let e_phentsize = if self.segment_num == 0 {
+        let e_phoff = layout.segment_offset as u64;
+        let e_phentsize = if layout.segment_num == 0 {
             0
         } else {
-            self.class().program_header_size() as u16
+            class.program_header_size() as u16
         };
-        let e_phnum = if self.segment_num >= elf::PN_XNUM.into() {
-            if self.section_num == 0 {
+        let e_phnum = if layout.segment_num >= elf::PN_XNUM.into() {
+            if layout.section_num == 0 {
                 return Err(Error(String::from(
                     "e_phnum overflow requires section headers",
                 )));
             }
             elf::PN_XNUM
         } else {
-            self.segment_num as u16
+            layout.segment_num as u16
         };
 
-        let e_shoff = self.section_offset as u64;
-        let e_shentsize = if self.section_num == 0 {
+        let e_shoff = layout.section_offset as u64;
+        let e_shentsize = if layout.section_num == 0 {
             0
         } else {
-            self.class().section_header_size() as u16
+            class.section_header_size() as u16
         };
-        let e_shnum = if self.section_num >= elf::SHN_LORESERVE.into() {
+        let e_shnum = if layout.section_num >= elf::SHN_LORESERVE.into() {
             0
         } else {
-            self.section_num as u16
+            layout.section_num as u16
         };
-        let e_shstrndx = elf::SymbolSection::new(self.shstrtab_index.0);
+        let e_shstrndx = elf::SymbolSection::new(layout.shstrtab_index.0);
 
-        let endian = self.endian;
-        if self.is_64 {
+        if class.is_64 {
             let file = elf::FileHeader64 {
                 e_ident,
                 e_type: U16::new(endian, header.e_type),
@@ -333,7 +373,7 @@ impl<'a> Writer<'a> {
                 e_shnum: U16::new(endian, e_shnum),
                 e_shstrndx: U16::new(endian, e_shstrndx),
             };
-            self.buffer.write(&file)
+            buffer.write(&file)
         } else {
             let file = elf::FileHeader32 {
                 e_ident,
@@ -351,7 +391,7 @@ impl<'a> Writer<'a> {
                 e_shnum: U16::new(endian, e_shnum),
                 e_shstrndx: U16::new(endian, e_shstrndx),
             };
-            self.buffer.write(&file);
+            buffer.write(&file);
         }
 
         Ok(())
@@ -359,17 +399,27 @@ impl<'a> Writer<'a> {
 
     /// Write alignment padding bytes prior to the program headers.
     pub fn write_align_program_headers(&mut self) {
-        if self.segment_offset == 0 {
+        if !M::need_offset(self.layout.segment_offset) {
             return;
         }
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.segment_offset, self.buffer.len());
+        M::set_offset(&mut self.layout.segment_offset, self.buffer.len());
     }
 
     /// Write a program header.
     pub fn write_program_header(&mut self, header: &ProgramHeader) {
-        let endian = self.endian;
-        if self.is_64 {
+        Self::write_program_header_impl(self.buffer, self.endian, self.is_64, header);
+        self.written_segment_num += 1;
+        M::set_count(&mut self.layout.segment_num, self.written_segment_num);
+    }
+
+    fn write_program_header_impl(
+        buffer: &mut dyn WritableBuffer,
+        endian: Endianness,
+        is_64: bool,
+        header: &ProgramHeader,
+    ) {
+        if is_64 {
             let header = elf::ProgramHeader64 {
                 p_type: U32::new(endian, header.p_type),
                 p_flags: U32::new(endian, header.p_flags),
@@ -380,7 +430,7 @@ impl<'a> Writer<'a> {
                 p_memsz: U64::new(endian, header.p_memsz),
                 p_align: U64::new(endian, header.p_align),
             };
-            self.buffer.write(&header);
+            buffer.write(&header);
         } else {
             let header = elf::ProgramHeader32 {
                 p_type: U32::new(endian, header.p_type),
@@ -392,7 +442,7 @@ impl<'a> Writer<'a> {
                 p_flags: U32::new(endian, header.p_flags),
                 p_align: U32::new(endian, header.p_align as u32),
             };
-            self.buffer.write(&header);
+            buffer.write(&header);
         }
     }
 
@@ -401,29 +451,29 @@ impl<'a> Writer<'a> {
     /// This must be the first section header that is written.
     /// This function does nothing if no sections were reserved.
     pub fn write_null_section_header(&mut self) {
-        if self.section_num == 0 {
+        if !M::need_offset(self.layout.section_offset) {
             return;
         }
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.section_offset, self.buffer.len());
+        M::set_offset(&mut self.layout.section_offset, self.buffer.len());
         self.write_section_header(&SectionHeader {
             name: None,
             sh_type: elf::SHT_NULL,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
             sh_offset: 0,
-            sh_size: if self.section_num >= elf::SHN_LORESERVE.into() {
-                self.section_num.into()
+            sh_size: if self.layout.section_num >= elf::SHN_LORESERVE.into() {
+                self.layout.section_num.into()
             } else {
                 0
             },
-            sh_link: if self.shstrtab_index.0 >= elf::SHN_LORESERVE.into() {
-                self.shstrtab_index.0
+            sh_link: if self.layout.shstrtab_index.0 >= elf::SHN_LORESERVE.into() {
+                self.layout.shstrtab_index.0
             } else {
                 0
             },
-            sh_info: if self.segment_num >= elf::PN_XNUM.into() {
-                self.segment_num
+            sh_info: if self.layout.segment_num >= elf::PN_XNUM.into() {
+                self.layout.segment_num
             } else {
                 0
             },
@@ -433,7 +483,7 @@ impl<'a> Writer<'a> {
     }
 
     /// Write a section header.
-    pub fn write_section_header(&mut self, section: &SectionHeader) {
+    pub fn write_section_header(&mut self, section: &SectionHeader) -> SectionIndex {
         let sh_name = if let Some(name) = section.name {
             self.shstrtab.get_offset(name)
         } else {
@@ -469,6 +519,10 @@ impl<'a> Writer<'a> {
             };
             self.buffer.write(&section);
         }
+        let index = SectionIndex(self.written_section_num);
+        self.written_section_num += 1;
+        M::set_count(&mut self.layout.section_num, self.written_section_num);
+        index
     }
 
     /// Add a section name to the section header string table.
@@ -485,31 +539,33 @@ impl<'a> Writer<'a> {
     ///
     /// This function does nothing if the section index was not reserved.
     pub fn write_shstrtab_section_header(&mut self) {
-        if self.shstrtab_index == SectionIndex(0) {
+        if self.shstrtab_str_id.is_none() {
             return;
         }
-        self.write_section_header(&SectionHeader {
+        debug_assert_ne!(self.shstrtab_offset, 0);
+        let index = self.write_section_header(&SectionHeader {
             name: self.shstrtab_str_id,
             sh_type: elf::SHT_STRTAB,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
             sh_offset: self.shstrtab_offset as u64,
-            sh_size: self.shstrtab_data.len() as u64,
+            sh_size: self.shstrtab_size.into(),
             sh_link: 0,
             sh_info: 0,
             sh_addralign: 1,
             sh_entsize: 0,
         });
+        M::set_section_index(&mut self.layout.shstrtab_index, index);
     }
 
     /// Add a string to the string table.
     ///
     /// This will be stored in the `.strtab` section.
     ///
-    /// This must be called before [`Self::reserve_strtab`].
+    /// This must be called before [`Self::reserve_strtab`] in two-phase mode,
+    /// or before [`Self::write_strtab`] in single-phase mode.
     pub fn add_string(&mut self, name: &'a [u8]) -> StringId {
         debug_assert_eq!(self.strtab_offset, 0);
-        self.need_strtab = true;
         self.strtab.add(name)
     }
 
@@ -517,21 +573,22 @@ impl<'a> Writer<'a> {
     ///
     /// This function does nothing if the section index was not reserved.
     pub fn write_strtab_section_header(&mut self) {
-        if self.strtab_index == SectionIndex(0) {
+        if self.strtab_str_id.is_none() {
             return;
         }
-        self.write_section_header(&SectionHeader {
+        let index = self.write_section_header(&SectionHeader {
             name: self.strtab_str_id,
             sh_type: elf::SHT_STRTAB,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
             sh_offset: self.strtab_offset as u64,
-            sh_size: self.strtab_data.len() as u64,
+            sh_size: self.strtab_size.into(),
             sh_link: 0,
             sh_info: 0,
             sh_addralign: 1,
             sh_entsize: 0,
         });
+        M::set_section_index(&mut self.strtab_index, index);
     }
 
     /// Write the null symbol.
@@ -539,25 +596,31 @@ impl<'a> Writer<'a> {
     /// This must be the first symbol that is written.
     /// This function does nothing if no symbols were reserved.
     pub fn write_null_symbol(&mut self) {
-        if self.symtab_num == 0 {
+        if !M::need_offset(self.symtab_offset) {
             return;
         }
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.symtab_offset, self.buffer.len());
+        M::set_offset(&mut self.symtab_offset, self.buffer.len());
+        M::set_section_name(&mut self.symtab_str_id, &mut self.shstrtab, b".symtab");
         if self.is_64 {
             self.buffer.write(&elf::Sym64::<Endianness>::default());
         } else {
             self.buffer.write(&elf::Sym32::<Endianness>::default());
         }
 
-        if self.need_symtab_shndx {
+        if M::need_offset(self.symtab_shndx_offset) {
             self.symtab_shndx_data
                 .write_pod(&U32::new(self.endian, 0u32));
         }
+
+        self.written_symtab_num = 1;
+        M::set_count(&mut self.symtab_num, self.written_symtab_num);
+        // The symtab must link to a strtab.
+        self.need_strtab = true;
     }
 
     /// Write a symbol.
-    pub fn write_symbol(&mut self, sym: &Sym) {
+    pub fn write_symbol(&mut self, sym: &Sym) -> SymbolIndex {
         let st_name = if let Some(name) = sym.name {
             self.strtab.get_offset(name)
         } else {
@@ -592,8 +655,9 @@ impl<'a> Writer<'a> {
             self.buffer.write(&sym);
         }
 
-        if self.need_symtab_shndx {
+        if M::need_offset(self.symtab_shndx_offset) {
             let section_index = if st_shndx == elf::SHN_XINDEX {
+                self.need_symtab_shndx = true;
                 sym.section.map_or(0, |s| s.0)
             } else {
                 0
@@ -601,16 +665,21 @@ impl<'a> Writer<'a> {
             self.symtab_shndx_data
                 .write_pod(&U32::new(self.endian, section_index));
         }
+
+        let index = SymbolIndex(self.written_symtab_num);
+        self.written_symtab_num += 1;
+        M::set_count(&mut self.symtab_num, self.written_symtab_num);
+        index
     }
 
     /// Write the section header for the symbol table.
     ///
     /// This function does nothing if the section index was not reserved.
     pub fn write_symtab_section_header(&mut self, num_local: u32) {
-        if self.symtab_index == SectionIndex(0) {
+        if self.symtab_str_id.is_none() {
             return;
         }
-        self.write_section_header(&SectionHeader {
+        let index = self.write_section_header(&SectionHeader {
             name: self.symtab_str_id,
             sh_type: elf::SHT_SYMTAB,
             sh_flags: elf::SectionFlags(0),
@@ -622,19 +691,26 @@ impl<'a> Writer<'a> {
             sh_addralign: self.elf_align as u64,
             sh_entsize: self.class().sym_size() as u64,
         });
+        M::set_section_index(&mut self.symtab_index, index);
     }
 
     /// Write the extended section indices for the symbol table.
     ///
     /// This function does nothing if the section was not reserved.
     pub fn write_symtab_shndx(&mut self) {
-        if self.symtab_shndx_offset == 0 {
+        if !self.need_symtab_shndx {
+            self.symtab_shndx_data = Vec::new();
             return;
         }
         util::write_align(self.buffer, ALIGN_SYMTAB_SHNDX);
-        debug_assert_eq!(self.symtab_shndx_offset, self.buffer.len());
-        debug_assert_eq!(self.symtab_num as usize * 4, self.symtab_shndx_data.len());
+        M::set_offset(&mut self.symtab_shndx_offset, self.buffer.len());
+        M::set_section_name(
+            &mut self.symtab_shndx_str_id,
+            &mut self.shstrtab,
+            b".symtab_shndx",
+        );
         self.buffer.write_bytes(&self.symtab_shndx_data);
+        self.symtab_shndx_data = Vec::new();
     }
 
     /// Write the section header for the extended section indices for the symbol table.
@@ -667,10 +743,10 @@ impl<'a> Writer<'a> {
     ///
     /// This will be stored in the `.dynstr` section.
     ///
-    /// This must be called before [`Self::reserve_dynstr`].
+    /// This must be called before [`Self::reserve_dynstr`] in two-phase mode,
+    /// or before [`Self::write_dynstr`] in single-phase mode.
     pub fn add_dynamic_string(&mut self, name: &'a [u8]) -> StringId {
         debug_assert_eq!(self.dynstr_offset, 0);
-        self.need_dynstr = true;
         self.dynstr.add(name)
     }
 
@@ -685,21 +761,22 @@ impl<'a> Writer<'a> {
     ///
     /// This function does nothing if the section index was not reserved.
     pub fn write_dynstr_section_header(&mut self, sh_addr: u64) {
-        if self.dynstr_index == SectionIndex(0) {
+        if self.dynstr_str_id.is_none() {
             return;
         }
-        self.write_section_header(&SectionHeader {
+        let index = self.write_section_header(&SectionHeader {
             name: self.dynstr_str_id,
             sh_type: elf::SHT_STRTAB,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
             sh_offset: self.dynstr_offset as u64,
-            sh_size: self.dynstr_data.len() as u64,
+            sh_size: self.dynstr_size.into(),
             sh_link: 0,
             sh_info: 0,
             sh_addralign: 1,
             sh_entsize: 0,
         });
+        M::set_section_index(&mut self.dynstr_index, index);
     }
 
     /// Write the null dynamic symbol.
@@ -707,20 +784,26 @@ impl<'a> Writer<'a> {
     /// This must be the first dynamic symbol that is written.
     /// This function does nothing if no dynamic symbols were reserved.
     pub fn write_null_dynamic_symbol(&mut self) {
-        if self.dynsym_num == 0 {
+        if !M::need_offset(self.dynsym_offset) {
             return;
         }
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.dynsym_offset, self.buffer.len());
+        M::set_offset(&mut self.dynsym_offset, self.buffer.len());
+        M::set_section_name(&mut self.dynsym_str_id, &mut self.shstrtab, b".dynsym");
         if self.is_64 {
             self.buffer.write(&elf::Sym64::<Endianness>::default());
         } else {
             self.buffer.write(&elf::Sym32::<Endianness>::default());
         }
+
+        self.written_dynsym_num = 1;
+        M::set_count(&mut self.dynsym_num, self.written_dynsym_num);
+        // The symbol table must link to a string table.
+        self.need_dynstr = true;
     }
 
     /// Write a dynamic symbol.
-    pub fn write_dynamic_symbol(&mut self, sym: &Sym) {
+    pub fn write_dynamic_symbol(&mut self, sym: &Sym) -> SymbolIndex {
         let st_name = if let Some(name) = sym.name {
             self.dynstr.get_offset(name)
         } else {
@@ -757,16 +840,21 @@ impl<'a> Writer<'a> {
             };
             self.buffer.write(&sym);
         }
+
+        let index = SymbolIndex(self.written_dynsym_num);
+        self.written_dynsym_num += 1;
+        M::set_count(&mut self.dynsym_num, self.written_dynsym_num);
+        index
     }
 
     /// Write the section header for the dynamic symbol table.
     ///
     /// This function does nothing if the section index was not reserved.
     pub fn write_dynsym_section_header(&mut self, sh_addr: u64, num_local: u32) {
-        if self.dynsym_index == SectionIndex(0) {
+        if self.dynsym_str_id.is_none() {
             return;
         }
-        self.write_section_header(&SectionHeader {
+        let index = self.write_section_header(&SectionHeader {
             name: self.dynsym_str_id,
             sh_type: elf::SHT_DYNSYM,
             sh_flags: elf::SHF_ALLOC,
@@ -778,17 +866,19 @@ impl<'a> Writer<'a> {
             sh_addralign: self.elf_align as u64,
             sh_entsize: self.class().sym_size() as u64,
         });
+        M::set_section_index(&mut self.dynsym_index, index);
     }
 
     /// Write alignment padding bytes prior to the `.dynamic` section.
     ///
     /// This function does nothing if the section was not reserved.
     pub fn write_align_dynamic(&mut self) {
-        if self.dynamic_offset == 0 {
+        if !M::need_offset(self.dynamic_offset) {
             return;
         }
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.dynamic_offset, self.buffer.len());
+        M::set_offset(&mut self.dynamic_offset, self.buffer.len());
+        M::set_section_name(&mut self.dynamic_str_id, &mut self.shstrtab, b".dynamic");
     }
 
     /// Write a dynamic string entry.
@@ -817,6 +907,8 @@ impl<'a> Writer<'a> {
             };
             self.buffer.write(&d);
         }
+        self.written_dynamic_num += 1;
+        M::set_count(&mut self.dynamic_num, self.written_dynamic_num);
         Ok(())
     }
 
@@ -860,13 +952,15 @@ impl<'a> Writer<'a> {
         }
 
         util::write_align(self.buffer, ALIGN_HASH);
-        debug_assert_eq!(self.hash_offset, self.buffer.len());
+        M::set_offset(&mut self.hash_offset, self.buffer.len());
+        M::set_section_name(&mut self.hash_str_id, &mut self.shstrtab, b".hash");
         self.buffer.write(&elf::HashHeader {
             bucket_count: U32::new(self.endian, bucket_count),
             chain_count: U32::new(self.endian, chain_count),
         });
         self.buffer.write_slice(&buckets);
         self.buffer.write_slice(&chains);
+        M::set_size(&mut self.hash_size, self.buffer.len() - self.hash_offset);
     }
 
     /// Write the section header for the SysV hash table.
@@ -908,7 +1002,8 @@ impl<'a> Writer<'a> {
         F: Fn(u32) -> u32,
     {
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.gnu_hash_offset, self.buffer.len());
+        M::set_offset(&mut self.gnu_hash_offset, self.buffer.len());
+        M::set_section_name(&mut self.gnu_hash_str_id, &mut self.shstrtab, b".gnu.hash");
         self.buffer.write(&elf::GnuHashHeader {
             bucket_count: U32::new(self.endian, bucket_count),
             symbol_base: U32::new(self.endian, symbol_base),
@@ -969,6 +1064,11 @@ impl<'a> Writer<'a> {
             }
             self.buffer.write(&U32::new(self.endian, h));
         }
+
+        M::set_size(
+            &mut self.gnu_hash_size,
+            self.buffer.len() - self.gnu_hash_offset,
+        );
     }
 
     /// Write the section header for the GNU hash table.
@@ -997,11 +1097,16 @@ impl<'a> Writer<'a> {
     /// This must be the first symbol version that is written.
     /// This function does nothing if no dynamic symbols were reserved.
     pub fn write_null_gnu_versym(&mut self) {
-        if self.dynsym_num == 0 {
+        if !M::need_offset(self.gnu_versym_offset) {
             return;
         }
         util::write_align(self.buffer, ALIGN_GNU_VERSYM);
-        debug_assert_eq!(self.gnu_versym_offset, self.buffer.len());
+        M::set_offset(&mut self.gnu_versym_offset, self.buffer.len());
+        M::set_section_name(
+            &mut self.gnu_versym_str_id,
+            &mut self.shstrtab,
+            b".gnu.version",
+        );
         self.write_gnu_versym(elf::VER_NDX_LOCAL.into());
     }
 
@@ -1033,11 +1138,16 @@ impl<'a> Writer<'a> {
 
     /// Write alignment padding bytes prior to a `.gnu.version_d` section.
     pub fn write_align_gnu_verdef(&mut self) {
-        if self.gnu_verdef_offset == 0 {
+        if !M::need_offset(self.gnu_verdef_offset) {
             return;
         }
         util::write_align(self.buffer, ALIGN_GNU_VERDEF);
-        debug_assert_eq!(self.gnu_verdef_offset, self.buffer.len());
+        M::set_offset(&mut self.gnu_verdef_offset, self.buffer.len());
+        M::set_section_name(
+            &mut self.gnu_verdef_str_id,
+            &mut self.shstrtab,
+            b".gnu.version_d",
+        );
     }
 
     /// Write a version definition entry.
@@ -1053,6 +1163,8 @@ impl<'a> Writer<'a> {
 
         debug_assert_ne!(verdef.aux_count, 0);
         self.gnu_verdaux_remaining = verdef.aux_count;
+        self.written_verdaux_count += verdef.aux_count as usize;
+        M::set_count(&mut self.gnu_verdaux_count, self.written_verdaux_count);
         let vd_aux = mem::size_of::<elf::Verdef<Endianness>>() as u32;
 
         self.buffer.write(&elf::Verdef {
@@ -1114,13 +1226,17 @@ impl<'a> Writer<'a> {
         if self.gnu_verdef_str_id.is_none() {
             return;
         }
+        let sh_size = self
+            .class()
+            .gnu_verdef_size(self.gnu_verdef_count as usize, self.gnu_verdaux_count)
+            as u64;
         self.write_section_header(&SectionHeader {
             name: self.gnu_verdef_str_id,
             sh_type: elf::SHT_GNU_VERDEF,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
             sh_offset: self.gnu_verdef_offset as u64,
-            sh_size: self.gnu_verdef_size as u64,
+            sh_size,
             sh_link: self.dynstr_index.0,
             sh_info: self.gnu_verdef_count.into(),
             sh_addralign: ALIGN_GNU_VERDEF as u64,
@@ -1130,11 +1246,16 @@ impl<'a> Writer<'a> {
 
     /// Write alignment padding bytes prior to a `.gnu.version_r` section.
     pub fn write_align_gnu_verneed(&mut self) {
-        if self.gnu_verneed_offset == 0 {
+        if !M::need_offset(self.gnu_verneed_offset) {
             return;
         }
         util::write_align(self.buffer, ALIGN_GNU_VERNEED);
-        debug_assert_eq!(self.gnu_verneed_offset, self.buffer.len());
+        M::set_offset(&mut self.gnu_verneed_offset, self.buffer.len());
+        M::set_section_name(
+            &mut self.gnu_verneed_str_id,
+            &mut self.shstrtab,
+            b".gnu.version_r",
+        );
     }
 
     /// Write a version need entry.
@@ -1148,10 +1269,12 @@ impl<'a> Writer<'a> {
                 + verneed.aux_count as u32 * mem::size_of::<elf::Vernaux<Endianness>>() as u32
         };
 
-        self.gnu_vernaux_remaining = verneed.aux_count;
         let vn_aux = if verneed.aux_count == 0 {
             0
         } else {
+            self.gnu_vernaux_remaining = verneed.aux_count;
+            self.written_vernaux_count += verneed.aux_count as usize;
+            M::set_count(&mut self.gnu_vernaux_count, self.written_vernaux_count);
             mem::size_of::<elf::Verneed<Endianness>>() as u32
         };
 
@@ -1189,13 +1312,17 @@ impl<'a> Writer<'a> {
         if self.gnu_verneed_str_id.is_none() {
             return;
         }
+        let sh_size = self
+            .class()
+            .gnu_verneed_size(self.gnu_verneed_count as usize, self.gnu_vernaux_count)
+            as u64;
         self.write_section_header(&SectionHeader {
             name: self.gnu_verneed_str_id,
             sh_type: elf::SHT_GNU_VERNEED,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
             sh_offset: self.gnu_verneed_offset as u64,
-            sh_size: self.gnu_verneed_size as u64,
+            sh_size,
             sh_link: self.dynstr_index.0,
             sh_info: self.gnu_verneed_count.into(),
             sh_addralign: ALIGN_GNU_VERNEED as u64,
@@ -1226,12 +1353,19 @@ impl<'a> Writer<'a> {
 
     /// Write the data for the `.gnu.attributes` section.
     pub fn write_gnu_attributes(&mut self, data: &[u8]) {
-        if self.gnu_attributes_offset == 0 {
+        if !M::need_offset(self.gnu_attributes_offset) {
             return;
         }
         util::write_align(self.buffer, self.elf_align);
-        debug_assert_eq!(self.gnu_attributes_offset, self.buffer.len());
+        M::set_offset(&mut self.gnu_attributes_offset, self.buffer.len());
+        M::set_section_name(
+            &mut self.gnu_attributes_str_id,
+            &mut self.shstrtab,
+            b".gnu.attributes",
+        );
         self.buffer.write_bytes(data);
+        let size = self.buffer.len() - self.gnu_attributes_offset;
+        M::set_size(&mut self.gnu_attributes_size, size);
     }
 
     /// Write alignment padding bytes prior to a relocation section.
@@ -1371,10 +1505,312 @@ impl<'a> Writer<'a> {
     }
 }
 
-impl<'a> Writer<'a> {
+/// Single-phase writer for ELF files.
+///
+/// See [`SinglePhase`].
+pub type SinglePhaseWriter<'a> = Writer<'a, SinglePhase>;
+
+/// Single-phase writing mode for [`Writer`].
+///
+/// Construct a writer with this mode using [`Writer::new_single_phase`].
+///
+/// There is no reservation phase: items are written directly and their file offsets are
+/// discovered as they are written. The `reserve_*` methods are not available in this mode.
+///
+/// Items must be written before they are referenced:
+/// - write section data before section headers
+/// - write string tables before they are referenced
+/// - write metadata section headers before they are referenced (e.g. `.strtab` before `.symtab`)
+///
+/// The one exception is the file header, which must be written first, but needs to
+/// reference the program header table and section header table. To support this, you can
+/// call [`Writer::write_file_header`] to write placeholders, then after everything
+/// is written call [`Writer::write_file_header_to`] using a new buffer, and manually copy
+/// the header to the start.
+///
+/// The `Writer` will assign section indices to metadata sections as the headers are
+/// written. However, for text/data sections you will need to manually determine
+/// the section indices ahead of time if you need to reference sections from
+/// symbols. Similarly, for symbol indices if you need to reference symbols from
+/// relocations.
+#[derive(Debug)]
+pub struct SinglePhase(());
+
+impl Mode for SinglePhase {}
+#[allow(private_interfaces)]
+impl ModeSealed for SinglePhase {
+    fn reserve(&self, _buffer: &mut dyn WritableBuffer) -> Result<()> {
+        Ok(())
+    }
+
+    fn need_offset(offset: usize) -> bool {
+        debug_assert_eq!(offset, 0);
+        true
+    }
+
+    fn set_offset(dest: &mut usize, offset: usize) {
+        debug_assert_eq!(*dest, 0);
+        *dest = offset;
+    }
+
+    fn set_size(dest: &mut usize, size: usize) {
+        debug_assert_eq!(*dest, 0);
+        *dest = size;
+    }
+
+    fn set_section_index(dest: &mut SectionIndex, index: SectionIndex) {
+        debug_assert_eq!(dest.0, 0);
+        *dest = index;
+    }
+
+    fn set_section_name(
+        dest: &mut Option<StringId>,
+        shstrtab: &mut StringTable<'_>,
+        name: &'static [u8],
+    ) {
+        debug_assert!(dest.is_none());
+        *dest = Some(shstrtab.add(name));
+    }
+
+    fn set_count<T: Copy + PartialOrd>(dest: &mut T, count: T) {
+        debug_assert!(*dest < count);
+        *dest = count;
+    }
+}
+
+impl<'a> Writer<'a, SinglePhase> {
+    /// Create a new single-phase `Writer` for the given endianness and ELF class.
+    pub fn new_single_phase(
+        endian: Endianness,
+        is_64: bool,
+        buffer: &'a mut dyn GrowableBuffer,
+    ) -> Self {
+        Writer::new_with_mode(endian, is_64, buffer.as_writable(), SinglePhase(()))
+    }
+
+    /// Write the file header to the given buffer.
+    ///
+    /// This is needed to write fields such as the section header offset into the file
+    /// header. You must manually copy the resulting `buffer` contents to the start of the
+    /// original buffer after dropping the `Writer`.
+    pub fn write_file_header_to(&mut self, buffer: &mut dyn WritableBuffer) -> Result<()> {
+        if self.layout.section_num >= elf::SHN_LORESERVE.into() {
+            // The null section header was written before section_num was known,
+            // so it won't contain the overflow value.
+            return Err(Error(String::from(
+                "single phase write doesn't support e_shnum overflow",
+            )));
+        }
+        Self::write_file_header_impl(buffer, self.endian, self.is_64, &self.header, &self.layout)
+    }
+
+    /// Write a placeholder for the program header table immediately after the file header.
+    ///
+    /// Must be called immediately after [`Self::write_file_header`] and before any
+    /// other data is written. This pads the buffer by `count` program header entries.
+    /// Use [`Self::write_headers_to`] to write the program headers once their contents
+    /// are known.
+    pub fn write_program_headers_placeholder(&mut self, count: u32) {
+        if count == 0 {
+            return;
+        }
+        debug_assert_eq!(self.buffer.len(), self.class().file_header_size());
+        // file_header_size is always a multiple of elf_align, so no alignment
+        // padding is required.
+        SinglePhase::set_offset(&mut self.layout.segment_offset, self.buffer.len());
+        SinglePhase::set_count(&mut self.layout.segment_num, count);
+        self.written_segment_num = count;
+        let new_len = self.buffer.len() + count as usize * self.class().program_header_size();
+        self.buffer.resize(new_len);
+    }
+
+    /// Write the file header and program headers to the given buffer.
+    ///
+    /// This serves the same purpose as [`Self::write_file_header_to`], but additionally
+    /// writes the program headers immediately following the file header.  You must
+    /// manually copy the resulting `buffer` contents to the start of the original buffer
+    /// after dropping the `Writer`.
+    ///
+    /// The number of program headers must match the count passed to
+    /// [`Self::write_program_headers_placeholder`].
+    pub fn write_headers_to(
+        &mut self,
+        buffer: &mut dyn WritableBuffer,
+        program_headers: &[ProgramHeader],
+    ) -> Result<()> {
+        debug_assert_eq!(program_headers.len() as u32, self.layout.segment_num);
+        Self::write_file_header_impl(buffer, self.endian, self.is_64, &self.header, &self.layout)?;
+        for header in program_headers {
+            Self::write_program_header_impl(buffer, self.endian, self.is_64, header);
+        }
+        Ok(())
+    }
+
+    /// Write a program header to the given buffer.
+    ///
+    /// This serves the same purpose as [`Self::write_headers_to`], but allows you to use
+    /// separate calls for writing the file header and each program header.
+    pub fn write_program_header_to(
+        &mut self,
+        buffer: &mut dyn WritableBuffer,
+        header: &ProgramHeader,
+    ) {
+        Self::write_program_header_impl(buffer, self.endian, self.is_64, header);
+    }
+
+    /// Write the section header string table.
+    ///
+    /// This will always write the string table, even if it is empty.
+    pub fn write_shstrtab(&mut self) -> Result<()> {
+        // This must be written before the .shstrtab section header, so
+        // we can't use write_null_section_header to determine if it is needed.
+        // Thus we always write this if called.
+        debug_assert_eq!(self.shstrtab_offset, 0);
+        self.shstrtab_str_id = Some(self.add_section_name(b".shstrtab"));
+        // Start with null section name.
+        let mut data = vec![0];
+        self.shstrtab_size = self.shstrtab.write(1, &mut data)?;
+        self.shstrtab_offset = self.buffer.len();
+        self.write(&data);
+        Ok(())
+    }
+
+    /// Write the string table.
+    ///
+    /// Only writes the string table if there is a symbol table
+    /// or if it is not empty.
+    pub fn write_strtab(&mut self) -> Result<()> {
+        if !self.need_strtab && self.strtab.is_empty() {
+            return Ok(());
+        }
+        debug_assert_eq!(self.strtab_offset, 0);
+        self.strtab_str_id = Some(self.add_section_name(b".strtab"));
+        // Start with null section name.
+        let mut data = vec![0];
+        self.strtab_size = self.strtab.write(1, &mut data)?;
+        self.strtab_offset = self.buffer.len();
+        self.write(&data);
+        Ok(())
+    }
+
+    /// Write the dynamic string table.
+    ///
+    /// Only writes the string table if there is a dynamic symbol table
+    /// or if it is not empty.
+    pub fn write_dynstr(&mut self) -> Result<()> {
+        if !self.need_dynstr && self.dynstr.is_empty() {
+            return Ok(());
+        }
+        debug_assert_eq!(self.dynstr_offset, 0);
+        self.dynstr_str_id = Some(self.add_section_name(b".dynstr"));
+        // Start with null section name.
+        let mut data = vec![0];
+        self.dynstr_size = self.dynstr.write(1, &mut data)?;
+        self.dynstr_offset = self.buffer.len();
+        self.write(&data);
+        Ok(())
+    }
+
+    /// Set the number of version definition entries that will be written.
+    ///
+    /// Must be called before [`Self::write_gnu_verdef`].
+    pub fn set_gnu_verdef_count(&mut self, count: u16) {
+        self.gnu_verdef_count = count;
+        self.gnu_verdef_remaining = count;
+    }
+
+    /// Set the number of version needed entries that will be written.
+    ///
+    /// Must be called before [`Self::write_gnu_verneed`].
+    pub fn set_gnu_verneed_count(&mut self, count: u16) {
+        self.gnu_verneed_count = count;
+        self.gnu_verneed_remaining = count;
+    }
+}
+
+/// Two-phase writing mode for [`Writer`].
+///
+/// Construct a writer with this mode using [`Writer::new`].
+///
+/// File ranges and indices are reserved up front with the `reserve_*` methods,
+/// then everything is written in the same order. This is the default mode.
+///
+/// The first phase uses the `reserve_*` methods to build up all of the information
+/// that may need to be known ahead of time:
+/// - string table offsets
+/// - section indices
+/// - symbol indices
+/// - file ranges for headers and sections
+///
+/// Some of the information has ordering requirements. For example, strings must be added
+/// to string tables before reserving the file range for the string table. Symbol indices
+/// must be reserved after reserving the section indices they reference. There are debug
+/// asserts to check some of these requirements.
+///
+/// The second phase writes everything out in order. Thus the caller must ensure writing
+/// is in the same order that file ranges were reserved. There are debug asserts to assist
+/// with checking this.
+#[derive(Debug)]
+pub struct TwoPhase {
+    len: usize,
+    shstrtab_data: Vec<u8>,
+    strtab_data: Vec<u8>,
+    dynstr_data: Vec<u8>,
+}
+
+impl Mode for TwoPhase {}
+#[allow(private_interfaces)]
+impl ModeSealed for TwoPhase {
+    fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()> {
+        buffer
+            .reserve(self.len)
+            .map_err(|_| Error(String::from("Cannot allocate buffer")))
+    }
+
+    fn need_offset(offset: usize) -> bool {
+        offset != 0
+    }
+
+    fn set_offset(dest: &mut usize, offset: usize) {
+        debug_assert_eq!(*dest, offset);
+    }
+
+    fn set_size(dest: &mut usize, size: usize) {
+        debug_assert_eq!(*dest, size);
+    }
+
+    fn set_section_index(dest: &mut SectionIndex, index: SectionIndex) {
+        debug_assert_eq!(*dest, index);
+    }
+
+    fn set_section_name(
+        dest: &mut Option<StringId>,
+        shstrtab: &mut StringTable<'_>,
+        name: &'static [u8],
+    ) {
+        debug_assert_eq!(*dest, Some(shstrtab.get_id(name)));
+    }
+
+    fn set_count<T: Copy + PartialOrd>(dest: &mut T, count: T) {
+        debug_assert!(*dest >= count);
+    }
+}
+
+impl<'a> Writer<'a, TwoPhase> {
+    /// Create a new two-phase `Writer` for the given endianness and ELF class.
+    pub fn new(endian: Endianness, is_64: bool, buffer: &'a mut dyn WritableBuffer) -> Self {
+        let mode = TwoPhase {
+            len: 0,
+            shstrtab_data: Vec::new(),
+            strtab_data: Vec::new(),
+            dynstr_data: Vec::new(),
+        };
+        Writer::new_with_mode(endian, is_64, buffer, mode)
+    }
+
     /// Return the current file length that has been reserved.
     pub fn reserved_len(&self) -> usize {
-        self.len
+        self.mode.len
     }
 
     /// Reserve a file range with the given size and starting alignment.
@@ -1384,24 +1820,24 @@ impl<'a> Writer<'a> {
     /// `align_start` must be a power of two.
     pub fn reserve(&mut self, len: usize, align_start: usize) -> usize {
         if align_start > 1 {
-            self.len = util::align(self.len, align_start);
+            self.mode.len = util::align(self.mode.len, align_start);
         }
-        let offset = self.len;
-        self.len += len;
+        let offset = self.mode.len;
+        self.mode.len += len;
         offset
     }
 
     /// Reserve the file range up to the given file offset.
     pub fn reserve_until(&mut self, offset: usize) {
-        debug_assert!(self.len <= offset);
-        self.len = offset;
+        debug_assert!(self.mode.len <= offset);
+        self.mode.len = offset;
     }
 
     /// Reserve the range for the file header.
     ///
     /// This must be at the start of the file.
     pub fn reserve_file_header(&mut self) {
-        debug_assert_eq!(self.len, 0);
+        debug_assert_eq!(self.mode.len, 0);
         self.reserve(self.class().file_header_size(), 1);
     }
 
@@ -1410,12 +1846,12 @@ impl<'a> Writer<'a> {
     /// If `num` is >= `elf::PN_XNUM`, you must also reserve and write
     /// the section table; this is checked in `write_file_header`.
     pub fn reserve_program_headers(&mut self, num: u32) {
-        debug_assert_eq!(self.segment_offset, 0);
+        debug_assert_eq!(self.layout.segment_offset, 0);
         if num == 0 {
             return;
         }
-        self.segment_num = num;
-        self.segment_offset = self.reserve(
+        self.layout.segment_num = num;
+        self.layout.segment_offset = self.reserve(
             num as usize * self.class().program_header_size(),
             self.elf_align,
         );
@@ -1428,9 +1864,9 @@ impl<'a> Writer<'a> {
     ///
     /// This must be called before [`Self::reserve_section_headers`].
     pub fn reserve_null_section_index(&mut self) -> SectionIndex {
-        debug_assert_eq!(self.section_num, 0);
-        if self.section_num == 0 {
-            self.section_num = 1;
+        debug_assert_eq!(self.layout.section_num, 0);
+        if self.layout.section_num == 0 {
+            self.layout.section_num = 1;
         }
         SectionIndex(0)
     }
@@ -1441,12 +1877,12 @@ impl<'a> Writer<'a> {
     ///
     /// This must be called before [`Self::reserve_section_headers`].
     pub fn reserve_section_index(&mut self) -> SectionIndex {
-        debug_assert_eq!(self.section_offset, 0);
-        if self.section_num == 0 {
-            self.section_num = 1;
+        debug_assert_eq!(self.layout.section_offset, 0);
+        if self.layout.section_num == 0 {
+            self.layout.section_num = 1;
         }
-        let index = self.section_num;
-        self.section_num += 1;
+        let index = self.layout.section_num;
+        self.layout.section_num += 1;
         SectionIndex(index)
     }
 
@@ -1456,12 +1892,12 @@ impl<'a> Writer<'a> {
     /// This must be called after [`Self::reserve_section_index`]
     /// and other functions that reserve section indices.
     pub fn reserve_section_headers(&mut self) {
-        debug_assert_eq!(self.section_offset, 0);
-        if self.section_num == 0 {
+        debug_assert_eq!(self.layout.section_offset, 0);
+        if self.layout.section_num == 0 {
             return;
         }
-        self.section_offset = self.reserve(
-            self.section_num as usize * self.class().section_header_size(),
+        self.layout.section_offset = self.reserve(
+            self.layout.section_num as usize * self.class().section_header_size(),
             self.elf_align,
         );
     }
@@ -1477,13 +1913,13 @@ impl<'a> Writer<'a> {
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_shstrtab(&mut self) -> Result<()> {
         debug_assert_eq!(self.shstrtab_offset, 0);
-        if self.section_num == 0 {
+        if self.layout.section_num == 0 {
             return Ok(());
         }
         // Start with null section name.
-        self.shstrtab_data = vec![0];
-        self.shstrtab.write(1, &mut self.shstrtab_data)?;
-        self.shstrtab_offset = self.reserve(self.shstrtab_data.len(), 1);
+        self.mode.shstrtab_data = vec![0];
+        self.shstrtab_size = self.shstrtab.write(1, &mut self.mode.shstrtab_data)?;
+        self.shstrtab_offset = self.reserve(self.shstrtab_size as usize, 1);
         Ok(())
     }
 
@@ -1495,7 +1931,7 @@ impl<'a> Writer<'a> {
             return;
         }
         debug_assert_eq!(self.shstrtab_offset, self.buffer.len());
-        self.buffer.write_bytes(&self.shstrtab_data);
+        self.buffer.write_bytes(&self.mode.shstrtab_data);
     }
 
     /// Reserve the section index for the section header string table.
@@ -1511,15 +1947,15 @@ impl<'a> Writer<'a> {
     /// This must be called before [`Self::reserve_shstrtab`]
     /// and [`Self::reserve_section_headers`].
     pub fn reserve_shstrtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert_eq!(self.shstrtab_index, SectionIndex(0));
+        debug_assert_eq!(self.layout.shstrtab_index, SectionIndex(0));
         self.shstrtab_str_id = Some(self.add_section_name(name));
-        self.shstrtab_index = self.reserve_section_index();
-        self.shstrtab_index
+        self.layout.shstrtab_index = self.reserve_section_index();
+        self.layout.shstrtab_index
     }
 
     /// Return true if `.strtab` is needed.
     pub fn strtab_needed(&self) -> bool {
-        self.need_strtab
+        self.need_strtab || !self.strtab.is_empty()
     }
 
     /// Require the string table even if no strings were added.
@@ -1531,19 +1967,20 @@ impl<'a> Writer<'a> {
     ///
     /// This range is used for a section named `.strtab`.
     ///
-    /// This function does nothing if a string table is not required.
+    /// The range is only reserved if the string table is needed (either `require_strtab`
+    /// was called, or symbols or strings are present).
     /// This must be called after [`Self::add_string`].
     ///
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_strtab(&mut self) -> Result<()> {
         debug_assert_eq!(self.strtab_offset, 0);
-        if !self.need_strtab {
+        if !self.strtab_needed() {
             return Ok(());
         }
         // Start with null string.
-        self.strtab_data = vec![0];
-        self.strtab.write(1, &mut self.strtab_data)?;
-        self.strtab_offset = self.reserve(self.strtab_data.len(), 1);
+        self.mode.strtab_data = vec![0];
+        self.strtab_size = self.strtab.write(1, &mut self.mode.strtab_data)?;
+        self.strtab_offset = self.reserve(self.strtab_size as usize, 1);
         Ok(())
     }
 
@@ -1555,7 +1992,7 @@ impl<'a> Writer<'a> {
             return;
         }
         debug_assert_eq!(self.strtab_offset, self.buffer.len());
-        self.buffer.write_bytes(&self.strtab_data);
+        self.buffer.write_bytes(&self.mode.strtab_data);
     }
 
     /// Reserve the section index for the string table.
@@ -1693,7 +2130,7 @@ impl<'a> Writer<'a> {
     /// This must be called after [`Self::reserve_symbol_index`].
     pub fn reserve_symtab_shndx(&mut self) {
         debug_assert_eq!(self.symtab_shndx_offset, 0);
-        if !self.need_symtab_shndx {
+        if !self.symtab_shndx_needed() {
             return;
         }
         self.symtab_shndx_offset = self.reserve(self.symtab_num as usize * 4, ALIGN_SYMTAB_SHNDX);
@@ -1724,7 +2161,7 @@ impl<'a> Writer<'a> {
 
     /// Return true if `.dynstr` is needed.
     pub fn dynstr_needed(&self) -> bool {
-        self.need_dynstr
+        self.need_dynstr || !self.dynstr.is_empty()
     }
 
     /// Require the dynamic string table even if no strings were added.
@@ -1736,19 +2173,20 @@ impl<'a> Writer<'a> {
     ///
     /// This range is used for a section named `.dynstr`.
     ///
-    /// This function does nothing if no dynamic strings were defined.
+    /// The range is only reserved if the string table is needed (either `require_dynstr`
+    /// was called, or dynamic symbols or dynamic strings are present).
     /// This must be called after [`Self::add_dynamic_string`].
     ///
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_dynstr(&mut self) -> Result<usize> {
         debug_assert_eq!(self.dynstr_offset, 0);
-        if !self.need_dynstr {
+        if !self.dynstr_needed() {
             return Ok(0);
         }
         // Start with null string.
-        self.dynstr_data = vec![0];
-        self.dynstr.write(1, &mut self.dynstr_data)?;
-        self.dynstr_offset = self.reserve(self.dynstr_data.len(), 1);
+        self.mode.dynstr_data = vec![0];
+        self.dynstr_size = self.dynstr.write(1, &mut self.mode.dynstr_data)?;
+        self.dynstr_offset = self.reserve(self.dynstr_size as usize, 1);
         Ok(self.dynstr_offset)
     }
 
@@ -1757,7 +2195,7 @@ impl<'a> Writer<'a> {
     /// This must be called after [`Self::reserve_dynstr`].
     pub fn dynstr_len(&mut self) -> usize {
         debug_assert_ne!(self.dynstr_offset, 0);
-        self.dynstr_data.len()
+        self.mode.dynstr_data.len()
     }
 
     /// Write the dynamic string table.
@@ -1768,7 +2206,7 @@ impl<'a> Writer<'a> {
             return;
         }
         debug_assert_eq!(self.dynstr_offset, self.buffer.len());
-        self.buffer.write_bytes(&self.dynstr_data);
+        self.buffer.write_bytes(&self.mode.dynstr_data);
     }
 
     /// Reserve the section index for the dynamic string table.
@@ -1888,7 +2326,6 @@ impl<'a> Writer<'a> {
         if dynamic_num == 0 {
             return 0;
         }
-        self.dynamic_num = dynamic_num;
         self.dynamic_offset = self.reserve_dynamics(dynamic_num);
         self.dynamic_offset
     }
@@ -1897,6 +2334,7 @@ impl<'a> Writer<'a> {
     ///
     /// Returns the offset of the range.
     pub fn reserve_dynamics(&mut self, dynamic_num: usize) -> usize {
+        self.dynamic_num += dynamic_num;
         self.reserve(dynamic_num * self.class().dyn_size(), self.elf_align)
     }
 
@@ -1988,9 +2426,10 @@ impl<'a> Writer<'a> {
         if verdef_count == 0 {
             return 0;
         }
-        self.gnu_verdef_size = self.class().gnu_verdef_size(verdef_count, verdaux_count);
-        self.gnu_verdef_offset = self.reserve(self.gnu_verdef_size, ALIGN_GNU_VERDEF);
+        let size = self.class().gnu_verdef_size(verdef_count, verdaux_count);
+        self.gnu_verdef_offset = self.reserve(size, ALIGN_GNU_VERDEF);
         self.gnu_verdef_count = verdef_count as u16;
+        self.gnu_verdaux_count = verdaux_count;
         self.gnu_verdef_remaining = self.gnu_verdef_count;
         self.gnu_verdef_offset
     }
@@ -2013,9 +2452,10 @@ impl<'a> Writer<'a> {
         if verneed_count == 0 {
             return 0;
         }
-        self.gnu_verneed_size = self.class().gnu_verneed_size(verneed_count, vernaux_count);
-        self.gnu_verneed_offset = self.reserve(self.gnu_verneed_size, ALIGN_GNU_VERNEED);
+        let size = self.class().gnu_verneed_size(verneed_count, vernaux_count);
+        self.gnu_verneed_offset = self.reserve(size, ALIGN_GNU_VERNEED);
         self.gnu_verneed_count = verneed_count as u16;
+        self.gnu_vernaux_count = vernaux_count;
         self.gnu_verneed_remaining = self.gnu_verneed_count;
         self.gnu_verneed_offset
     }
@@ -2320,7 +2760,7 @@ impl Class {
 
 /// Native endian version of [`elf::FileHeader64`].
 #[allow(missing_docs)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FileHeader {
     pub os_abi: elf::OsAbi,
     pub abi_version: u8,
@@ -2328,6 +2768,15 @@ pub struct FileHeader {
     pub e_machine: elf::Machine,
     pub e_entry: u64,
     pub e_flags: elf::FileFlags,
+}
+
+#[derive(Debug, Clone, Default)]
+struct FileHeaderLayout {
+    segment_offset: usize,
+    segment_num: u32,
+    section_offset: usize,
+    section_num: u32,
+    shstrtab_index: SectionIndex,
 }
 
 /// Native endian version of [`elf::ProgramHeader64`].

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -222,29 +222,10 @@ impl<'a> Writer<'a> {
         Class { is_64: self.is_64 }
     }
 
-    /// Return the current file length that has been reserved.
-    pub fn reserved_len(&self) -> usize {
-        self.len
-    }
-
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.buffer.len()
-    }
-
-    /// Reserve a file range with the given size and starting alignment.
-    ///
-    /// Returns the aligned offset of the start of the range.
-    ///
-    /// `align_start` must be a power of two.
-    pub fn reserve(&mut self, len: usize, align_start: usize) -> usize {
-        if align_start > 1 {
-            self.len = util::align(self.len, align_start);
-        }
-        let offset = self.len;
-        self.len += len;
-        offset
     }
 
     /// Write alignment padding bytes.
@@ -261,24 +242,10 @@ impl<'a> Writer<'a> {
         self.buffer.write_bytes(data);
     }
 
-    /// Reserve the file range up to the given file offset.
-    pub fn reserve_until(&mut self, offset: usize) {
-        debug_assert!(self.len <= offset);
-        self.len = offset;
-    }
-
     /// Write padding up to the given file offset.
     pub fn pad_until(&mut self, offset: usize) {
         debug_assert!(self.buffer.len() <= offset);
         self.buffer.resize(offset);
-    }
-
-    /// Reserve the range for the file header.
-    ///
-    /// This must be at the start of the file.
-    pub fn reserve_file_header(&mut self) {
-        debug_assert_eq!(self.len, 0);
-        self.reserve(self.class().file_header_size(), 1);
     }
 
     /// Write the file header.
@@ -390,22 +357,6 @@ impl<'a> Writer<'a> {
         Ok(())
     }
 
-    /// Reserve the range for the program headers.
-    ///
-    /// If `num` is >= `elf::PN_XNUM`, you must also reserve and write
-    /// the section table; this is checked in `write_file_header`.
-    pub fn reserve_program_headers(&mut self, num: u32) {
-        debug_assert_eq!(self.segment_offset, 0);
-        if num == 0 {
-            return;
-        }
-        self.segment_num = num;
-        self.segment_offset = self.reserve(
-            num as usize * self.class().program_header_size(),
-            self.elf_align,
-        );
-    }
-
     /// Write alignment padding bytes prior to the program headers.
     pub fn write_align_program_headers(&mut self) {
         if self.segment_offset == 0 {
@@ -443,51 +394,6 @@ impl<'a> Writer<'a> {
             };
             self.buffer.write(&header);
         }
-    }
-
-    /// Reserve the section index for the null section header.
-    ///
-    /// The null section header is usually automatically reserved,
-    /// but this can be used to force an empty section table.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_null_section_index(&mut self) -> SectionIndex {
-        debug_assert_eq!(self.section_num, 0);
-        if self.section_num == 0 {
-            self.section_num = 1;
-        }
-        SectionIndex(0)
-    }
-
-    /// Reserve a section table index.
-    ///
-    /// Automatically also reserves the null section header if required.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_section_index(&mut self) -> SectionIndex {
-        debug_assert_eq!(self.section_offset, 0);
-        if self.section_num == 0 {
-            self.section_num = 1;
-        }
-        let index = self.section_num;
-        self.section_num += 1;
-        SectionIndex(index)
-    }
-
-    /// Reserve the range for the section headers.
-    ///
-    /// This function does nothing if no sections were reserved.
-    /// This must be called after [`Self::reserve_section_index`]
-    /// and other functions that reserve section indices.
-    pub fn reserve_section_headers(&mut self) {
-        debug_assert_eq!(self.section_offset, 0);
-        if self.section_num == 0 {
-            return;
-        }
-        self.section_offset = self.reserve(
-            self.section_num as usize * self.class().section_header_size(),
-            self.elf_align,
-        );
     }
 
     /// Write the null section header.
@@ -575,57 +481,6 @@ impl<'a> Writer<'a> {
         self.shstrtab.add(name)
     }
 
-    /// Reserve the range for the section header string table.
-    ///
-    /// This range is used for a section named `.shstrtab`.
-    ///
-    /// This function does nothing if no sections were reserved.
-    /// This must be called after [`Self::add_section_name`].
-    /// and other functions that reserve section names and indices.
-    ///
-    /// Returns an error if the string table could not be finalized.
-    pub fn reserve_shstrtab(&mut self) -> Result<()> {
-        debug_assert_eq!(self.shstrtab_offset, 0);
-        if self.section_num == 0 {
-            return Ok(());
-        }
-        // Start with null section name.
-        self.shstrtab_data = vec![0];
-        self.shstrtab.write(1, &mut self.shstrtab_data)?;
-        self.shstrtab_offset = self.reserve(self.shstrtab_data.len(), 1);
-        Ok(())
-    }
-
-    /// Write the section header string table.
-    ///
-    /// This function does nothing if the section was not reserved.
-    pub fn write_shstrtab(&mut self) {
-        if self.shstrtab_offset == 0 {
-            return;
-        }
-        debug_assert_eq!(self.shstrtab_offset, self.buffer.len());
-        self.buffer.write_bytes(&self.shstrtab_data);
-    }
-
-    /// Reserve the section index for the section header string table.
-    ///
-    /// This must be called before [`Self::reserve_shstrtab`]
-    /// and [`Self::reserve_section_headers`].
-    pub fn reserve_shstrtab_section_index(&mut self) -> SectionIndex {
-        self.reserve_shstrtab_section_index_with_name(&b".shstrtab"[..])
-    }
-
-    /// Reserve the section index for the section header string table.
-    ///
-    /// This must be called before [`Self::reserve_shstrtab`]
-    /// and [`Self::reserve_section_headers`].
-    pub fn reserve_shstrtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert_eq!(self.shstrtab_index, SectionIndex(0));
-        self.shstrtab_str_id = Some(self.add_section_name(name));
-        self.shstrtab_index = self.reserve_section_index();
-        self.shstrtab_index
-    }
-
     /// Write the section header for the section header string table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -658,70 +513,6 @@ impl<'a> Writer<'a> {
         self.strtab.add(name)
     }
 
-    /// Return true if `.strtab` is needed.
-    pub fn strtab_needed(&self) -> bool {
-        self.need_strtab
-    }
-
-    /// Require the string table even if no strings were added.
-    pub fn require_strtab(&mut self) {
-        self.need_strtab = true;
-    }
-
-    /// Reserve the range for the string table.
-    ///
-    /// This range is used for a section named `.strtab`.
-    ///
-    /// This function does nothing if a string table is not required.
-    /// This must be called after [`Self::add_string`].
-    ///
-    /// Returns an error if the string table could not be finalized.
-    pub fn reserve_strtab(&mut self) -> Result<()> {
-        debug_assert_eq!(self.strtab_offset, 0);
-        if !self.need_strtab {
-            return Ok(());
-        }
-        // Start with null string.
-        self.strtab_data = vec![0];
-        self.strtab.write(1, &mut self.strtab_data)?;
-        self.strtab_offset = self.reserve(self.strtab_data.len(), 1);
-        Ok(())
-    }
-
-    /// Write the string table.
-    ///
-    /// This function does nothing if the section was not reserved.
-    pub fn write_strtab(&mut self) {
-        if self.strtab_offset == 0 {
-            return;
-        }
-        debug_assert_eq!(self.strtab_offset, self.buffer.len());
-        self.buffer.write_bytes(&self.strtab_data);
-    }
-
-    /// Reserve the section index for the string table.
-    ///
-    /// You should check [`Self::strtab_needed`] before calling this
-    /// unless you have other means of knowing if this section is needed.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_strtab_section_index(&mut self) -> SectionIndex {
-        self.reserve_strtab_section_index_with_name(&b".strtab"[..])
-    }
-
-    /// Reserve the section index for the string table.
-    ///
-    /// You should check [`Self::strtab_needed`] before calling this
-    /// unless you have other means of knowing if this section is needed.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_strtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert_eq!(self.strtab_index, SectionIndex(0));
-        self.strtab_str_id = Some(self.add_section_name(name));
-        self.strtab_index = self.reserve_section_index();
-        self.strtab_index
-    }
-
     /// Write the section header for the string table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -741,76 +532,6 @@ impl<'a> Writer<'a> {
             sh_addralign: 1,
             sh_entsize: 0,
         });
-    }
-
-    /// Reserve the null symbol table entry.
-    ///
-    /// This will be stored in the `.symtab` section.
-    ///
-    /// The null symbol table entry is usually automatically reserved,
-    /// but this can be used to force an empty symbol table.
-    ///
-    /// This must be called before [`Self::reserve_symtab`].
-    pub fn reserve_null_symbol_index(&mut self) -> SymbolIndex {
-        debug_assert_eq!(self.symtab_offset, 0);
-        debug_assert_eq!(self.symtab_num, 0);
-        self.symtab_num = 1;
-        // The symtab must link to a strtab.
-        self.need_strtab = true;
-        SymbolIndex(0)
-    }
-
-    /// Reserve a symbol table entry.
-    ///
-    /// This will be stored in the `.symtab` section.
-    ///
-    /// `section_index` is used to determine whether `.symtab_shndx` is required.
-    ///
-    /// Automatically also reserves the null symbol if required.
-    /// Callers may assume that the returned indices will be sequential
-    /// starting at 1.
-    ///
-    /// This must be called before [`Self::reserve_symtab`] and
-    /// [`Self::reserve_symtab_shndx`].
-    pub fn reserve_symbol_index(&mut self, section_index: Option<SectionIndex>) -> SymbolIndex {
-        debug_assert_eq!(self.symtab_offset, 0);
-        debug_assert_eq!(self.symtab_shndx_offset, 0);
-        if self.symtab_num == 0 {
-            self.symtab_num = 1;
-            // The symtab must link to a strtab.
-            self.need_strtab = true;
-        }
-        let index = self.symtab_num;
-        self.symtab_num += 1;
-        if let Some(section_index) = section_index {
-            if section_index.0 >= elf::SHN_LORESERVE.into() {
-                self.need_symtab_shndx = true;
-            }
-        }
-        SymbolIndex(index)
-    }
-
-    /// Return the number of reserved symbol table entries.
-    ///
-    /// Includes the null symbol.
-    pub fn symbol_count(&self) -> u32 {
-        self.symtab_num
-    }
-
-    /// Reserve the range for the symbol table.
-    ///
-    /// This range is used for a section named `.symtab`.
-    /// This function does nothing if no symbols were reserved.
-    /// This must be called after [`Self::reserve_symbol_index`].
-    pub fn reserve_symtab(&mut self) {
-        debug_assert_eq!(self.symtab_offset, 0);
-        if self.symtab_num == 0 {
-            return;
-        }
-        self.symtab_offset = self.reserve(
-            self.symtab_num as usize * self.class().sym_size(),
-            self.elf_align,
-        );
     }
 
     /// Write the null symbol.
@@ -882,28 +603,6 @@ impl<'a> Writer<'a> {
         }
     }
 
-    /// Reserve the section index for the symbol table.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_symtab_section_index(&mut self) -> SectionIndex {
-        self.reserve_symtab_section_index_with_name(&b".symtab"[..])
-    }
-
-    /// Reserve the section index for the symbol table.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_symtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert_eq!(self.symtab_index, SectionIndex(0));
-        self.symtab_str_id = Some(self.add_section_name(name));
-        self.symtab_index = self.reserve_section_index();
-        self.symtab_index
-    }
-
-    /// Return the section index of the symbol table.
-    pub fn symtab_index(&mut self) -> SectionIndex {
-        self.symtab_index
-    }
-
     /// Write the section header for the symbol table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -925,33 +624,6 @@ impl<'a> Writer<'a> {
         });
     }
 
-    /// Return true if `.symtab_shndx` is needed.
-    pub fn symtab_shndx_needed(&self) -> bool {
-        self.need_symtab_shndx
-    }
-
-    /// Require the extended section indices for the symbol table even
-    /// if no section indices are too large.
-    pub fn require_symtab_shndx(&mut self) {
-        self.need_symtab_shndx = true;
-    }
-
-    /// Reserve the range for the extended section indices for the symbol table.
-    ///
-    /// This range is used for a section named `.symtab_shndx`.
-    /// This also reserves a section index.
-    ///
-    /// This function does nothing if extended section indices are not needed.
-    /// This must be called after [`Self::reserve_symbol_index`].
-    pub fn reserve_symtab_shndx(&mut self) {
-        debug_assert_eq!(self.symtab_shndx_offset, 0);
-        if !self.need_symtab_shndx {
-            return;
-        }
-        self.symtab_shndx_offset = self.reserve(self.symtab_num as usize * 4, ALIGN_SYMTAB_SHNDX);
-        self.symtab_shndx_data.reserve(self.symtab_num as usize * 4);
-    }
-
     /// Write the extended section indices for the symbol table.
     ///
     /// This function does nothing if the section was not reserved.
@@ -963,28 +635,6 @@ impl<'a> Writer<'a> {
         debug_assert_eq!(self.symtab_shndx_offset, self.buffer.len());
         debug_assert_eq!(self.symtab_num as usize * 4, self.symtab_shndx_data.len());
         self.buffer.write_bytes(&self.symtab_shndx_data);
-    }
-
-    /// Reserve the section index for the extended section indices symbol table.
-    ///
-    /// You should check [`Self::symtab_shndx_needed`] before calling this
-    /// unless you have other means of knowing if this section is needed.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_symtab_shndx_section_index(&mut self) -> SectionIndex {
-        self.reserve_symtab_shndx_section_index_with_name(&b".symtab_shndx"[..])
-    }
-
-    /// Reserve the section index for the extended section indices symbol table.
-    ///
-    /// You should check [`Self::symtab_shndx_needed`] before calling this
-    /// unless you have other means of knowing if this section is needed.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_symtab_shndx_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert!(self.symtab_shndx_str_id.is_none());
-        self.symtab_shndx_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
     }
 
     /// Write the section header for the extended section indices for the symbol table.
@@ -1031,83 +681,6 @@ impl<'a> Writer<'a> {
         self.dynstr.get_id(name)
     }
 
-    /// Return true if `.dynstr` is needed.
-    pub fn dynstr_needed(&self) -> bool {
-        self.need_dynstr
-    }
-
-    /// Require the dynamic string table even if no strings were added.
-    pub fn require_dynstr(&mut self) {
-        self.need_dynstr = true;
-    }
-
-    /// Reserve the range for the dynamic string table.
-    ///
-    /// This range is used for a section named `.dynstr`.
-    ///
-    /// This function does nothing if no dynamic strings were defined.
-    /// This must be called after [`Self::add_dynamic_string`].
-    ///
-    /// Returns an error if the string table could not be finalized.
-    pub fn reserve_dynstr(&mut self) -> Result<usize> {
-        debug_assert_eq!(self.dynstr_offset, 0);
-        if !self.need_dynstr {
-            return Ok(0);
-        }
-        // Start with null string.
-        self.dynstr_data = vec![0];
-        self.dynstr.write(1, &mut self.dynstr_data)?;
-        self.dynstr_offset = self.reserve(self.dynstr_data.len(), 1);
-        Ok(self.dynstr_offset)
-    }
-
-    /// Return the size of the dynamic string table.
-    ///
-    /// This must be called after [`Self::reserve_dynstr`].
-    pub fn dynstr_len(&mut self) -> usize {
-        debug_assert_ne!(self.dynstr_offset, 0);
-        self.dynstr_data.len()
-    }
-
-    /// Write the dynamic string table.
-    ///
-    /// This function does nothing if the section was not reserved.
-    pub fn write_dynstr(&mut self) {
-        if self.dynstr_offset == 0 {
-            return;
-        }
-        debug_assert_eq!(self.dynstr_offset, self.buffer.len());
-        self.buffer.write_bytes(&self.dynstr_data);
-    }
-
-    /// Reserve the section index for the dynamic string table.
-    ///
-    /// You should check [`Self::dynstr_needed`] before calling this
-    /// unless you have other means of knowing if this section is needed.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_dynstr_section_index(&mut self) -> SectionIndex {
-        self.reserve_dynstr_section_index_with_name(&b".dynstr"[..])
-    }
-
-    /// Reserve the section index for the dynamic string table.
-    ///
-    /// You should check [`Self::dynstr_needed`] before calling this
-    /// unless you have other means of knowing if this section is needed.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_dynstr_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert_eq!(self.dynstr_index, SectionIndex(0));
-        self.dynstr_str_id = Some(self.add_section_name(name));
-        self.dynstr_index = self.reserve_section_index();
-        self.dynstr_index
-    }
-
-    /// Return the section index of the dynamic string table.
-    pub fn dynstr_index(&mut self) -> SectionIndex {
-        self.dynstr_index
-    }
-
     /// Write the section header for the dynamic string table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1127,65 +700,6 @@ impl<'a> Writer<'a> {
             sh_addralign: 1,
             sh_entsize: 0,
         });
-    }
-
-    /// Reserve the null dynamic symbol table entry.
-    ///
-    /// This will be stored in the `.dynsym` section.
-    ///
-    /// The null dynamic symbol table entry is usually automatically reserved,
-    /// but this can be used to force an empty dynamic symbol table.
-    ///
-    /// This must be called before [`Self::reserve_dynsym`].
-    pub fn reserve_null_dynamic_symbol_index(&mut self) -> SymbolIndex {
-        debug_assert_eq!(self.dynsym_offset, 0);
-        debug_assert_eq!(self.dynsym_num, 0);
-        self.dynsym_num = 1;
-        SymbolIndex(0)
-    }
-
-    /// Reserve a dynamic symbol table entry.
-    ///
-    /// This will be stored in the `.dynsym` section.
-    ///
-    /// Automatically also reserves the null symbol if required.
-    /// Callers may assume that the returned indices will be sequential
-    /// starting at 1.
-    ///
-    /// This must be called before [`Self::reserve_dynsym`].
-    pub fn reserve_dynamic_symbol_index(&mut self) -> SymbolIndex {
-        debug_assert_eq!(self.dynsym_offset, 0);
-        if self.dynsym_num == 0 {
-            self.dynsym_num = 1;
-        }
-        let index = self.dynsym_num;
-        self.dynsym_num += 1;
-        SymbolIndex(index)
-    }
-
-    /// Return the number of reserved dynamic symbols.
-    ///
-    /// Includes the null symbol.
-    pub fn dynamic_symbol_count(&mut self) -> u32 {
-        self.dynsym_num
-    }
-
-    /// Reserve the range for the dynamic symbol table.
-    ///
-    /// This range is used for a section named `.dynsym`.
-    ///
-    /// This function does nothing if no dynamic symbols were reserved.
-    /// This must be called after [`Self::reserve_dynamic_symbol_index`].
-    pub fn reserve_dynsym(&mut self) -> usize {
-        debug_assert_eq!(self.dynsym_offset, 0);
-        if self.dynsym_num == 0 {
-            return 0;
-        }
-        self.dynsym_offset = self.reserve(
-            self.dynsym_num as usize * self.class().sym_size(),
-            self.elf_align,
-        );
-        self.dynsym_offset
     }
 
     /// Write the null dynamic symbol.
@@ -1245,28 +759,6 @@ impl<'a> Writer<'a> {
         }
     }
 
-    /// Reserve the section index for the dynamic symbol table.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_dynsym_section_index(&mut self) -> SectionIndex {
-        self.reserve_dynsym_section_index_with_name(&b".dynsym"[..])
-    }
-
-    /// Reserve the section index for the dynamic symbol table.
-    ///
-    /// This must be called before [`Self::reserve_section_headers`].
-    pub fn reserve_dynsym_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert_eq!(self.dynsym_index, SectionIndex(0));
-        self.dynsym_str_id = Some(self.add_section_name(name));
-        self.dynsym_index = self.reserve_section_index();
-        self.dynsym_index
-    }
-
-    /// Return the section index of the dynamic symbol table.
-    pub fn dynsym_index(&mut self) -> SectionIndex {
-        self.dynsym_index
-    }
-
     /// Write the section header for the dynamic symbol table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1288,19 +780,6 @@ impl<'a> Writer<'a> {
         });
     }
 
-    /// Reserve the range for the `.dynamic` section.
-    ///
-    /// This function does nothing if `dynamic_num` is zero.
-    pub fn reserve_dynamic(&mut self, dynamic_num: usize) -> usize {
-        debug_assert_eq!(self.dynamic_offset, 0);
-        if dynamic_num == 0 {
-            return 0;
-        }
-        self.dynamic_num = dynamic_num;
-        self.dynamic_offset = self.reserve_dynamics(dynamic_num);
-        self.dynamic_offset
-    }
-
     /// Write alignment padding bytes prior to the `.dynamic` section.
     ///
     /// This function does nothing if the section was not reserved.
@@ -1310,13 +789,6 @@ impl<'a> Writer<'a> {
         }
         util::write_align(self.buffer, self.elf_align);
         debug_assert_eq!(self.dynamic_offset, self.buffer.len());
-    }
-
-    /// Reserve a file range for the given number of dynamic entries.
-    ///
-    /// Returns the offset of the range.
-    pub fn reserve_dynamics(&mut self, dynamic_num: usize) -> usize {
-        self.reserve(dynamic_num * self.class().dyn_size(), self.elf_align)
     }
 
     /// Write a dynamic string entry.
@@ -1348,13 +820,6 @@ impl<'a> Writer<'a> {
         Ok(())
     }
 
-    /// Reserve the section index for the dynamic table.
-    pub fn reserve_dynamic_section_index(&mut self) -> SectionIndex {
-        debug_assert!(self.dynamic_str_id.is_none());
-        self.dynamic_str_id = Some(self.add_section_name(&b".dynamic"[..]));
-        self.reserve_section_index()
-    }
-
     /// Write the section header for the dynamic table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1374,16 +839,6 @@ impl<'a> Writer<'a> {
             sh_addralign: self.elf_align as u64,
             sh_entsize: self.class().dyn_size() as u64,
         });
-    }
-
-    /// Reserve a file range for a SysV hash section.
-    ///
-    /// `symbol_count` is the number of symbols in the hash,
-    /// not the total number of symbols.
-    pub fn reserve_hash(&mut self, bucket_count: u32, chain_count: u32) -> usize {
-        self.hash_size = self.class().hash_size(bucket_count, chain_count);
-        self.hash_offset = self.reserve(self.hash_size, ALIGN_HASH);
-        self.hash_offset
     }
 
     /// Write a SysV hash section.
@@ -1414,18 +869,6 @@ impl<'a> Writer<'a> {
         self.buffer.write_slice(&chains);
     }
 
-    /// Reserve the section index for the SysV hash table.
-    pub fn reserve_hash_section_index(&mut self) -> SectionIndex {
-        self.reserve_hash_section_index_with_name(&b".hash"[..])
-    }
-
-    /// Reserve the section index for the SysV hash table.
-    pub fn reserve_hash_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert!(self.hash_str_id.is_none());
-        self.hash_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
-    }
-
     /// Write the section header for the SysV hash table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1445,23 +888,6 @@ impl<'a> Writer<'a> {
             sh_addralign: ALIGN_HASH as u64,
             sh_entsize: 4,
         });
-    }
-
-    /// Reserve a file range for a GNU hash section.
-    ///
-    /// `symbol_count` is the number of symbols in the hash,
-    /// not the total number of symbols.
-    pub fn reserve_gnu_hash(
-        &mut self,
-        bloom_count: u32,
-        bucket_count: u32,
-        symbol_count: u32,
-    ) -> usize {
-        self.gnu_hash_size = self
-            .class()
-            .gnu_hash_size(bloom_count, bucket_count, symbol_count);
-        self.gnu_hash_offset = self.reserve(self.gnu_hash_size, self.elf_align);
-        self.gnu_hash_offset
     }
 
     /// Write a GNU hash section.
@@ -1545,18 +971,6 @@ impl<'a> Writer<'a> {
         }
     }
 
-    /// Reserve the section index for the GNU hash table.
-    pub fn reserve_gnu_hash_section_index(&mut self) -> SectionIndex {
-        self.reserve_gnu_hash_section_index_with_name(&b".gnu.hash"[..])
-    }
-
-    /// Reserve the section index for the GNU hash table.
-    pub fn reserve_gnu_hash_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert!(self.gnu_hash_str_id.is_none());
-        self.gnu_hash_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
-    }
-
     /// Write the section header for the GNU hash table.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1578,18 +992,6 @@ impl<'a> Writer<'a> {
         });
     }
 
-    /// Reserve the range for the `.gnu.version` section.
-    ///
-    /// This function does nothing if no dynamic symbols were reserved.
-    pub fn reserve_gnu_versym(&mut self) -> usize {
-        debug_assert_eq!(self.gnu_versym_offset, 0);
-        if self.dynsym_num == 0 {
-            return 0;
-        }
-        self.gnu_versym_offset = self.reserve(self.dynsym_num as usize * 2, ALIGN_GNU_VERSYM);
-        self.gnu_versym_offset
-    }
-
     /// Write the null symbol version entry.
     ///
     /// This must be the first symbol version that is written.
@@ -1606,18 +1008,6 @@ impl<'a> Writer<'a> {
     /// Write a symbol version entry.
     pub fn write_gnu_versym(&mut self, versym: elf::VersymIndex) {
         self.buffer.write(&U16::new(self.endian, versym));
-    }
-
-    /// Reserve the section index for the `.gnu.version` section.
-    pub fn reserve_gnu_versym_section_index(&mut self) -> SectionIndex {
-        self.reserve_gnu_versym_section_index_with_name(&b".gnu.version"[..])
-    }
-
-    /// Reserve the section index for the `.gnu.version` section.
-    pub fn reserve_gnu_versym_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert!(self.gnu_versym_str_id.is_none());
-        self.gnu_versym_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
     }
 
     /// Write the section header for the `.gnu.version` section.
@@ -1639,19 +1029,6 @@ impl<'a> Writer<'a> {
             sh_addralign: ALIGN_GNU_VERSYM as u64,
             sh_entsize: 2,
         });
-    }
-
-    /// Reserve the range for the `.gnu.version_d` section.
-    pub fn reserve_gnu_verdef(&mut self, verdef_count: usize, verdaux_count: usize) -> usize {
-        debug_assert_eq!(self.gnu_verdef_offset, 0);
-        if verdef_count == 0 {
-            return 0;
-        }
-        self.gnu_verdef_size = self.class().gnu_verdef_size(verdef_count, verdaux_count);
-        self.gnu_verdef_offset = self.reserve(self.gnu_verdef_size, ALIGN_GNU_VERDEF);
-        self.gnu_verdef_count = verdef_count as u16;
-        self.gnu_verdef_remaining = self.gnu_verdef_count;
-        self.gnu_verdef_offset
     }
 
     /// Write alignment padding bytes prior to a `.gnu.version_d` section.
@@ -1730,18 +1107,6 @@ impl<'a> Writer<'a> {
         });
     }
 
-    /// Reserve the section index for the `.gnu.version_d` section.
-    pub fn reserve_gnu_verdef_section_index(&mut self) -> SectionIndex {
-        self.reserve_gnu_verdef_section_index_with_name(&b".gnu.version_d"[..])
-    }
-
-    /// Reserve the section index for the `.gnu.version_d` section.
-    pub fn reserve_gnu_verdef_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert!(self.gnu_verdef_str_id.is_none());
-        self.gnu_verdef_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
-    }
-
     /// Write the section header for the `.gnu.version_d` section.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1761,19 +1126,6 @@ impl<'a> Writer<'a> {
             sh_addralign: ALIGN_GNU_VERDEF as u64,
             sh_entsize: 0,
         });
-    }
-
-    /// Reserve the range for the `.gnu.version_r` section.
-    pub fn reserve_gnu_verneed(&mut self, verneed_count: usize, vernaux_count: usize) -> usize {
-        debug_assert_eq!(self.gnu_verneed_offset, 0);
-        if verneed_count == 0 {
-            return 0;
-        }
-        self.gnu_verneed_size = self.class().gnu_verneed_size(verneed_count, vernaux_count);
-        self.gnu_verneed_offset = self.reserve(self.gnu_verneed_size, ALIGN_GNU_VERNEED);
-        self.gnu_verneed_count = verneed_count as u16;
-        self.gnu_verneed_remaining = self.gnu_verneed_count;
-        self.gnu_verneed_offset
     }
 
     /// Write alignment padding bytes prior to a `.gnu.version_r` section.
@@ -1830,18 +1182,6 @@ impl<'a> Writer<'a> {
         });
     }
 
-    /// Reserve the section index for the `.gnu.version_r` section.
-    pub fn reserve_gnu_verneed_section_index(&mut self) -> SectionIndex {
-        self.reserve_gnu_verneed_section_index_with_name(&b".gnu.version_r"[..])
-    }
-
-    /// Reserve the section index for the `.gnu.version_r` section.
-    pub fn reserve_gnu_verneed_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
-        debug_assert!(self.gnu_verneed_str_id.is_none());
-        self.gnu_verneed_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
-    }
-
     /// Write the section header for the `.gnu.version_r` section.
     ///
     /// This function does nothing if the section index was not reserved.
@@ -1861,32 +1201,6 @@ impl<'a> Writer<'a> {
             sh_addralign: ALIGN_GNU_VERNEED as u64,
             sh_entsize: 0,
         });
-    }
-
-    /// Reserve the section index for the `.gnu.attributes` section.
-    pub fn reserve_gnu_attributes_section_index(&mut self) -> SectionIndex {
-        self.reserve_gnu_attributes_section_index_with_name(&b".gnu.attributes"[..])
-    }
-
-    /// Reserve the section index for the `.gnu.attributes` section.
-    pub fn reserve_gnu_attributes_section_index_with_name(
-        &mut self,
-        name: &'a [u8],
-    ) -> SectionIndex {
-        debug_assert!(self.gnu_attributes_str_id.is_none());
-        self.gnu_attributes_str_id = Some(self.add_section_name(name));
-        self.reserve_section_index()
-    }
-
-    /// Reserve the range for the `.gnu.attributes` section.
-    pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: usize) -> usize {
-        debug_assert_eq!(self.gnu_attributes_offset, 0);
-        if gnu_attributes_size == 0 {
-            return 0;
-        }
-        self.gnu_attributes_size = gnu_attributes_size;
-        self.gnu_attributes_offset = self.reserve(self.gnu_attributes_size, self.elf_align);
-        self.gnu_attributes_offset
     }
 
     /// Write the section header for the `.gnu.attributes` section.
@@ -1918,13 +1232,6 @@ impl<'a> Writer<'a> {
         util::write_align(self.buffer, self.elf_align);
         debug_assert_eq!(self.gnu_attributes_offset, self.buffer.len());
         self.buffer.write_bytes(data);
-    }
-
-    /// Reserve a file range for the given number of relocations.
-    ///
-    /// Returns the offset of the range.
-    pub fn reserve_relocations(&mut self, count: usize, is_rela: bool) -> usize {
-        self.reserve(count * self.class().rel_size(is_rela), self.elf_align)
     }
 
     /// Write alignment padding bytes prior to a relocation section.
@@ -2024,15 +1331,6 @@ impl<'a> Writer<'a> {
         });
     }
 
-    /// Reserve a file range for a COMDAT section.
-    ///
-    /// `count` is the number of sections in the COMDAT group.
-    ///
-    /// Returns the offset of the range.
-    pub fn reserve_comdat(&mut self, count: usize) -> usize {
-        self.reserve((count + 1) * 4, 4)
-    }
-
     /// Write `GRP_COMDAT` at the start of the COMDAT section.
     pub fn write_comdat_header(&mut self) {
         util::write_align(self.buffer, 4);
@@ -2070,6 +1368,710 @@ impl<'a> Writer<'a> {
     /// Return a helper for writing an attributes section.
     pub fn attributes_writer(&self) -> AttributesWriter {
         AttributesWriter::new(self.endian)
+    }
+}
+
+impl<'a> Writer<'a> {
+    /// Return the current file length that has been reserved.
+    pub fn reserved_len(&self) -> usize {
+        self.len
+    }
+
+    /// Reserve a file range with the given size and starting alignment.
+    ///
+    /// Returns the aligned offset of the start of the range.
+    ///
+    /// `align_start` must be a power of two.
+    pub fn reserve(&mut self, len: usize, align_start: usize) -> usize {
+        if align_start > 1 {
+            self.len = util::align(self.len, align_start);
+        }
+        let offset = self.len;
+        self.len += len;
+        offset
+    }
+
+    /// Reserve the file range up to the given file offset.
+    pub fn reserve_until(&mut self, offset: usize) {
+        debug_assert!(self.len <= offset);
+        self.len = offset;
+    }
+
+    /// Reserve the range for the file header.
+    ///
+    /// This must be at the start of the file.
+    pub fn reserve_file_header(&mut self) {
+        debug_assert_eq!(self.len, 0);
+        self.reserve(self.class().file_header_size(), 1);
+    }
+
+    /// Reserve the range for the program headers.
+    ///
+    /// If `num` is >= `elf::PN_XNUM`, you must also reserve and write
+    /// the section table; this is checked in `write_file_header`.
+    pub fn reserve_program_headers(&mut self, num: u32) {
+        debug_assert_eq!(self.segment_offset, 0);
+        if num == 0 {
+            return;
+        }
+        self.segment_num = num;
+        self.segment_offset = self.reserve(
+            num as usize * self.class().program_header_size(),
+            self.elf_align,
+        );
+    }
+
+    /// Reserve the section index for the null section header.
+    ///
+    /// The null section header is usually automatically reserved,
+    /// but this can be used to force an empty section table.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_null_section_index(&mut self) -> SectionIndex {
+        debug_assert_eq!(self.section_num, 0);
+        if self.section_num == 0 {
+            self.section_num = 1;
+        }
+        SectionIndex(0)
+    }
+
+    /// Reserve a section table index.
+    ///
+    /// Automatically also reserves the null section header if required.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_section_index(&mut self) -> SectionIndex {
+        debug_assert_eq!(self.section_offset, 0);
+        if self.section_num == 0 {
+            self.section_num = 1;
+        }
+        let index = self.section_num;
+        self.section_num += 1;
+        SectionIndex(index)
+    }
+
+    /// Reserve the range for the section headers.
+    ///
+    /// This function does nothing if no sections were reserved.
+    /// This must be called after [`Self::reserve_section_index`]
+    /// and other functions that reserve section indices.
+    pub fn reserve_section_headers(&mut self) {
+        debug_assert_eq!(self.section_offset, 0);
+        if self.section_num == 0 {
+            return;
+        }
+        self.section_offset = self.reserve(
+            self.section_num as usize * self.class().section_header_size(),
+            self.elf_align,
+        );
+    }
+
+    /// Reserve the range for the section header string table.
+    ///
+    /// This range is used for a section named `.shstrtab`.
+    ///
+    /// This function does nothing if no sections were reserved.
+    /// This must be called after [`Self::add_section_name`].
+    /// and other functions that reserve section names and indices.
+    ///
+    /// Returns an error if the string table could not be finalized.
+    pub fn reserve_shstrtab(&mut self) -> Result<()> {
+        debug_assert_eq!(self.shstrtab_offset, 0);
+        if self.section_num == 0 {
+            return Ok(());
+        }
+        // Start with null section name.
+        self.shstrtab_data = vec![0];
+        self.shstrtab.write(1, &mut self.shstrtab_data)?;
+        self.shstrtab_offset = self.reserve(self.shstrtab_data.len(), 1);
+        Ok(())
+    }
+
+    /// Write the section header string table.
+    ///
+    /// This function does nothing if the section was not reserved.
+    pub fn write_shstrtab(&mut self) {
+        if self.shstrtab_offset == 0 {
+            return;
+        }
+        debug_assert_eq!(self.shstrtab_offset, self.buffer.len());
+        self.buffer.write_bytes(&self.shstrtab_data);
+    }
+
+    /// Reserve the section index for the section header string table.
+    ///
+    /// This must be called before [`Self::reserve_shstrtab`]
+    /// and [`Self::reserve_section_headers`].
+    pub fn reserve_shstrtab_section_index(&mut self) -> SectionIndex {
+        self.reserve_shstrtab_section_index_with_name(&b".shstrtab"[..])
+    }
+
+    /// Reserve the section index for the section header string table.
+    ///
+    /// This must be called before [`Self::reserve_shstrtab`]
+    /// and [`Self::reserve_section_headers`].
+    pub fn reserve_shstrtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert_eq!(self.shstrtab_index, SectionIndex(0));
+        self.shstrtab_str_id = Some(self.add_section_name(name));
+        self.shstrtab_index = self.reserve_section_index();
+        self.shstrtab_index
+    }
+
+    /// Return true if `.strtab` is needed.
+    pub fn strtab_needed(&self) -> bool {
+        self.need_strtab
+    }
+
+    /// Require the string table even if no strings were added.
+    pub fn require_strtab(&mut self) {
+        self.need_strtab = true;
+    }
+
+    /// Reserve the range for the string table.
+    ///
+    /// This range is used for a section named `.strtab`.
+    ///
+    /// This function does nothing if a string table is not required.
+    /// This must be called after [`Self::add_string`].
+    ///
+    /// Returns an error if the string table could not be finalized.
+    pub fn reserve_strtab(&mut self) -> Result<()> {
+        debug_assert_eq!(self.strtab_offset, 0);
+        if !self.need_strtab {
+            return Ok(());
+        }
+        // Start with null string.
+        self.strtab_data = vec![0];
+        self.strtab.write(1, &mut self.strtab_data)?;
+        self.strtab_offset = self.reserve(self.strtab_data.len(), 1);
+        Ok(())
+    }
+
+    /// Write the string table.
+    ///
+    /// This function does nothing if the section was not reserved.
+    pub fn write_strtab(&mut self) {
+        if self.strtab_offset == 0 {
+            return;
+        }
+        debug_assert_eq!(self.strtab_offset, self.buffer.len());
+        self.buffer.write_bytes(&self.strtab_data);
+    }
+
+    /// Reserve the section index for the string table.
+    ///
+    /// You should check [`Self::strtab_needed`] before calling this
+    /// unless you have other means of knowing if this section is needed.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_strtab_section_index(&mut self) -> SectionIndex {
+        self.reserve_strtab_section_index_with_name(&b".strtab"[..])
+    }
+
+    /// Reserve the section index for the string table.
+    ///
+    /// You should check [`Self::strtab_needed`] before calling this
+    /// unless you have other means of knowing if this section is needed.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_strtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert_eq!(self.strtab_index, SectionIndex(0));
+        self.strtab_str_id = Some(self.add_section_name(name));
+        self.strtab_index = self.reserve_section_index();
+        self.strtab_index
+    }
+
+    /// Reserve the null symbol table entry.
+    ///
+    /// This will be stored in the `.symtab` section.
+    ///
+    /// The null symbol table entry is usually automatically reserved,
+    /// but this can be used to force an empty symbol table.
+    ///
+    /// This must be called before [`Self::reserve_symtab`].
+    pub fn reserve_null_symbol_index(&mut self) -> SymbolIndex {
+        debug_assert_eq!(self.symtab_offset, 0);
+        debug_assert_eq!(self.symtab_num, 0);
+        self.symtab_num = 1;
+        // The symtab must link to a strtab.
+        self.need_strtab = true;
+        SymbolIndex(0)
+    }
+
+    /// Reserve a symbol table entry.
+    ///
+    /// This will be stored in the `.symtab` section.
+    ///
+    /// `section_index` is used to determine whether `.symtab_shndx` is required.
+    ///
+    /// Automatically also reserves the null symbol if required.
+    /// Callers may assume that the returned indices will be sequential
+    /// starting at 1.
+    ///
+    /// This must be called before [`Self::reserve_symtab`] and
+    /// [`Self::reserve_symtab_shndx`].
+    pub fn reserve_symbol_index(&mut self, section_index: Option<SectionIndex>) -> SymbolIndex {
+        debug_assert_eq!(self.symtab_offset, 0);
+        debug_assert_eq!(self.symtab_shndx_offset, 0);
+        if self.symtab_num == 0 {
+            self.symtab_num = 1;
+            // The symtab must link to a strtab.
+            self.need_strtab = true;
+        }
+        let index = self.symtab_num;
+        self.symtab_num += 1;
+        if let Some(section_index) = section_index {
+            if section_index.0 >= elf::SHN_LORESERVE.into() {
+                self.need_symtab_shndx = true;
+            }
+        }
+        SymbolIndex(index)
+    }
+
+    /// Return the number of reserved symbol table entries.
+    ///
+    /// Includes the null symbol.
+    pub fn symbol_count(&self) -> u32 {
+        self.symtab_num
+    }
+
+    /// Reserve the range for the symbol table.
+    ///
+    /// This range is used for a section named `.symtab`.
+    /// This function does nothing if no symbols were reserved.
+    /// This must be called after [`Self::reserve_symbol_index`].
+    pub fn reserve_symtab(&mut self) {
+        debug_assert_eq!(self.symtab_offset, 0);
+        if self.symtab_num == 0 {
+            return;
+        }
+        self.symtab_offset = self.reserve(
+            self.symtab_num as usize * self.class().sym_size(),
+            self.elf_align,
+        );
+    }
+
+    /// Reserve the section index for the symbol table.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_symtab_section_index(&mut self) -> SectionIndex {
+        self.reserve_symtab_section_index_with_name(&b".symtab"[..])
+    }
+
+    /// Reserve the section index for the symbol table.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_symtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert_eq!(self.symtab_index, SectionIndex(0));
+        self.symtab_str_id = Some(self.add_section_name(name));
+        self.symtab_index = self.reserve_section_index();
+        self.symtab_index
+    }
+
+    /// Return the section index of the symbol table.
+    pub fn symtab_index(&mut self) -> SectionIndex {
+        self.symtab_index
+    }
+
+    /// Return true if `.symtab_shndx` is needed.
+    pub fn symtab_shndx_needed(&self) -> bool {
+        self.need_symtab_shndx
+    }
+
+    /// Require the extended section indices for the symbol table even
+    /// if no section indices are too large.
+    pub fn require_symtab_shndx(&mut self) {
+        self.need_symtab_shndx = true;
+    }
+
+    /// Reserve the range for the extended section indices for the symbol table.
+    ///
+    /// This range is used for a section named `.symtab_shndx`.
+    /// This also reserves a section index.
+    ///
+    /// This function does nothing if extended section indices are not needed.
+    /// This must be called after [`Self::reserve_symbol_index`].
+    pub fn reserve_symtab_shndx(&mut self) {
+        debug_assert_eq!(self.symtab_shndx_offset, 0);
+        if !self.need_symtab_shndx {
+            return;
+        }
+        self.symtab_shndx_offset = self.reserve(self.symtab_num as usize * 4, ALIGN_SYMTAB_SHNDX);
+        self.symtab_shndx_data.reserve(self.symtab_num as usize * 4);
+    }
+
+    /// Reserve the section index for the extended section indices symbol table.
+    ///
+    /// You should check [`Self::symtab_shndx_needed`] before calling this
+    /// unless you have other means of knowing if this section is needed.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_symtab_shndx_section_index(&mut self) -> SectionIndex {
+        self.reserve_symtab_shndx_section_index_with_name(&b".symtab_shndx"[..])
+    }
+
+    /// Reserve the section index for the extended section indices symbol table.
+    ///
+    /// You should check [`Self::symtab_shndx_needed`] before calling this
+    /// unless you have other means of knowing if this section is needed.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_symtab_shndx_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert!(self.symtab_shndx_str_id.is_none());
+        self.symtab_shndx_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Return true if `.dynstr` is needed.
+    pub fn dynstr_needed(&self) -> bool {
+        self.need_dynstr
+    }
+
+    /// Require the dynamic string table even if no strings were added.
+    pub fn require_dynstr(&mut self) {
+        self.need_dynstr = true;
+    }
+
+    /// Reserve the range for the dynamic string table.
+    ///
+    /// This range is used for a section named `.dynstr`.
+    ///
+    /// This function does nothing if no dynamic strings were defined.
+    /// This must be called after [`Self::add_dynamic_string`].
+    ///
+    /// Returns an error if the string table could not be finalized.
+    pub fn reserve_dynstr(&mut self) -> Result<usize> {
+        debug_assert_eq!(self.dynstr_offset, 0);
+        if !self.need_dynstr {
+            return Ok(0);
+        }
+        // Start with null string.
+        self.dynstr_data = vec![0];
+        self.dynstr.write(1, &mut self.dynstr_data)?;
+        self.dynstr_offset = self.reserve(self.dynstr_data.len(), 1);
+        Ok(self.dynstr_offset)
+    }
+
+    /// Return the size of the dynamic string table.
+    ///
+    /// This must be called after [`Self::reserve_dynstr`].
+    pub fn dynstr_len(&mut self) -> usize {
+        debug_assert_ne!(self.dynstr_offset, 0);
+        self.dynstr_data.len()
+    }
+
+    /// Write the dynamic string table.
+    ///
+    /// This function does nothing if the section was not reserved.
+    pub fn write_dynstr(&mut self) {
+        if self.dynstr_offset == 0 {
+            return;
+        }
+        debug_assert_eq!(self.dynstr_offset, self.buffer.len());
+        self.buffer.write_bytes(&self.dynstr_data);
+    }
+
+    /// Reserve the section index for the dynamic string table.
+    ///
+    /// You should check [`Self::dynstr_needed`] before calling this
+    /// unless you have other means of knowing if this section is needed.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_dynstr_section_index(&mut self) -> SectionIndex {
+        self.reserve_dynstr_section_index_with_name(&b".dynstr"[..])
+    }
+
+    /// Reserve the section index for the dynamic string table.
+    ///
+    /// You should check [`Self::dynstr_needed`] before calling this
+    /// unless you have other means of knowing if this section is needed.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_dynstr_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert_eq!(self.dynstr_index, SectionIndex(0));
+        self.dynstr_str_id = Some(self.add_section_name(name));
+        self.dynstr_index = self.reserve_section_index();
+        self.dynstr_index
+    }
+
+    /// Return the section index of the dynamic string table.
+    pub fn dynstr_index(&mut self) -> SectionIndex {
+        self.dynstr_index
+    }
+
+    /// Reserve the null dynamic symbol table entry.
+    ///
+    /// This will be stored in the `.dynsym` section.
+    ///
+    /// The null dynamic symbol table entry is usually automatically reserved,
+    /// but this can be used to force an empty dynamic symbol table.
+    ///
+    /// This must be called before [`Self::reserve_dynsym`].
+    pub fn reserve_null_dynamic_symbol_index(&mut self) -> SymbolIndex {
+        debug_assert_eq!(self.dynsym_offset, 0);
+        debug_assert_eq!(self.dynsym_num, 0);
+        self.dynsym_num = 1;
+        SymbolIndex(0)
+    }
+
+    /// Reserve a dynamic symbol table entry.
+    ///
+    /// This will be stored in the `.dynsym` section.
+    ///
+    /// Automatically also reserves the null symbol if required.
+    /// Callers may assume that the returned indices will be sequential
+    /// starting at 1.
+    ///
+    /// This must be called before [`Self::reserve_dynsym`].
+    pub fn reserve_dynamic_symbol_index(&mut self) -> SymbolIndex {
+        debug_assert_eq!(self.dynsym_offset, 0);
+        if self.dynsym_num == 0 {
+            self.dynsym_num = 1;
+        }
+        let index = self.dynsym_num;
+        self.dynsym_num += 1;
+        SymbolIndex(index)
+    }
+
+    /// Return the number of reserved dynamic symbols.
+    ///
+    /// Includes the null symbol.
+    pub fn dynamic_symbol_count(&mut self) -> u32 {
+        self.dynsym_num
+    }
+
+    /// Reserve the range for the dynamic symbol table.
+    ///
+    /// This range is used for a section named `.dynsym`.
+    ///
+    /// This function does nothing if no dynamic symbols were reserved.
+    /// This must be called after [`Self::reserve_dynamic_symbol_index`].
+    pub fn reserve_dynsym(&mut self) -> usize {
+        debug_assert_eq!(self.dynsym_offset, 0);
+        if self.dynsym_num == 0 {
+            return 0;
+        }
+        self.dynsym_offset = self.reserve(
+            self.dynsym_num as usize * self.class().sym_size(),
+            self.elf_align,
+        );
+        self.dynsym_offset
+    }
+
+    /// Reserve the section index for the dynamic symbol table.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_dynsym_section_index(&mut self) -> SectionIndex {
+        self.reserve_dynsym_section_index_with_name(&b".dynsym"[..])
+    }
+
+    /// Reserve the section index for the dynamic symbol table.
+    ///
+    /// This must be called before [`Self::reserve_section_headers`].
+    pub fn reserve_dynsym_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert_eq!(self.dynsym_index, SectionIndex(0));
+        self.dynsym_str_id = Some(self.add_section_name(name));
+        self.dynsym_index = self.reserve_section_index();
+        self.dynsym_index
+    }
+
+    /// Return the section index of the dynamic symbol table.
+    pub fn dynsym_index(&mut self) -> SectionIndex {
+        self.dynsym_index
+    }
+
+    /// Reserve the range for the `.dynamic` section.
+    ///
+    /// This function does nothing if `dynamic_num` is zero.
+    pub fn reserve_dynamic(&mut self, dynamic_num: usize) -> usize {
+        debug_assert_eq!(self.dynamic_offset, 0);
+        if dynamic_num == 0 {
+            return 0;
+        }
+        self.dynamic_num = dynamic_num;
+        self.dynamic_offset = self.reserve_dynamics(dynamic_num);
+        self.dynamic_offset
+    }
+
+    /// Reserve a file range for the given number of dynamic entries.
+    ///
+    /// Returns the offset of the range.
+    pub fn reserve_dynamics(&mut self, dynamic_num: usize) -> usize {
+        self.reserve(dynamic_num * self.class().dyn_size(), self.elf_align)
+    }
+
+    /// Reserve the section index for the dynamic table.
+    pub fn reserve_dynamic_section_index(&mut self) -> SectionIndex {
+        debug_assert!(self.dynamic_str_id.is_none());
+        self.dynamic_str_id = Some(self.add_section_name(&b".dynamic"[..]));
+        self.reserve_section_index()
+    }
+
+    /// Reserve a file range for a SysV hash section.
+    ///
+    /// `symbol_count` is the number of symbols in the hash,
+    /// not the total number of symbols.
+    pub fn reserve_hash(&mut self, bucket_count: u32, chain_count: u32) -> usize {
+        self.hash_size = self.class().hash_size(bucket_count, chain_count);
+        self.hash_offset = self.reserve(self.hash_size, ALIGN_HASH);
+        self.hash_offset
+    }
+
+    /// Reserve the section index for the SysV hash table.
+    pub fn reserve_hash_section_index(&mut self) -> SectionIndex {
+        self.reserve_hash_section_index_with_name(&b".hash"[..])
+    }
+
+    /// Reserve the section index for the SysV hash table.
+    pub fn reserve_hash_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert!(self.hash_str_id.is_none());
+        self.hash_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Reserve a file range for a GNU hash section.
+    ///
+    /// `symbol_count` is the number of symbols in the hash,
+    /// not the total number of symbols.
+    pub fn reserve_gnu_hash(
+        &mut self,
+        bloom_count: u32,
+        bucket_count: u32,
+        symbol_count: u32,
+    ) -> usize {
+        self.gnu_hash_size = self
+            .class()
+            .gnu_hash_size(bloom_count, bucket_count, symbol_count);
+        self.gnu_hash_offset = self.reserve(self.gnu_hash_size, self.elf_align);
+        self.gnu_hash_offset
+    }
+
+    /// Reserve the section index for the GNU hash table.
+    pub fn reserve_gnu_hash_section_index(&mut self) -> SectionIndex {
+        self.reserve_gnu_hash_section_index_with_name(&b".gnu.hash"[..])
+    }
+
+    /// Reserve the section index for the GNU hash table.
+    pub fn reserve_gnu_hash_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert!(self.gnu_hash_str_id.is_none());
+        self.gnu_hash_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Reserve the range for the `.gnu.version` section.
+    ///
+    /// This function does nothing if no dynamic symbols were reserved.
+    pub fn reserve_gnu_versym(&mut self) -> usize {
+        debug_assert_eq!(self.gnu_versym_offset, 0);
+        if self.dynsym_num == 0 {
+            return 0;
+        }
+        self.gnu_versym_offset = self.reserve(self.dynsym_num as usize * 2, ALIGN_GNU_VERSYM);
+        self.gnu_versym_offset
+    }
+
+    /// Reserve the section index for the `.gnu.version` section.
+    pub fn reserve_gnu_versym_section_index(&mut self) -> SectionIndex {
+        self.reserve_gnu_versym_section_index_with_name(&b".gnu.version"[..])
+    }
+
+    /// Reserve the section index for the `.gnu.version` section.
+    pub fn reserve_gnu_versym_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert!(self.gnu_versym_str_id.is_none());
+        self.gnu_versym_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Reserve the range for the `.gnu.version_d` section.
+    pub fn reserve_gnu_verdef(&mut self, verdef_count: usize, verdaux_count: usize) -> usize {
+        debug_assert_eq!(self.gnu_verdef_offset, 0);
+        if verdef_count == 0 {
+            return 0;
+        }
+        self.gnu_verdef_size = self.class().gnu_verdef_size(verdef_count, verdaux_count);
+        self.gnu_verdef_offset = self.reserve(self.gnu_verdef_size, ALIGN_GNU_VERDEF);
+        self.gnu_verdef_count = verdef_count as u16;
+        self.gnu_verdef_remaining = self.gnu_verdef_count;
+        self.gnu_verdef_offset
+    }
+
+    /// Reserve the section index for the `.gnu.version_d` section.
+    pub fn reserve_gnu_verdef_section_index(&mut self) -> SectionIndex {
+        self.reserve_gnu_verdef_section_index_with_name(&b".gnu.version_d"[..])
+    }
+
+    /// Reserve the section index for the `.gnu.version_d` section.
+    pub fn reserve_gnu_verdef_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert!(self.gnu_verdef_str_id.is_none());
+        self.gnu_verdef_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Reserve the range for the `.gnu.version_r` section.
+    pub fn reserve_gnu_verneed(&mut self, verneed_count: usize, vernaux_count: usize) -> usize {
+        debug_assert_eq!(self.gnu_verneed_offset, 0);
+        if verneed_count == 0 {
+            return 0;
+        }
+        self.gnu_verneed_size = self.class().gnu_verneed_size(verneed_count, vernaux_count);
+        self.gnu_verneed_offset = self.reserve(self.gnu_verneed_size, ALIGN_GNU_VERNEED);
+        self.gnu_verneed_count = verneed_count as u16;
+        self.gnu_verneed_remaining = self.gnu_verneed_count;
+        self.gnu_verneed_offset
+    }
+
+    /// Reserve the section index for the `.gnu.version_r` section.
+    pub fn reserve_gnu_verneed_section_index(&mut self) -> SectionIndex {
+        self.reserve_gnu_verneed_section_index_with_name(&b".gnu.version_r"[..])
+    }
+
+    /// Reserve the section index for the `.gnu.version_r` section.
+    pub fn reserve_gnu_verneed_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
+        debug_assert!(self.gnu_verneed_str_id.is_none());
+        self.gnu_verneed_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Reserve the section index for the `.gnu.attributes` section.
+    pub fn reserve_gnu_attributes_section_index(&mut self) -> SectionIndex {
+        self.reserve_gnu_attributes_section_index_with_name(&b".gnu.attributes"[..])
+    }
+
+    /// Reserve the section index for the `.gnu.attributes` section.
+    pub fn reserve_gnu_attributes_section_index_with_name(
+        &mut self,
+        name: &'a [u8],
+    ) -> SectionIndex {
+        debug_assert!(self.gnu_attributes_str_id.is_none());
+        self.gnu_attributes_str_id = Some(self.add_section_name(name));
+        self.reserve_section_index()
+    }
+
+    /// Reserve the range for the `.gnu.attributes` section.
+    pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: usize) -> usize {
+        debug_assert_eq!(self.gnu_attributes_offset, 0);
+        if gnu_attributes_size == 0 {
+            return 0;
+        }
+        self.gnu_attributes_size = gnu_attributes_size;
+        self.gnu_attributes_offset = self.reserve(self.gnu_attributes_size, self.elf_align);
+        self.gnu_attributes_offset
+    }
+
+    /// Reserve a file range for the given number of relocations.
+    ///
+    /// Returns the offset of the range.
+    pub fn reserve_relocations(&mut self, count: usize, is_rela: bool) -> usize {
+        self.reserve(count * self.class().rel_size(is_rela), self.elf_align)
+    }
+
+    /// Reserve a file range for a COMDAT section.
+    ///
+    /// `count` is the number of sections in the COMDAT group.
+    ///
+    /// Returns the offset of the range.
+    pub fn reserve_comdat(&mut self, count: usize) -> usize {
+        self.reserve((count + 1) * 4, 4)
     }
 }
 

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -38,6 +38,7 @@ mod private {
 
     #[allow(private_interfaces)]
     pub trait ModeSealed {
+        fn string_table() -> StringTable<'static>;
         fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()>;
         fn need_offset(offset: u64) -> bool;
         fn set_offset(dest: &mut u64, offset: u64);
@@ -171,13 +172,13 @@ impl<'a, M: Mode> Writer<'a, M> {
             written_segment_num: 0,
             written_section_num: 0,
 
-            shstrtab: StringTable::default(),
+            shstrtab: M::string_table(),
             shstrtab_str_id: None,
             shstrtab_offset: 0,
             shstrtab_size: 0,
 
             need_strtab: false,
-            strtab: StringTable::default(),
+            strtab: M::string_table(),
             strtab_str_id: None,
             strtab_index: SectionIndex(0),
             strtab_offset: 0,
@@ -195,7 +196,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             symtab_shndx_data: Vec::new(),
 
             need_dynstr: false,
-            dynstr: StringTable::default(),
+            dynstr: M::string_table(),
             dynstr_str_id: None,
             dynstr_index: SectionIndex(0),
             dynstr_offset: 0,
@@ -1620,8 +1621,11 @@ pub type SinglePhaseWriter<'a> = Writer<'a, SinglePhase>;
 ///
 /// Items must be written before they are referenced:
 /// - write section data before section headers
-/// - write string tables before they are referenced
 /// - write metadata section headers before they are referenced (e.g. `.strtab` before `.symtab`)
+///
+/// Strings in strings tables are written in the order they are added, without suffix merging.
+/// This means that string offsets are known before the string table is written.
+/// For example, [`Writer::write_symbol`] may be called before [`Writer::write_strtab`].
 ///
 /// The one exception is the file header, which must be written first, but needs to
 /// reference the program header table and section header table. To support this, you can
@@ -1640,6 +1644,10 @@ pub struct SinglePhase(());
 impl Mode for SinglePhase {}
 #[allow(private_interfaces)]
 impl ModeSealed for SinglePhase {
+    fn string_table() -> StringTable<'static> {
+        StringTable::new_in_order(1)
+    }
+
     fn reserve(&self, _buffer: &mut dyn WritableBuffer) -> Result<()> {
         Ok(())
     }
@@ -1871,6 +1879,10 @@ pub struct TwoPhase {
 impl Mode for TwoPhase {}
 #[allow(private_interfaces)]
 impl ModeSealed for TwoPhase {
+    fn string_table() -> StringTable<'static> {
+        StringTable::new()
+    }
+
     fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()> {
         buffer
             .reserve(self.len)

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -39,9 +39,9 @@ mod private {
     #[allow(private_interfaces)]
     pub trait ModeSealed {
         fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()>;
-        fn need_offset(offset: usize) -> bool;
-        fn set_offset(dest: &mut usize, offset: usize);
-        fn set_size(dest: &mut usize, size: usize);
+        fn need_offset(offset: u64) -> bool;
+        fn set_offset(dest: &mut u64, offset: u64);
+        fn set_size(dest: &mut u64, size: u64);
         fn set_section_index(dest: &mut SectionIndex, index: SectionIndex);
         fn set_section_name(
             dest: &mut Option<StringId>,
@@ -76,58 +76,58 @@ pub struct Writer<'a, M: Mode = TwoPhase> {
 
     shstrtab: StringTable<'a>,
     shstrtab_str_id: Option<StringId>,
-    shstrtab_offset: usize,
+    shstrtab_offset: u64,
     shstrtab_size: u32,
 
     need_strtab: bool,
     strtab: StringTable<'a>,
     strtab_str_id: Option<StringId>,
     strtab_index: SectionIndex,
-    strtab_offset: usize,
+    strtab_offset: u64,
     strtab_size: u32,
 
     symtab_str_id: Option<StringId>,
     symtab_index: SectionIndex,
-    symtab_offset: usize,
+    symtab_offset: u64,
     symtab_num: u32,
     written_symtab_num: u32,
 
     need_symtab_shndx: bool,
     symtab_shndx_str_id: Option<StringId>,
-    symtab_shndx_offset: usize,
+    symtab_shndx_offset: u64,
     symtab_shndx_data: Vec<u8>,
 
     need_dynstr: bool,
     dynstr: StringTable<'a>,
     dynstr_str_id: Option<StringId>,
     dynstr_index: SectionIndex,
-    dynstr_offset: usize,
+    dynstr_offset: u64,
     dynstr_size: u32,
 
     dynsym_str_id: Option<StringId>,
     dynsym_index: SectionIndex,
-    dynsym_offset: usize,
+    dynsym_offset: u64,
     dynsym_num: u32,
     written_dynsym_num: u32,
 
     dynamic_str_id: Option<StringId>,
-    dynamic_offset: usize,
+    dynamic_offset: u64,
     dynamic_num: usize,
     written_dynamic_num: usize,
 
     hash_str_id: Option<StringId>,
-    hash_offset: usize,
-    hash_size: usize,
+    hash_offset: u64,
+    hash_size: u64,
 
     gnu_hash_str_id: Option<StringId>,
-    gnu_hash_offset: usize,
-    gnu_hash_size: usize,
+    gnu_hash_offset: u64,
+    gnu_hash_size: u64,
 
     gnu_versym_str_id: Option<StringId>,
-    gnu_versym_offset: usize,
+    gnu_versym_offset: u64,
 
     gnu_verdef_str_id: Option<StringId>,
-    gnu_verdef_offset: usize,
+    gnu_verdef_offset: u64,
     gnu_verdef_count: u16,
     gnu_verdaux_count: usize,
     written_verdaux_count: usize,
@@ -135,7 +135,7 @@ pub struct Writer<'a, M: Mode = TwoPhase> {
     gnu_verdaux_remaining: u16,
 
     gnu_verneed_str_id: Option<StringId>,
-    gnu_verneed_offset: usize,
+    gnu_verneed_offset: u64,
     gnu_verneed_count: u16,
     gnu_vernaux_count: usize,
     written_vernaux_count: usize,
@@ -143,8 +143,8 @@ pub struct Writer<'a, M: Mode = TwoPhase> {
     gnu_vernaux_remaining: u16,
 
     gnu_attributes_str_id: Option<StringId>,
-    gnu_attributes_offset: usize,
-    gnu_attributes_size: usize,
+    gnu_attributes_offset: u64,
+    gnu_attributes_size: u64,
 }
 
 impl<'a, M: Mode> Writer<'a, M> {
@@ -256,11 +256,19 @@ impl<'a, M: Mode> Writer<'a, M> {
         self.buffer.len()
     }
 
+    /// Return the file offset of the next write.
+    pub fn offset(&self) -> u64 {
+        self.buffer.len() as u64
+    }
+
     /// Write alignment padding bytes.
-    pub fn write_align(&mut self, align_start: usize) {
+    ///
+    /// Returns the file offset after the padding.
+    pub fn write_align(&mut self, align_start: usize) -> u64 {
         if align_start > 1 {
             util::write_align(self.buffer, align_start);
         }
+        self.offset()
     }
 
     /// Write data.
@@ -271,9 +279,10 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write padding up to the given file offset.
-    pub fn pad_until(&mut self, offset: usize) {
-        debug_assert!(self.buffer.len() <= offset);
-        self.buffer.resize(offset);
+    pub fn pad_until(&mut self, offset: u64) {
+        debug_assert!(self.offset() <= offset);
+        debug_assert!(offset <= usize::MAX as u64);
+        self.buffer.resize(offset as usize);
     }
 
     /// Write the file header.
@@ -326,7 +335,7 @@ impl<'a, M: Mode> Writer<'a, M> {
 
         let e_ehsize = class.file_header_size() as u16;
 
-        let e_phoff = layout.segment_offset as u64;
+        let e_phoff = layout.segment_offset;
         let e_phentsize = if layout.segment_num == 0 {
             0
         } else {
@@ -343,7 +352,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             layout.segment_num as u16
         };
 
-        let e_shoff = layout.section_offset as u64;
+        let e_shoff = layout.section_offset;
         let e_shentsize = if layout.section_num == 0 {
             0
         } else {
@@ -399,13 +408,15 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write alignment padding bytes prior to the program headers.
     ///
-    /// In two-phase mode, does nothing if no program headers were reserved.
-    pub fn write_align_program_headers(&mut self) {
+    /// Returns the file offset after the padding.
+    /// In two-phase mode, returns 0 without writing if no program headers were reserved.
+    pub fn write_align_program_headers(&mut self) -> u64 {
         if !M::need_offset(self.layout.segment_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.layout.segment_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.layout.segment_offset, offset);
+        offset
     }
 
     /// Write a program header.
@@ -453,13 +464,15 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null section header.
     ///
     /// This must be the first section header that is written.
-    /// In two-phase mode, does nothing if no sections were reserved.
-    pub fn write_null_section_header(&mut self) {
+    ///
+    /// Returns the file offset of the header.
+    /// In two-phase mode, returns 0 without writing if no sections were reserved.
+    pub fn write_null_section_header(&mut self) -> u64 {
         if !M::need_offset(self.layout.section_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.layout.section_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.layout.section_offset, offset);
         self.write_section_header(&SectionHeader {
             name: None,
             sh_type: elf::SHT_NULL,
@@ -484,6 +497,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_addralign: 0,
             sh_entsize: 0,
         });
+        offset
     }
 
     /// Write a section header.
@@ -556,7 +570,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_STRTAB,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
-            sh_offset: self.shstrtab_offset as u64,
+            sh_offset: self.shstrtab_offset,
             sh_size: self.shstrtab_size.into(),
             sh_link: 0,
             sh_info: 0,
@@ -590,7 +604,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_STRTAB,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
-            sh_offset: self.strtab_offset as u64,
+            sh_offset: self.strtab_offset,
             sh_size: self.strtab_size.into(),
             sh_link: 0,
             sh_info: 0,
@@ -603,13 +617,15 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null symbol.
     ///
     /// This must be the first symbol that is written.
-    /// In two-phase mode, does nothing if no symbols were reserved.
-    pub fn write_null_symbol(&mut self) {
+    ///
+    /// Returns the file offset of the symbol.
+    /// In two-phase mode, returns 0 without writing if no symbols were reserved.
+    pub fn write_null_symbol(&mut self) -> u64 {
         if !M::need_offset(self.symtab_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.symtab_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.symtab_offset, offset);
         M::set_section_name(&mut self.symtab_str_id, &mut self.shstrtab, b".symtab");
         if self.is_64 {
             self.buffer.write(&elf::Sym64::<Endianness>::default());
@@ -626,6 +642,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_count(&mut self.symtab_num, self.written_symtab_num);
         // The symtab must link to a strtab.
         self.need_strtab = true;
+        offset
     }
 
     /// Write a symbol.
@@ -696,7 +713,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_SYMTAB,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
-            sh_offset: self.symtab_offset as u64,
+            sh_offset: self.symtab_offset,
             sh_size: self.symtab_num as u64 * self.class().sym_size() as u64,
             sh_link: self.strtab_index.0,
             sh_info: num_local,
@@ -708,14 +725,15 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the extended section indices for the symbol table.
     ///
-    /// Does nothing if extended section indices are not needed.
-    pub fn write_symtab_shndx(&mut self) {
+    /// Returns the file offset of the start of the data.
+    /// Returns 0 without writing if extended section indices are not needed.
+    pub fn write_symtab_shndx(&mut self) -> u64 {
         if !self.need_symtab_shndx {
             self.symtab_shndx_data = Vec::new();
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, ALIGN_SYMTAB_SHNDX);
-        M::set_offset(&mut self.symtab_shndx_offset, self.buffer.len());
+        let offset = self.write_align(ALIGN_SYMTAB_SHNDX);
+        M::set_offset(&mut self.symtab_shndx_offset, offset);
         M::set_section_name(
             &mut self.symtab_shndx_str_id,
             &mut self.shstrtab,
@@ -723,6 +741,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         );
         self.buffer.write_bytes(&self.symtab_shndx_data);
         self.symtab_shndx_data = Vec::new();
+        offset
     }
 
     /// Write the section header for the extended section indices for the symbol table.
@@ -743,7 +762,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_SYMTAB_SHNDX,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
-            sh_offset: self.symtab_shndx_offset as u64,
+            sh_offset: self.symtab_shndx_offset,
             sh_size,
             sh_link: self.symtab_index.0,
             sh_info: 0,
@@ -783,7 +802,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_STRTAB,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.dynstr_offset as u64,
+            sh_offset: self.dynstr_offset,
             sh_size: self.dynstr_size.into(),
             sh_link: 0,
             sh_info: 0,
@@ -796,13 +815,15 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null dynamic symbol.
     ///
     /// This must be the first dynamic symbol that is written.
-    /// In two-phase mode, does nothing if no dynamic symbols were reserved.
-    pub fn write_null_dynamic_symbol(&mut self) {
+    ///
+    /// Returns the file offset of the symbol.
+    /// In two-phase mode, returns 0 without writing if no dynamic symbols were reserved.
+    pub fn write_null_dynamic_symbol(&mut self) -> u64 {
         if !M::need_offset(self.dynsym_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.dynsym_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.dynsym_offset, offset);
         M::set_section_name(&mut self.dynsym_str_id, &mut self.shstrtab, b".dynsym");
         if self.is_64 {
             self.buffer.write(&elf::Sym64::<Endianness>::default());
@@ -814,6 +835,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_count(&mut self.dynsym_num, self.written_dynsym_num);
         // The symbol table must link to a string table.
         self.need_dynstr = true;
+        offset
     }
 
     /// Write a dynamic symbol.
@@ -876,7 +898,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_DYNSYM,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.dynsym_offset as u64,
+            sh_offset: self.dynsym_offset,
             sh_size: self.dynsym_num as u64 * self.class().sym_size() as u64,
             sh_link: self.dynstr_index.0,
             sh_info: num_local,
@@ -888,14 +910,16 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write alignment padding bytes prior to the `.dynamic` section.
     ///
-    /// In two-phase mode, does nothing if the section was not reserved.
-    pub fn write_align_dynamic(&mut self) {
+    /// Returns the file offset after the padding.
+    /// In two-phase mode, returns 0 without writing if the section was not reserved.
+    pub fn write_align_dynamic(&mut self) -> u64 {
         if !M::need_offset(self.dynamic_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.dynamic_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.dynamic_offset, offset);
         M::set_section_name(&mut self.dynamic_str_id, &mut self.shstrtab, b".dynamic");
+        offset
     }
 
     /// Write a dynamic string entry.
@@ -946,7 +970,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_DYNAMIC,
             sh_flags: elf::SHF_WRITE | elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.dynamic_offset as u64,
+            sh_offset: self.dynamic_offset,
             sh_size: (self.dynamic_num * self.class().dyn_size()) as u64,
             sh_link: self.dynstr_index.0,
             sh_info: 0,
@@ -961,7 +985,9 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// The argument to `hash` will be in the range `0..chain_count`.
     ///
     /// In two-phase mode, [`Self::reserve_hash`] must be called before this.
-    pub fn write_hash<F>(&mut self, bucket_count: u32, chain_count: u32, hash: F)
+    ///
+    /// Returns the file offset of the hash table data.
+    pub fn write_hash<F>(&mut self, bucket_count: u32, chain_count: u32, hash: F) -> u64
     where
         F: Fn(u32) -> Option<u32>,
     {
@@ -975,8 +1001,8 @@ impl<'a, M: Mode> Writer<'a, M> {
             }
         }
 
-        util::write_align(self.buffer, ALIGN_HASH);
-        M::set_offset(&mut self.hash_offset, self.buffer.len());
+        let offset = self.write_align(ALIGN_HASH);
+        M::set_offset(&mut self.hash_offset, offset);
         M::set_section_name(&mut self.hash_str_id, &mut self.shstrtab, b".hash");
         self.buffer.write(&elf::HashHeader {
             bucket_count: U32::new(self.endian, bucket_count),
@@ -984,7 +1010,9 @@ impl<'a, M: Mode> Writer<'a, M> {
         });
         self.buffer.write_slice(&buckets);
         self.buffer.write_slice(&chains);
-        M::set_size(&mut self.hash_size, self.buffer.len() - self.hash_offset);
+        let size = self.offset() - self.hash_offset;
+        M::set_size(&mut self.hash_size, size);
+        offset
     }
 
     /// Write the section header for the SysV hash table.
@@ -1000,8 +1028,8 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_HASH,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.hash_offset as u64,
-            sh_size: self.hash_size as u64,
+            sh_offset: self.hash_offset,
+            sh_size: self.hash_size,
             sh_link: self.dynsym_index.0,
             sh_info: 0,
             sh_addralign: ALIGN_HASH as u64,
@@ -1017,6 +1045,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// This requires that symbols are already sorted by bucket.
     ///
     /// In two-phase mode, [`Self::reserve_gnu_hash`] must be called before this.
+    ///
+    /// Returns the file offset of the hash table data.
     pub fn write_gnu_hash<F>(
         &mut self,
         symbol_base: u32,
@@ -1025,11 +1055,12 @@ impl<'a, M: Mode> Writer<'a, M> {
         bucket_count: u32,
         symbol_count: u32,
         hash: F,
-    ) where
+    ) -> u64
+    where
         F: Fn(u32) -> u32,
     {
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.gnu_hash_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.gnu_hash_offset, offset);
         M::set_section_name(&mut self.gnu_hash_str_id, &mut self.shstrtab, b".gnu.hash");
         self.buffer.write(&elf::GnuHashHeader {
             bucket_count: U32::new(self.endian, bucket_count),
@@ -1092,10 +1123,9 @@ impl<'a, M: Mode> Writer<'a, M> {
             self.buffer.write(&U32::new(self.endian, h));
         }
 
-        M::set_size(
-            &mut self.gnu_hash_size,
-            self.buffer.len() - self.gnu_hash_offset,
-        );
+        let size = self.offset() - self.gnu_hash_offset;
+        M::set_size(&mut self.gnu_hash_size, size);
+        offset
     }
 
     /// Write the section header for the GNU hash table.
@@ -1111,8 +1141,8 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_GNU_HASH,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.gnu_hash_offset as u64,
-            sh_size: self.gnu_hash_size as u64,
+            sh_offset: self.gnu_hash_offset,
+            sh_size: self.gnu_hash_size,
             sh_link: self.dynsym_index.0,
             sh_info: 0,
             sh_addralign: self.elf_align as u64,
@@ -1123,19 +1153,22 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null symbol version entry.
     ///
     /// This must be the first symbol version that is written.
-    /// In two-phase mode, does nothing if no dynamic symbols were reserved.
-    pub fn write_null_gnu_versym(&mut self) {
+    ///
+    /// Returns the file offset of the entry.
+    /// In two-phase mode, returns 0 without writing if no dynamic symbols were reserved.
+    pub fn write_null_gnu_versym(&mut self) -> u64 {
         if !M::need_offset(self.gnu_versym_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, ALIGN_GNU_VERSYM);
-        M::set_offset(&mut self.gnu_versym_offset, self.buffer.len());
+        let offset = self.write_align(ALIGN_GNU_VERSYM);
+        M::set_offset(&mut self.gnu_versym_offset, offset);
         M::set_section_name(
             &mut self.gnu_versym_str_id,
             &mut self.shstrtab,
             b".gnu.version",
         );
         self.write_gnu_versym(elf::VER_NDX_LOCAL.into());
+        offset
     }
 
     /// Write a symbol version entry.
@@ -1158,7 +1191,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_GNU_VERSYM,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.gnu_versym_offset as u64,
+            sh_offset: self.gnu_versym_offset,
             sh_size: self.class().gnu_versym_size(self.dynsym_num as usize) as u64,
             sh_link: self.dynsym_index.0,
             sh_info: 0,
@@ -1169,18 +1202,20 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write alignment padding bytes prior to a `.gnu.version_d` section.
     ///
-    /// In two-phase mode, does nothing if the section was not reserved.
-    pub fn write_align_gnu_verdef(&mut self) {
+    /// Returns the file offset after the padding.
+    /// In two-phase mode, returns 0 without writing if the section was not reserved.
+    pub fn write_align_gnu_verdef(&mut self) -> u64 {
         if !M::need_offset(self.gnu_verdef_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, ALIGN_GNU_VERDEF);
-        M::set_offset(&mut self.gnu_verdef_offset, self.buffer.len());
+        let offset = self.write_align(ALIGN_GNU_VERDEF);
+        M::set_offset(&mut self.gnu_verdef_offset, offset);
         M::set_section_name(
             &mut self.gnu_verdef_str_id,
             &mut self.shstrtab,
             b".gnu.version_d",
         );
+        offset
     }
 
     /// Write a version definition entry.
@@ -1279,7 +1314,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_GNU_VERDEF,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.gnu_verdef_offset as u64,
+            sh_offset: self.gnu_verdef_offset,
             sh_size,
             sh_link: self.dynstr_index.0,
             sh_info: self.gnu_verdef_count.into(),
@@ -1290,18 +1325,20 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write alignment padding bytes prior to a `.gnu.version_r` section.
     ///
-    /// In two-phase mode, does nothing if the section was not reserved.
-    pub fn write_align_gnu_verneed(&mut self) {
+    /// Returns the file offset after the padding.
+    /// In two-phase mode, returns 0 without writing if the section was not reserved.
+    pub fn write_align_gnu_verneed(&mut self) -> u64 {
         if !M::need_offset(self.gnu_verneed_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, ALIGN_GNU_VERNEED);
-        M::set_offset(&mut self.gnu_verneed_offset, self.buffer.len());
+        let offset = self.write_align(ALIGN_GNU_VERNEED);
+        M::set_offset(&mut self.gnu_verneed_offset, offset);
         M::set_section_name(
             &mut self.gnu_verneed_str_id,
             &mut self.shstrtab,
             b".gnu.version_r",
         );
+        offset
     }
 
     /// Write a version need entry.
@@ -1374,7 +1411,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_GNU_VERNEED,
             sh_flags: elf::SHF_ALLOC,
             sh_addr,
-            sh_offset: self.gnu_verneed_offset as u64,
+            sh_offset: self.gnu_verneed_offset,
             sh_size,
             sh_link: self.dynstr_index.0,
             sh_info: self.gnu_verneed_count.into(),
@@ -1396,8 +1433,8 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_GNU_ATTRIBUTES,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
-            sh_offset: self.gnu_attributes_offset as u64,
-            sh_size: self.gnu_attributes_size as u64,
+            sh_offset: self.gnu_attributes_offset,
+            sh_size: self.gnu_attributes_size,
             sh_link: self.dynstr_index.0,
             sh_info: 0, // TODO
             sh_addralign: self.elf_align as u64,
@@ -1407,26 +1444,30 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the data for the `.gnu.attributes` section.
     ///
-    /// In two-phase mode, does nothing if the section was not reserved.
-    pub fn write_gnu_attributes(&mut self, data: &[u8]) {
+    /// Returns the file offset of the data.
+    /// In two-phase mode, returns 0 without writing if the section was not reserved.
+    pub fn write_gnu_attributes(&mut self, data: &[u8]) -> u64 {
         if !M::need_offset(self.gnu_attributes_offset) {
-            return;
+            return 0;
         }
-        util::write_align(self.buffer, self.elf_align);
-        M::set_offset(&mut self.gnu_attributes_offset, self.buffer.len());
+        let offset = self.write_align(self.elf_align);
+        M::set_offset(&mut self.gnu_attributes_offset, offset);
         M::set_section_name(
             &mut self.gnu_attributes_str_id,
             &mut self.shstrtab,
             b".gnu.attributes",
         );
         self.buffer.write_bytes(data);
-        let size = self.buffer.len() - self.gnu_attributes_offset;
+        let size = self.offset() - self.gnu_attributes_offset;
         M::set_size(&mut self.gnu_attributes_size, size);
+        offset
     }
 
     /// Write alignment padding bytes prior to a relocation section.
-    pub fn write_align_relocation(&mut self) {
-        util::write_align(self.buffer, self.elf_align);
+    ///
+    /// Returns the file offset after the padding.
+    pub fn write_align_relocation(&mut self) -> u64 {
+        self.write_align(self.elf_align)
     }
 
     /// Write a relocation.
@@ -1483,7 +1524,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         name: StringId,
         section: SectionIndex,
         symtab: SectionIndex,
-        offset: usize,
+        offset: u64,
         count: usize,
         is_rela: bool,
     ) {
@@ -1492,7 +1533,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: if is_rela { elf::SHT_RELA } else { elf::SHT_REL },
             sh_flags: elf::SHF_INFO_LINK,
             sh_addr: 0,
-            sh_offset: offset as u64,
+            sh_offset: offset,
             sh_size: (count * self.class().rel_size(is_rela)) as u64,
             sh_link: symtab.0,
             sh_info: section.0,
@@ -1542,7 +1583,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         name: StringId,
         symtab: SectionIndex,
         symbol: SymbolIndex,
-        offset: usize,
+        offset: u64,
         count: usize,
     ) {
         self.write_section_header(&SectionHeader {
@@ -1550,7 +1591,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_type: elf::SHT_GROUP,
             sh_flags: elf::SectionFlags(0),
             sh_addr: 0,
-            sh_offset: offset as u64,
+            sh_offset: offset,
             sh_size: ((count + 1) * 4) as u64,
             sh_link: symtab.0,
             sh_info: symbol.0,
@@ -1603,17 +1644,17 @@ impl ModeSealed for SinglePhase {
         Ok(())
     }
 
-    fn need_offset(offset: usize) -> bool {
+    fn need_offset(offset: u64) -> bool {
         debug_assert_eq!(offset, 0);
         true
     }
 
-    fn set_offset(dest: &mut usize, offset: usize) {
+    fn set_offset(dest: &mut u64, offset: u64) {
         debug_assert_eq!(*dest, 0);
         *dest = offset;
     }
 
-    fn set_size(dest: &mut usize, size: usize) {
+    fn set_size(dest: &mut u64, size: u64) {
         debug_assert_eq!(*dest, 0);
         *dest = size;
     }
@@ -1671,19 +1712,22 @@ impl<'a> Writer<'a, SinglePhase> {
     /// Use [`Self::write_headers_to`] to write the program headers once their contents
     /// are known.
     ///
-    /// Does nothing if `count` is zero.
-    pub fn write_program_headers_placeholder(&mut self, count: u32) {
+    /// Returns the file offset and size of the program headers.
+    /// Returns `(0, 0)` if `count` is zero.
+    pub fn write_program_headers_placeholder(&mut self, count: u32) -> (u64, u64) {
         if count == 0 {
-            return;
+            return (0, 0);
         }
-        debug_assert_eq!(self.buffer.len(), self.class().file_header_size());
         // file_header_size is always a multiple of elf_align, so no alignment
         // padding is required.
-        SinglePhase::set_offset(&mut self.layout.segment_offset, self.buffer.len());
+        let offset = self.offset();
+        debug_assert_eq!(offset, self.class().file_header_size() as u64);
+        SinglePhase::set_offset(&mut self.layout.segment_offset, offset);
         SinglePhase::set_count(&mut self.layout.segment_num, count);
         self.written_segment_num = count;
-        let new_len = self.buffer.len() + count as usize * self.class().program_header_size();
-        self.buffer.resize(new_len);
+        let size = count as usize * self.class().program_header_size();
+        self.buffer.resize(self.buffer.len() + size);
+        (offset, size as u64)
     }
 
     /// Write the file header and program headers to the given buffer.
@@ -1723,7 +1767,9 @@ impl<'a> Writer<'a, SinglePhase> {
     /// Write the section header string table.
     ///
     /// Always writes the string table, even if it is empty.
-    pub fn write_shstrtab(&mut self) -> Result<()> {
+    ///
+    /// Returns the file offset and size of the data.
+    pub fn write_shstrtab(&mut self) -> Result<(u64, u32)> {
         // This must be written before the .shstrtab section header, so
         // we can't use write_null_section_header to determine if it is needed.
         // Thus we always write this if called.
@@ -1732,44 +1778,47 @@ impl<'a> Writer<'a, SinglePhase> {
         // Start with null section name.
         let mut data = vec![0];
         self.shstrtab_size = self.shstrtab.write(1, &mut data)?;
-        self.shstrtab_offset = self.buffer.len();
+        self.shstrtab_offset = self.offset();
         self.write(&data);
-        Ok(())
+        Ok((self.shstrtab_offset, self.shstrtab_size))
     }
 
     /// Write the string table.
     ///
-    /// Only writes the string table if it is not empty, or if there is a symbol table.
-    pub fn write_strtab(&mut self) -> Result<()> {
+    /// Returns the file offset and size of the data.
+    /// Returns `(0, 0)` without writing anything if the string table is empty and
+    /// there is no symbol table.
+    pub fn write_strtab(&mut self) -> Result<(u64, u32)> {
         if !self.need_strtab && self.strtab.is_empty() {
-            return Ok(());
+            return Ok((0, 0));
         }
         debug_assert_eq!(self.strtab_offset, 0);
         self.strtab_str_id = Some(self.add_section_name(b".strtab"));
         // Start with null section name.
         let mut data = vec![0];
         self.strtab_size = self.strtab.write(1, &mut data)?;
-        self.strtab_offset = self.buffer.len();
+        self.strtab_offset = self.offset();
         self.write(&data);
-        Ok(())
+        Ok((self.strtab_offset, self.strtab_size))
     }
 
     /// Write the dynamic string table.
     ///
-    /// Only writes the string table if it is not empty, or if there is a dynamic symbol
-    /// table.
-    pub fn write_dynstr(&mut self) -> Result<()> {
+    /// Returns the file offset and size of the data.
+    /// Returns `(0, 0)` without writing anything if the string table is empty and
+    /// there is no dynamic symbol table.
+    pub fn write_dynstr(&mut self) -> Result<(u64, u32)> {
         if !self.need_dynstr && self.dynstr.is_empty() {
-            return Ok(());
+            return Ok((0, 0));
         }
         debug_assert_eq!(self.dynstr_offset, 0);
         self.dynstr_str_id = Some(self.add_section_name(b".dynstr"));
         // Start with null section name.
         let mut data = vec![0];
         self.dynstr_size = self.dynstr.write(1, &mut data)?;
-        self.dynstr_offset = self.buffer.len();
+        self.dynstr_offset = self.offset();
         self.write(&data);
-        Ok(())
+        Ok((self.dynstr_offset, self.dynstr_size))
     }
 
     /// Set the number of version definition entries that will be written.
@@ -1828,15 +1877,15 @@ impl ModeSealed for TwoPhase {
             .map_err(|_| Error(String::from("Cannot allocate buffer")))
     }
 
-    fn need_offset(offset: usize) -> bool {
+    fn need_offset(offset: u64) -> bool {
         offset != 0
     }
 
-    fn set_offset(dest: &mut usize, offset: usize) {
+    fn set_offset(dest: &mut u64, offset: u64) {
         debug_assert_eq!(*dest, offset);
     }
 
-    fn set_size(dest: &mut usize, size: usize) {
+    fn set_size(dest: &mut u64, size: u64) {
         debug_assert_eq!(*dest, size);
     }
 
@@ -1879,13 +1928,13 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Returns the aligned offset of the start of the range.
     ///
     /// `align_start` must be a power of two.
-    pub fn reserve(&mut self, len: usize, align_start: usize) -> usize {
+    pub fn reserve(&mut self, len: usize, align_start: usize) -> u64 {
         if align_start > 1 {
             self.mode.len = util::align(self.mode.len, align_start);
         }
         let offset = self.mode.len;
         self.mode.len += len;
-        offset
+        offset as u64
     }
 
     /// Reserve the file range up to the given file offset.
@@ -1994,7 +2043,7 @@ impl<'a> Writer<'a, TwoPhase> {
         if self.shstrtab_offset == 0 {
             return;
         }
-        debug_assert_eq!(self.shstrtab_offset, self.buffer.len());
+        debug_assert_eq!(self.shstrtab_offset, self.offset());
         self.buffer.write_bytes(&self.mode.shstrtab_data);
     }
 
@@ -2055,7 +2104,7 @@ impl<'a> Writer<'a, TwoPhase> {
         if self.strtab_offset == 0 {
             return;
         }
-        debug_assert_eq!(self.strtab_offset, self.buffer.len());
+        debug_assert_eq!(self.strtab_offset, self.offset());
         self.buffer.write_bytes(&self.mode.strtab_data);
     }
 
@@ -2242,8 +2291,10 @@ impl<'a> Writer<'a, TwoPhase> {
     /// was called, or dynamic symbols or dynamic strings are present).
     /// Must be called after [`Self::add_dynamic_string`].
     ///
+    /// Returns the file offset of the data.
+    /// Returns 0 if the range was not reserved.
     /// Returns an error if the string table could not be finalized.
-    pub fn reserve_dynstr(&mut self) -> Result<usize> {
+    pub fn reserve_dynstr(&mut self) -> Result<u64> {
         debug_assert_eq!(self.dynstr_offset, 0);
         if !self.dynstr_needed() {
             return Ok(0);
@@ -2258,9 +2309,9 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Return the size of the dynamic string table.
     ///
     /// Must be called after [`Self::reserve_dynstr`].
-    pub fn dynstr_len(&mut self) -> usize {
+    pub fn dynstr_len(&mut self) -> u32 {
         debug_assert_ne!(self.dynstr_offset, 0);
-        self.mode.dynstr_data.len()
+        self.dynstr_size
     }
 
     /// Write the dynamic string table.
@@ -2270,7 +2321,7 @@ impl<'a> Writer<'a, TwoPhase> {
         if self.dynstr_offset == 0 {
             return;
         }
-        debug_assert_eq!(self.dynstr_offset, self.buffer.len());
+        debug_assert_eq!(self.dynstr_offset, self.offset());
         self.buffer.write_bytes(&self.mode.dynstr_data);
     }
 
@@ -2348,9 +2399,11 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// This range is used for a section named `.dynsym`.
     ///
-    /// Does nothing if no dynamic symbols were reserved.
     /// Must be called after [`Self::reserve_dynamic_symbol_index`].
-    pub fn reserve_dynsym(&mut self) -> usize {
+    ///
+    /// Returns the file offset of the symbol table.
+    /// Returns 0 if no dynamic symbols were reserved.
+    pub fn reserve_dynsym(&mut self) -> u64 {
         debug_assert_eq!(self.dynsym_offset, 0);
         if self.dynsym_num == 0 {
             return 0;
@@ -2386,8 +2439,9 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.dynamic` section.
     ///
-    /// Does nothing if `dynamic_num` is zero.
-    pub fn reserve_dynamic(&mut self, dynamic_num: usize) -> usize {
+    /// Returns the file offset of the reserved range.
+    /// Returns 0 if `dynamic_num` is zero.
+    pub fn reserve_dynamic(&mut self, dynamic_num: usize) -> u64 {
         debug_assert_eq!(self.dynamic_offset, 0);
         if dynamic_num == 0 {
             return 0;
@@ -2399,7 +2453,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Reserve a file range for the given number of dynamic entries.
     ///
     /// Returns the offset of the range.
-    pub fn reserve_dynamics(&mut self, dynamic_num: usize) -> usize {
+    pub fn reserve_dynamics(&mut self, dynamic_num: usize) -> u64 {
         self.dynamic_num += dynamic_num;
         self.reserve(dynamic_num * self.class().dyn_size(), self.elf_align)
     }
@@ -2417,9 +2471,10 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// `symbol_count` is the number of symbols in the hash,
     /// not the total number of symbols.
-    pub fn reserve_hash(&mut self, bucket_count: u32, chain_count: u32) -> usize {
-        self.hash_size = self.class().hash_size(bucket_count, chain_count);
-        self.hash_offset = self.reserve(self.hash_size, ALIGN_HASH);
+    pub fn reserve_hash(&mut self, bucket_count: u32, chain_count: u32) -> u64 {
+        let size = self.class().hash_size(bucket_count, chain_count);
+        self.hash_offset = self.reserve(size, ALIGN_HASH);
+        self.hash_size = size as u64;
         self.hash_offset
     }
 
@@ -2448,11 +2503,12 @@ impl<'a> Writer<'a, TwoPhase> {
         bloom_count: u32,
         bucket_count: u32,
         symbol_count: u32,
-    ) -> usize {
-        self.gnu_hash_size = self
+    ) -> u64 {
+        let size = self
             .class()
             .gnu_hash_size(bloom_count, bucket_count, symbol_count);
-        self.gnu_hash_offset = self.reserve(self.gnu_hash_size, self.elf_align);
+        self.gnu_hash_offset = self.reserve(size, self.elf_align);
+        self.gnu_hash_size = size as u64;
         self.gnu_hash_offset
     }
 
@@ -2474,8 +2530,9 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.gnu.version` section.
     ///
-    /// Does nothing if no dynamic symbols were reserved.
-    pub fn reserve_gnu_versym(&mut self) -> usize {
+    /// Returns the file offset of the reserved range.
+    /// Returns 0 if no dynamic symbols were reserved.
+    pub fn reserve_gnu_versym(&mut self) -> u64 {
         debug_assert_eq!(self.gnu_versym_offset, 0);
         if self.dynsym_num == 0 {
             return 0;
@@ -2502,8 +2559,9 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.gnu.version_d` section.
     ///
-    /// Does nothing if `verdef_count` is zero.
-    pub fn reserve_gnu_verdef(&mut self, verdef_count: usize, verdaux_count: usize) -> usize {
+    /// Returns the file offset of the reserved range.
+    /// Returns 0 if `verdef_count` is zero.
+    pub fn reserve_gnu_verdef(&mut self, verdef_count: usize, verdaux_count: usize) -> u64 {
         debug_assert_eq!(self.gnu_verdef_offset, 0);
         if verdef_count == 0 {
             return 0;
@@ -2534,8 +2592,9 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.gnu.version_r` section.
     ///
-    /// Does nothing if `verneed_count` is zero.
-    pub fn reserve_gnu_verneed(&mut self, verneed_count: usize, vernaux_count: usize) -> usize {
+    /// Returns the file offset of the reserved range.
+    /// Returns 0 if `verneed_count` is zero.
+    pub fn reserve_gnu_verneed(&mut self, verneed_count: usize, vernaux_count: usize) -> u64 {
         debug_assert_eq!(self.gnu_verneed_offset, 0);
         if verneed_count == 0 {
             return 0;
@@ -2585,21 +2644,22 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.gnu.attributes` section.
     ///
-    /// Does nothing if `gnu_attributes_size` is zero.
-    pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: usize) -> usize {
+    /// Returns the file offset of the reserved range.
+    /// Returns 0 if `gnu_attributes_size` is zero.
+    pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: usize) -> u64 {
         debug_assert_eq!(self.gnu_attributes_offset, 0);
         if gnu_attributes_size == 0 {
             return 0;
         }
-        self.gnu_attributes_size = gnu_attributes_size;
-        self.gnu_attributes_offset = self.reserve(self.gnu_attributes_size, self.elf_align);
+        self.gnu_attributes_size = gnu_attributes_size as u64;
+        self.gnu_attributes_offset = self.reserve(gnu_attributes_size, self.elf_align);
         self.gnu_attributes_offset
     }
 
     /// Reserve a file range for the given number of relocations.
     ///
     /// Returns the offset of the range.
-    pub fn reserve_relocations(&mut self, count: usize, is_rela: bool) -> usize {
+    pub fn reserve_relocations(&mut self, count: usize, is_rela: bool) -> u64 {
         self.reserve(count * self.class().rel_size(is_rela), self.elf_align)
     }
 
@@ -2608,7 +2668,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// `count` is the number of sections in the COMDAT group.
     ///
     /// Returns the offset of the range.
-    pub fn reserve_comdat(&mut self, count: usize) -> usize {
+    pub fn reserve_comdat(&mut self, count: usize) -> u64 {
         self.reserve((count + 1) * 4, 4)
     }
 }
@@ -2870,9 +2930,9 @@ pub struct FileHeader {
 
 #[derive(Debug, Clone, Default)]
 struct FileHeaderLayout {
-    segment_offset: usize,
+    segment_offset: u64,
     segment_num: u32,
-    section_offset: usize,
+    section_offset: u64,
     section_num: u32,
     shstrtab_index: SectionIndex,
 }

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -398,6 +398,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write alignment padding bytes prior to the program headers.
+    ///
+    /// In two-phase mode, does nothing if no program headers were reserved.
     pub fn write_align_program_headers(&mut self) {
         if !M::need_offset(self.layout.segment_offset) {
             return;
@@ -407,6 +409,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a program header.
+    ///
+    /// Must be called after [`Self::write_align_program_headers`].
     pub fn write_program_header(&mut self, header: &ProgramHeader) {
         Self::write_program_header_impl(self.buffer, self.endian, self.is_64, header);
         self.written_segment_num += 1;
@@ -449,7 +453,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null section header.
     ///
     /// This must be the first section header that is written.
-    /// This function does nothing if no sections were reserved.
+    /// In two-phase mode, does nothing if no sections were reserved.
     pub fn write_null_section_header(&mut self) {
         if !M::need_offset(self.layout.section_offset) {
             return;
@@ -483,6 +487,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a section header.
+    ///
+    /// Must be called after [`Self::write_null_section_header`].
     pub fn write_section_header(&mut self, section: &SectionHeader) -> SectionIndex {
         let sh_name = if let Some(name) = section.name {
             self.shstrtab.get_offset(name)
@@ -529,7 +535,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// This will be stored in the `.shstrtab` section.
     ///
-    /// This must be called before [`Self::reserve_shstrtab`].
+    /// Must be called before [`Self::reserve_shstrtab`] in two-phase mode,
+    /// or before [`Self::write_shstrtab`] in single-phase mode.
     pub fn add_section_name(&mut self, name: &'a [u8]) -> StringId {
         debug_assert_eq!(self.shstrtab_offset, 0);
         self.shstrtab.add(name)
@@ -537,7 +544,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the section header string table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// The header is only written if the section index was reserved in two-phase
+    /// mode, or [`Self::write_shstrtab`] was called in single-phase mode.
     pub fn write_shstrtab_section_header(&mut self) {
         if self.shstrtab_str_id.is_none() {
             return;
@@ -562,7 +570,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// This will be stored in the `.strtab` section.
     ///
-    /// This must be called before [`Self::reserve_strtab`] in two-phase mode,
+    /// Must be called before [`Self::reserve_strtab`] in two-phase mode,
     /// or before [`Self::write_strtab`] in single-phase mode.
     pub fn add_string(&mut self, name: &'a [u8]) -> StringId {
         debug_assert_eq!(self.strtab_offset, 0);
@@ -571,7 +579,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the string table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_strtab`] wrote the string table in single-phase mode.
     pub fn write_strtab_section_header(&mut self) {
         if self.strtab_str_id.is_none() {
             return;
@@ -594,7 +603,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null symbol.
     ///
     /// This must be the first symbol that is written.
-    /// This function does nothing if no symbols were reserved.
+    /// In two-phase mode, does nothing if no symbols were reserved.
     pub fn write_null_symbol(&mut self) {
         if !M::need_offset(self.symtab_offset) {
             return;
@@ -620,6 +629,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a symbol.
+    ///
+    /// Must be called after [`Self::write_null_symbol`].
     pub fn write_symbol(&mut self, sym: &Sym) -> SymbolIndex {
         let st_name = if let Some(name) = sym.name {
             self.strtab.get_offset(name)
@@ -674,7 +685,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the symbol table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_null_symbol`] was called in single-phase mode.
     pub fn write_symtab_section_header(&mut self, num_local: u32) {
         if self.symtab_str_id.is_none() {
             return;
@@ -696,7 +708,7 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the extended section indices for the symbol table.
     ///
-    /// This function does nothing if the section was not reserved.
+    /// Does nothing if extended section indices are not needed.
     pub fn write_symtab_shndx(&mut self) {
         if !self.need_symtab_shndx {
             self.symtab_shndx_data = Vec::new();
@@ -715,7 +727,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the extended section indices for the symbol table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_symtab_shndx`] was called in single-phase mode.
     pub fn write_symtab_shndx_section_header(&mut self) {
         if self.symtab_shndx_str_id.is_none() {
             return;
@@ -743,7 +756,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// This will be stored in the `.dynstr` section.
     ///
-    /// This must be called before [`Self::reserve_dynstr`] in two-phase mode,
+    /// Must be called before [`Self::reserve_dynstr`] in two-phase mode,
     /// or before [`Self::write_dynstr`] in single-phase mode.
     pub fn add_dynamic_string(&mut self, name: &'a [u8]) -> StringId {
         debug_assert_eq!(self.dynstr_offset, 0);
@@ -759,7 +772,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the dynamic string table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_dynstr`] wrote the string table in single-phase mode.
     pub fn write_dynstr_section_header(&mut self, sh_addr: u64) {
         if self.dynstr_str_id.is_none() {
             return;
@@ -782,7 +796,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null dynamic symbol.
     ///
     /// This must be the first dynamic symbol that is written.
-    /// This function does nothing if no dynamic symbols were reserved.
+    /// In two-phase mode, does nothing if no dynamic symbols were reserved.
     pub fn write_null_dynamic_symbol(&mut self) {
         if !M::need_offset(self.dynsym_offset) {
             return;
@@ -803,6 +817,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a dynamic symbol.
+    ///
+    /// Must be called after [`Self::write_null_dynamic_symbol`].
     pub fn write_dynamic_symbol(&mut self, sym: &Sym) -> SymbolIndex {
         let st_name = if let Some(name) = sym.name {
             self.dynstr.get_offset(name)
@@ -849,7 +865,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the dynamic symbol table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_null_dynamic_symbol`] was called in single-phase mode.
     pub fn write_dynsym_section_header(&mut self, sh_addr: u64, num_local: u32) {
         if self.dynsym_str_id.is_none() {
             return;
@@ -871,7 +888,7 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write alignment padding bytes prior to the `.dynamic` section.
     ///
-    /// This function does nothing if the section was not reserved.
+    /// In two-phase mode, does nothing if the section was not reserved.
     pub fn write_align_dynamic(&mut self) {
         if !M::need_offset(self.dynamic_offset) {
             return;
@@ -882,11 +899,15 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a dynamic string entry.
+    ///
+    /// Must be called after [`Self::write_align_dynamic`].
     pub fn write_dynamic_string(&mut self, tag: elf::DynamicTag, id: StringId) -> Result<()> {
         self.write_dynamic(tag, self.dynstr.get_offset(id).into())
     }
 
     /// Write a dynamic value entry.
+    ///
+    /// Must be called after [`Self::write_align_dynamic`].
     pub fn write_dynamic(&mut self, d_tag: elf::DynamicTag, d_val: u64) -> Result<()> {
         let endian = self.endian;
         if self.is_64 {
@@ -914,7 +935,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the dynamic table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_align_dynamic`] was called in single-phase mode.
     pub fn write_dynamic_section_header(&mut self, sh_addr: u64) {
         if self.dynamic_str_id.is_none() {
             return;
@@ -937,6 +959,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// `chain_count` is the number of symbols in the hash.
     /// The argument to `hash` will be in the range `0..chain_count`.
+    ///
+    /// In two-phase mode, [`Self::reserve_hash`] must be called before this.
     pub fn write_hash<F>(&mut self, bucket_count: u32, chain_count: u32, hash: F)
     where
         F: Fn(u32) -> Option<u32>,
@@ -965,7 +989,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the SysV hash table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_hash`] was called in single-phase mode.
     pub fn write_hash_section_header(&mut self, sh_addr: u64) {
         if self.hash_str_id.is_none() {
             return;
@@ -990,6 +1015,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// The argument to `hash` will be in the range `0..symbol_count`.
     ///
     /// This requires that symbols are already sorted by bucket.
+    ///
+    /// In two-phase mode, [`Self::reserve_gnu_hash`] must be called before this.
     pub fn write_gnu_hash<F>(
         &mut self,
         symbol_base: u32,
@@ -1073,7 +1100,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the GNU hash table.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_gnu_hash`] was called in single-phase mode.
     pub fn write_gnu_hash_section_header(&mut self, sh_addr: u64) {
         if self.gnu_hash_str_id.is_none() {
             return;
@@ -1095,7 +1123,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write the null symbol version entry.
     ///
     /// This must be the first symbol version that is written.
-    /// This function does nothing if no dynamic symbols were reserved.
+    /// In two-phase mode, does nothing if no dynamic symbols were reserved.
     pub fn write_null_gnu_versym(&mut self) {
         if !M::need_offset(self.gnu_versym_offset) {
             return;
@@ -1111,13 +1139,16 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a symbol version entry.
+    ///
+    /// Must be called after [`Self::write_null_gnu_versym`].
     pub fn write_gnu_versym(&mut self, versym: elf::VersymIndex) {
         self.buffer.write(&U16::new(self.endian, versym));
     }
 
     /// Write the section header for the `.gnu.version` section.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_null_gnu_versym`] was called in single-phase mode.
     pub fn write_gnu_versym_section_header(&mut self, sh_addr: u64) {
         if self.gnu_versym_str_id.is_none() {
             return;
@@ -1137,6 +1168,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write alignment padding bytes prior to a `.gnu.version_d` section.
+    ///
+    /// In two-phase mode, does nothing if the section was not reserved.
     pub fn write_align_gnu_verdef(&mut self) {
         if !M::need_offset(self.gnu_verdef_offset) {
             return;
@@ -1151,6 +1184,10 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a version definition entry.
+    ///
+    /// Must be called after [`Self::write_align_gnu_verdef`]. The number of entries
+    /// must have been set via [`Self::reserve_gnu_verdef`] in two-phase mode, or
+    /// [`Self::set_gnu_verdef_count`] in single-phase mode.
     pub fn write_gnu_verdef(&mut self, verdef: &Verdef) {
         debug_assert_ne!(self.gnu_verdef_remaining, 0);
         self.gnu_verdef_remaining -= 1;
@@ -1183,6 +1220,10 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// This is typically useful when there are only two versions (including the base)
     /// and they have the same name.
+    ///
+    /// Must be called after [`Self::write_align_gnu_verdef`]. The number of entries
+    /// must have been set via [`Self::reserve_gnu_verdef`] in two-phase mode, or
+    /// [`Self::set_gnu_verdef_count`] in single-phase mode.
     pub fn write_gnu_verdef_shared(&mut self, verdef: &Verdef) {
         debug_assert_ne!(self.gnu_verdef_remaining, 0);
         self.gnu_verdef_remaining -= 1;
@@ -1205,6 +1246,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a version definition auxiliary entry.
+    ///
+    /// Must be called inside a version definition started by [`Self::write_gnu_verdef`].
     pub fn write_gnu_verdaux(&mut self, name: StringId) {
         debug_assert_ne!(self.gnu_verdaux_remaining, 0);
         self.gnu_verdaux_remaining -= 1;
@@ -1221,7 +1264,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the `.gnu.version_d` section.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_align_gnu_verdef`] was called in single-phase mode.
     pub fn write_gnu_verdef_section_header(&mut self, sh_addr: u64) {
         if self.gnu_verdef_str_id.is_none() {
             return;
@@ -1245,6 +1289,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write alignment padding bytes prior to a `.gnu.version_r` section.
+    ///
+    /// In two-phase mode, does nothing if the section was not reserved.
     pub fn write_align_gnu_verneed(&mut self) {
         if !M::need_offset(self.gnu_verneed_offset) {
             return;
@@ -1259,6 +1305,10 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a version need entry.
+    ///
+    /// Must be called after [`Self::write_align_gnu_verneed`]. The number of entries
+    /// must have been set via [`Self::reserve_gnu_verneed`] in two-phase mode, or
+    /// [`Self::set_gnu_verneed_count`] in single-phase mode.
     pub fn write_gnu_verneed(&mut self, verneed: &Verneed) {
         debug_assert_ne!(self.gnu_verneed_remaining, 0);
         self.gnu_verneed_remaining -= 1;
@@ -1288,6 +1338,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a version need auxiliary entry.
+    ///
+    /// Must be called inside a version need started by [`Self::write_gnu_verneed`].
     pub fn write_gnu_vernaux(&mut self, vernaux: &Vernaux) {
         debug_assert_ne!(self.gnu_vernaux_remaining, 0);
         self.gnu_vernaux_remaining -= 1;
@@ -1307,7 +1359,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the `.gnu.version_r` section.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_align_gnu_verneed`] was called in single-phase mode.
     pub fn write_gnu_verneed_section_header(&mut self, sh_addr: u64) {
         if self.gnu_verneed_str_id.is_none() {
             return;
@@ -1332,7 +1385,8 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write the section header for the `.gnu.attributes` section.
     ///
-    /// This function does nothing if the section index was not reserved.
+    /// Only writes the header if the section index was reserved in two-phase mode,
+    /// or [`Self::write_gnu_attributes`] was called in single-phase mode.
     pub fn write_gnu_attributes_section_header(&mut self) {
         if self.gnu_attributes_str_id.is_none() {
             return;
@@ -1352,6 +1406,8 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write the data for the `.gnu.attributes` section.
+    ///
+    /// In two-phase mode, does nothing if the section was not reserved.
     pub fn write_gnu_attributes(&mut self, data: &[u8]) {
         if !M::need_offset(self.gnu_attributes_offset) {
             return;
@@ -1374,6 +1430,10 @@ impl<'a, M: Mode> Writer<'a, M> {
     }
 
     /// Write a relocation.
+    ///
+    /// [`Self::write_align_relocation`] should be called before the first relocation
+    /// of a section. In two-phase mode, the file range must have been reserved with
+    /// [`Self::reserve_relocations`].
     pub fn write_relocation(&mut self, is_rela: bool, rel: &Rel) {
         let endian = self.endian;
         if self.is_64 {
@@ -1610,6 +1670,8 @@ impl<'a> Writer<'a, SinglePhase> {
     /// other data is written. This pads the buffer by `count` program header entries.
     /// Use [`Self::write_headers_to`] to write the program headers once their contents
     /// are known.
+    ///
+    /// Does nothing if `count` is zero.
     pub fn write_program_headers_placeholder(&mut self, count: u32) {
         if count == 0 {
             return;
@@ -1660,7 +1722,7 @@ impl<'a> Writer<'a, SinglePhase> {
 
     /// Write the section header string table.
     ///
-    /// This will always write the string table, even if it is empty.
+    /// Always writes the string table, even if it is empty.
     pub fn write_shstrtab(&mut self) -> Result<()> {
         // This must be written before the .shstrtab section header, so
         // we can't use write_null_section_header to determine if it is needed.
@@ -1677,8 +1739,7 @@ impl<'a> Writer<'a, SinglePhase> {
 
     /// Write the string table.
     ///
-    /// Only writes the string table if there is a symbol table
-    /// or if it is not empty.
+    /// Only writes the string table if it is not empty, or if there is a symbol table.
     pub fn write_strtab(&mut self) -> Result<()> {
         if !self.need_strtab && self.strtab.is_empty() {
             return Ok(());
@@ -1695,8 +1756,8 @@ impl<'a> Writer<'a, SinglePhase> {
 
     /// Write the dynamic string table.
     ///
-    /// Only writes the string table if there is a dynamic symbol table
-    /// or if it is not empty.
+    /// Only writes the string table if it is not empty, or if there is a dynamic symbol
+    /// table.
     pub fn write_dynstr(&mut self) -> Result<()> {
         if !self.need_dynstr && self.dynstr.is_empty() {
             return Ok(());
@@ -1845,6 +1906,8 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// If `num` is >= `elf::PN_XNUM`, you must also reserve and write
     /// the section table; this is checked in `write_file_header`.
+    ///
+    /// Does nothing if `num` is zero.
     pub fn reserve_program_headers(&mut self, num: u32) {
         debug_assert_eq!(self.layout.segment_offset, 0);
         if num == 0 {
@@ -1862,7 +1925,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// The null section header is usually automatically reserved,
     /// but this can be used to force an empty section table.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_index`] and
+    /// [`Self::reserve_section_headers`].
     pub fn reserve_null_section_index(&mut self) -> SectionIndex {
         debug_assert_eq!(self.layout.section_num, 0);
         if self.layout.section_num == 0 {
@@ -1875,7 +1939,7 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// Automatically also reserves the null section header if required.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_section_index(&mut self) -> SectionIndex {
         debug_assert_eq!(self.layout.section_offset, 0);
         if self.layout.section_num == 0 {
@@ -1888,8 +1952,8 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the section headers.
     ///
-    /// This function does nothing if no sections were reserved.
-    /// This must be called after [`Self::reserve_section_index`]
+    /// Does nothing if no sections were reserved.
+    /// Must be called after [`Self::reserve_section_index`]
     /// and other functions that reserve section indices.
     pub fn reserve_section_headers(&mut self) {
         debug_assert_eq!(self.layout.section_offset, 0);
@@ -1906,9 +1970,9 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// This range is used for a section named `.shstrtab`.
     ///
-    /// This function does nothing if no sections were reserved.
-    /// This must be called after [`Self::add_section_name`].
-    /// and other functions that reserve section names and indices.
+    /// Does nothing if no sections were reserved.
+    /// Must be called after [`Self::add_section_name`]
+    /// and other functions that add section names and reserve indices.
     ///
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_shstrtab(&mut self) -> Result<()> {
@@ -1925,7 +1989,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Write the section header string table.
     ///
-    /// This function does nothing if the section was not reserved.
+    /// Does nothing if the section was not reserved.
     pub fn write_shstrtab(&mut self) {
         if self.shstrtab_offset == 0 {
             return;
@@ -1936,7 +2000,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the section index for the section header string table.
     ///
-    /// This must be called before [`Self::reserve_shstrtab`]
+    /// Must be called before [`Self::reserve_shstrtab`]
     /// and [`Self::reserve_section_headers`].
     pub fn reserve_shstrtab_section_index(&mut self) -> SectionIndex {
         self.reserve_shstrtab_section_index_with_name(&b".shstrtab"[..])
@@ -1944,7 +2008,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the section index for the section header string table.
     ///
-    /// This must be called before [`Self::reserve_shstrtab`]
+    /// Must be called before [`Self::reserve_shstrtab`]
     /// and [`Self::reserve_section_headers`].
     pub fn reserve_shstrtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert_eq!(self.layout.shstrtab_index, SectionIndex(0));
@@ -1968,8 +2032,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// This range is used for a section named `.strtab`.
     ///
     /// The range is only reserved if the string table is needed (either `require_strtab`
-    /// was called, or symbols or strings are present).
-    /// This must be called after [`Self::add_string`].
+    /// was called, or at least one string or symbol was added).
+    /// Must be called after [`Self::add_string`].
     ///
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_strtab(&mut self) -> Result<()> {
@@ -1986,7 +2050,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Write the string table.
     ///
-    /// This function does nothing if the section was not reserved.
+    /// Does nothing if the section was not reserved.
     pub fn write_strtab(&mut self) {
         if self.strtab_offset == 0 {
             return;
@@ -2000,7 +2064,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// You should check [`Self::strtab_needed`] before calling this
     /// unless you have other means of knowing if this section is needed.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_strtab_section_index(&mut self) -> SectionIndex {
         self.reserve_strtab_section_index_with_name(&b".strtab"[..])
     }
@@ -2010,7 +2074,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// You should check [`Self::strtab_needed`] before calling this
     /// unless you have other means of knowing if this section is needed.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_strtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert_eq!(self.strtab_index, SectionIndex(0));
         self.strtab_str_id = Some(self.add_section_name(name));
@@ -2025,7 +2089,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// The null symbol table entry is usually automatically reserved,
     /// but this can be used to force an empty symbol table.
     ///
-    /// This must be called before [`Self::reserve_symtab`].
+    /// Must be called before [`Self::reserve_symbol_index`] and
+    /// [`Self::reserve_symtab`].
     pub fn reserve_null_symbol_index(&mut self) -> SymbolIndex {
         debug_assert_eq!(self.symtab_offset, 0);
         debug_assert_eq!(self.symtab_num, 0);
@@ -2045,7 +2110,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Callers may assume that the returned indices will be sequential
     /// starting at 1.
     ///
-    /// This must be called before [`Self::reserve_symtab`] and
+    /// Must be called before [`Self::reserve_symtab`] and
     /// [`Self::reserve_symtab_shndx`].
     pub fn reserve_symbol_index(&mut self, section_index: Option<SectionIndex>) -> SymbolIndex {
         debug_assert_eq!(self.symtab_offset, 0);
@@ -2075,8 +2140,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Reserve the range for the symbol table.
     ///
     /// This range is used for a section named `.symtab`.
-    /// This function does nothing if no symbols were reserved.
-    /// This must be called after [`Self::reserve_symbol_index`].
+    /// Does nothing if no symbols were reserved.
+    /// Must be called after [`Self::reserve_symbol_index`].
     pub fn reserve_symtab(&mut self) {
         debug_assert_eq!(self.symtab_offset, 0);
         if self.symtab_num == 0 {
@@ -2090,14 +2155,14 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the section index for the symbol table.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_symtab_section_index(&mut self) -> SectionIndex {
         self.reserve_symtab_section_index_with_name(&b".symtab"[..])
     }
 
     /// Reserve the section index for the symbol table.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_symtab_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert_eq!(self.symtab_index, SectionIndex(0));
         self.symtab_str_id = Some(self.add_section_name(name));
@@ -2126,8 +2191,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// This range is used for a section named `.symtab_shndx`.
     /// This also reserves a section index.
     ///
-    /// This function does nothing if extended section indices are not needed.
-    /// This must be called after [`Self::reserve_symbol_index`].
+    /// Does nothing if extended section indices are not needed.
+    /// Must be called after [`Self::reserve_symbol_index`].
     pub fn reserve_symtab_shndx(&mut self) {
         debug_assert_eq!(self.symtab_shndx_offset, 0);
         if !self.symtab_shndx_needed() {
@@ -2142,7 +2207,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// You should check [`Self::symtab_shndx_needed`] before calling this
     /// unless you have other means of knowing if this section is needed.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_symtab_shndx_section_index(&mut self) -> SectionIndex {
         self.reserve_symtab_shndx_section_index_with_name(&b".symtab_shndx"[..])
     }
@@ -2152,7 +2217,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// You should check [`Self::symtab_shndx_needed`] before calling this
     /// unless you have other means of knowing if this section is needed.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_symtab_shndx_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert!(self.symtab_shndx_str_id.is_none());
         self.symtab_shndx_str_id = Some(self.add_section_name(name));
@@ -2175,7 +2240,7 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// The range is only reserved if the string table is needed (either `require_dynstr`
     /// was called, or dynamic symbols or dynamic strings are present).
-    /// This must be called after [`Self::add_dynamic_string`].
+    /// Must be called after [`Self::add_dynamic_string`].
     ///
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_dynstr(&mut self) -> Result<usize> {
@@ -2192,7 +2257,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Return the size of the dynamic string table.
     ///
-    /// This must be called after [`Self::reserve_dynstr`].
+    /// Must be called after [`Self::reserve_dynstr`].
     pub fn dynstr_len(&mut self) -> usize {
         debug_assert_ne!(self.dynstr_offset, 0);
         self.mode.dynstr_data.len()
@@ -2200,7 +2265,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Write the dynamic string table.
     ///
-    /// This function does nothing if the section was not reserved.
+    /// Does nothing if the section was not reserved.
     pub fn write_dynstr(&mut self) {
         if self.dynstr_offset == 0 {
             return;
@@ -2214,7 +2279,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// You should check [`Self::dynstr_needed`] before calling this
     /// unless you have other means of knowing if this section is needed.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_dynstr_section_index(&mut self) -> SectionIndex {
         self.reserve_dynstr_section_index_with_name(&b".dynstr"[..])
     }
@@ -2224,7 +2289,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// You should check [`Self::dynstr_needed`] before calling this
     /// unless you have other means of knowing if this section is needed.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_dynstr_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert_eq!(self.dynstr_index, SectionIndex(0));
         self.dynstr_str_id = Some(self.add_section_name(name));
@@ -2244,7 +2309,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// The null dynamic symbol table entry is usually automatically reserved,
     /// but this can be used to force an empty dynamic symbol table.
     ///
-    /// This must be called before [`Self::reserve_dynsym`].
+    /// Must be called before [`Self::reserve_dynamic_symbol_index`] and
+    /// [`Self::reserve_dynsym`].
     pub fn reserve_null_dynamic_symbol_index(&mut self) -> SymbolIndex {
         debug_assert_eq!(self.dynsym_offset, 0);
         debug_assert_eq!(self.dynsym_num, 0);
@@ -2260,7 +2326,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Callers may assume that the returned indices will be sequential
     /// starting at 1.
     ///
-    /// This must be called before [`Self::reserve_dynsym`].
+    /// Must be called before [`Self::reserve_dynsym`].
     pub fn reserve_dynamic_symbol_index(&mut self) -> SymbolIndex {
         debug_assert_eq!(self.dynsym_offset, 0);
         if self.dynsym_num == 0 {
@@ -2282,8 +2348,8 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// This range is used for a section named `.dynsym`.
     ///
-    /// This function does nothing if no dynamic symbols were reserved.
-    /// This must be called after [`Self::reserve_dynamic_symbol_index`].
+    /// Does nothing if no dynamic symbols were reserved.
+    /// Must be called after [`Self::reserve_dynamic_symbol_index`].
     pub fn reserve_dynsym(&mut self) -> usize {
         debug_assert_eq!(self.dynsym_offset, 0);
         if self.dynsym_num == 0 {
@@ -2298,14 +2364,14 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the section index for the dynamic symbol table.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_dynsym_section_index(&mut self) -> SectionIndex {
         self.reserve_dynsym_section_index_with_name(&b".dynsym"[..])
     }
 
     /// Reserve the section index for the dynamic symbol table.
     ///
-    /// This must be called before [`Self::reserve_section_headers`].
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_dynsym_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert_eq!(self.dynsym_index, SectionIndex(0));
         self.dynsym_str_id = Some(self.add_section_name(name));
@@ -2320,7 +2386,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.dynamic` section.
     ///
-    /// This function does nothing if `dynamic_num` is zero.
+    /// Does nothing if `dynamic_num` is zero.
     pub fn reserve_dynamic(&mut self, dynamic_num: usize) -> usize {
         debug_assert_eq!(self.dynamic_offset, 0);
         if dynamic_num == 0 {
@@ -2339,6 +2405,8 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the dynamic table.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_dynamic_section_index(&mut self) -> SectionIndex {
         debug_assert!(self.dynamic_str_id.is_none());
         self.dynamic_str_id = Some(self.add_section_name(&b".dynamic"[..]));
@@ -2356,11 +2424,15 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the SysV hash table.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_hash_section_index(&mut self) -> SectionIndex {
         self.reserve_hash_section_index_with_name(&b".hash"[..])
     }
 
     /// Reserve the section index for the SysV hash table.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_hash_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert!(self.hash_str_id.is_none());
         self.hash_str_id = Some(self.add_section_name(name));
@@ -2385,11 +2457,15 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the GNU hash table.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_hash_section_index(&mut self) -> SectionIndex {
         self.reserve_gnu_hash_section_index_with_name(&b".gnu.hash"[..])
     }
 
     /// Reserve the section index for the GNU hash table.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_hash_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert!(self.gnu_hash_str_id.is_none());
         self.gnu_hash_str_id = Some(self.add_section_name(name));
@@ -2398,7 +2474,7 @@ impl<'a> Writer<'a, TwoPhase> {
 
     /// Reserve the range for the `.gnu.version` section.
     ///
-    /// This function does nothing if no dynamic symbols were reserved.
+    /// Does nothing if no dynamic symbols were reserved.
     pub fn reserve_gnu_versym(&mut self) -> usize {
         debug_assert_eq!(self.gnu_versym_offset, 0);
         if self.dynsym_num == 0 {
@@ -2409,11 +2485,15 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the `.gnu.version` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_versym_section_index(&mut self) -> SectionIndex {
         self.reserve_gnu_versym_section_index_with_name(&b".gnu.version"[..])
     }
 
     /// Reserve the section index for the `.gnu.version` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_versym_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert!(self.gnu_versym_str_id.is_none());
         self.gnu_versym_str_id = Some(self.add_section_name(name));
@@ -2421,6 +2501,8 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the range for the `.gnu.version_d` section.
+    ///
+    /// Does nothing if `verdef_count` is zero.
     pub fn reserve_gnu_verdef(&mut self, verdef_count: usize, verdaux_count: usize) -> usize {
         debug_assert_eq!(self.gnu_verdef_offset, 0);
         if verdef_count == 0 {
@@ -2435,11 +2517,15 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the `.gnu.version_d` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_verdef_section_index(&mut self) -> SectionIndex {
         self.reserve_gnu_verdef_section_index_with_name(&b".gnu.version_d"[..])
     }
 
     /// Reserve the section index for the `.gnu.version_d` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_verdef_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert!(self.gnu_verdef_str_id.is_none());
         self.gnu_verdef_str_id = Some(self.add_section_name(name));
@@ -2447,6 +2533,8 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the range for the `.gnu.version_r` section.
+    ///
+    /// Does nothing if `verneed_count` is zero.
     pub fn reserve_gnu_verneed(&mut self, verneed_count: usize, vernaux_count: usize) -> usize {
         debug_assert_eq!(self.gnu_verneed_offset, 0);
         if verneed_count == 0 {
@@ -2461,11 +2549,15 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the `.gnu.version_r` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_verneed_section_index(&mut self) -> SectionIndex {
         self.reserve_gnu_verneed_section_index_with_name(&b".gnu.version_r"[..])
     }
 
     /// Reserve the section index for the `.gnu.version_r` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_verneed_section_index_with_name(&mut self, name: &'a [u8]) -> SectionIndex {
         debug_assert!(self.gnu_verneed_str_id.is_none());
         self.gnu_verneed_str_id = Some(self.add_section_name(name));
@@ -2473,11 +2565,15 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the section index for the `.gnu.attributes` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_attributes_section_index(&mut self) -> SectionIndex {
         self.reserve_gnu_attributes_section_index_with_name(&b".gnu.attributes"[..])
     }
 
     /// Reserve the section index for the `.gnu.attributes` section.
+    ///
+    /// Must be called before [`Self::reserve_section_headers`].
     pub fn reserve_gnu_attributes_section_index_with_name(
         &mut self,
         name: &'a [u8],
@@ -2488,6 +2584,8 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Reserve the range for the `.gnu.attributes` section.
+    ///
+    /// Does nothing if `gnu_attributes_size` is zero.
     pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: usize) -> usize {
         debug_assert_eq!(self.gnu_attributes_offset, 0);
         if gnu_attributes_size == 0 {

--- a/src/write/string.rs
+++ b/src/write/string.rs
@@ -16,10 +16,36 @@ pub struct StringId(usize);
 pub(crate) struct StringTable<'a> {
     strings: IndexSet<&'a [u8]>,
     offsets: Vec<u32>,
+    size: u64,
+    in_order: bool,
+    // Only set for in_order.
+    base: u32,
 }
 
 impl<'a> StringTable<'a> {
+    /// Construct a new string table.
+    #[allow(dead_code)]
+    pub(crate) fn new() -> Self {
+        StringTable::default()
+    }
+
+    /// Construct a new string table that writes the strings in
+    /// the order they are added.
+    ///
+    /// This does not perform suffix merging.
+    #[allow(dead_code)]
+    pub(crate) fn new_in_order(base: u32) -> Self {
+        StringTable {
+            strings: IndexSet::default(),
+            offsets: Vec::new(),
+            size: base.into(),
+            in_order: true,
+            base,
+        }
+    }
+
     /// Return true if the string table contains no strings.
+    #[allow(dead_code)]
     pub(crate) fn is_empty(&self) -> bool {
         self.strings.is_empty()
     }
@@ -33,9 +59,13 @@ impl<'a> StringTable<'a> {
     /// The string must not contain a null byte; this is asserted here for
     /// debug builds, and checked by `write` for all builds.
     pub(crate) fn add(&mut self, string: &'a [u8]) -> StringId {
-        debug_assert!(self.offsets.is_empty());
+        debug_assert!(self.in_order || self.offsets.is_empty());
         debug_assert!(!string.contains(&0));
-        let id = self.strings.insert_full(string).0;
+        let (id, new) = self.strings.insert_full(string);
+        if new && self.in_order {
+            self.offsets.push(self.size as u32);
+            self.size += string.len() as u64 + 1;
+        }
         StringId(id)
     }
 
@@ -58,7 +88,11 @@ impl<'a> StringTable<'a> {
 
     /// Return the offset of the given string.
     ///
-    /// Must be called after [`Self::write`].
+    /// Must be called after [`Self::write`] unless the string table was
+    /// constructed with [`Self::new_in_order`].
+    ///
+    /// When using `new_in_order`, the offset returned will be truncated if it
+    /// overflows `u32`. Reporting the overflow is postponed to `write`.
     ///
     /// Panics if `id` is invalid or `write` was not called.
     pub(crate) fn get_offset(&self, id: StringId) -> u32 {
@@ -79,11 +113,21 @@ impl<'a> StringTable<'a> {
     /// - any string contains a null byte
     /// - the string table size is > `u32::MAX`
     pub(crate) fn write(&mut self, base: u32, w: &mut Vec<u8>) -> Result<u32> {
-        if !self.offsets.is_empty() {
+        if !self.in_order && !self.offsets.is_empty() {
             return Err(Error("string table already written".into()));
         }
         if self.strings.iter().any(|s| s.contains(&0)) {
             return Err(Error("string table entry contains null byte".into()));
+        }
+
+        if self.in_order {
+            debug_assert_eq!(self.base, base);
+            for string in &self.strings {
+                w.extend_from_slice(string);
+                w.push(0);
+            }
+            return u32::try_from(self.size)
+                .map_err(|_| Error("string table size overflow".into()));
         }
 
         let mut ids: Vec<_> = (0..self.strings.len()).collect();
@@ -115,6 +159,11 @@ impl<'a> StringTable<'a> {
     /// null byte.
     #[allow(dead_code)]
     pub(crate) fn size(&self, base: usize) -> usize {
+        if self.in_order {
+            debug_assert_eq!(self.base as usize, base);
+            return self.size as usize;
+        }
+
         // TODO: cache this result?
         let mut ids: Vec<_> = (0..self.strings.len()).collect();
         sort(&mut ids, 1, &self.strings);
@@ -198,8 +247,7 @@ mod tests {
         let id2 = table.add(b"bar");
         let id3 = table.add(b"foobar");
 
-        let mut data = Vec::new();
-        data.push(0);
+        let mut data = vec![0];
         assert_eq!(table.write(1, &mut data), Ok(12));
         assert_eq!(data, b"\0foobar\0foo\0");
 
@@ -210,5 +258,28 @@ mod tests {
 
         let mut data = Vec::new();
         assert!(table.write(1, &mut data).is_err());
+    }
+
+    #[test]
+    fn string_table_in_order() {
+        let mut table = StringTable::new_in_order(1);
+        let id0 = table.add(b"");
+        let id1 = table.add(b"foo");
+        let id2 = table.add(b"bar");
+        let id3 = table.add(b"foobar");
+
+        let mut data = vec![0];
+        assert_eq!(table.write(1, &mut data), Ok(17));
+        assert_eq!(data, b"\0\0foo\0bar\0foobar\0");
+
+        assert_eq!(table.get_offset(id0), 1);
+        assert_eq!(table.get_offset(id1), 2);
+        assert_eq!(table.get_offset(id2), 6);
+        assert_eq!(table.get_offset(id3), 10);
+
+        // Not documented or expected to be needed, but multiple writes aren't prevented.
+        let mut data2 = vec![0];
+        assert_eq!(table.write(1, &mut data2), Ok(17));
+        assert_eq!(data, data2);
     }
 }

--- a/src/write/string.rs
+++ b/src/write/string.rs
@@ -19,6 +19,11 @@ pub(crate) struct StringTable<'a> {
 }
 
 impl<'a> StringTable<'a> {
+    /// Return true if the string table contains no strings.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.strings.is_empty()
+    }
+
     /// Add a string to the string table.
     ///
     /// Duplicate strings return the id of the existing entry.

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -63,7 +63,12 @@ impl<'a> dyn WritableBuffer + 'a {
 ///
 /// [`WritableBuffer::reserve`] may still be called but this is not required.
 /// Writes will automatically increase the capacity of the buffer.
-pub trait GrowableBuffer: WritableBuffer {}
+pub trait GrowableBuffer: WritableBuffer {
+    /// Upcast to a [`WritableBuffer`] trait object.
+    //
+    // Manual upcast because trait upcasting coercion requires MSRV 1.86.
+    fn as_writable(&mut self) -> &mut dyn WritableBuffer;
+}
 
 impl<'a> dyn GrowableBuffer + 'a {
     /// Writes the specified `Pod` type at the end of the buffer.
@@ -77,7 +82,11 @@ impl<'a> dyn GrowableBuffer + 'a {
     }
 }
 
-impl GrowableBuffer for Vec<u8> {}
+impl GrowableBuffer for Vec<u8> {
+    fn as_writable(&mut self) -> &mut dyn WritableBuffer {
+        self
+    }
+}
 
 impl WritableBuffer for Vec<u8> {
     #[inline]
@@ -151,7 +160,11 @@ impl<W: io::Write> StreamingBuffer<W> {
 }
 
 #[cfg(feature = "std")]
-impl<W: io::Write> GrowableBuffer for StreamingBuffer<W> {}
+impl<W: io::Write> GrowableBuffer for StreamingBuffer<W> {
+    fn as_writable(&mut self) -> &mut dyn WritableBuffer {
+        self
+    }
+}
 
 #[cfg(feature = "std")]
 impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {


### PR DESCRIPTION
Breaking change: many `write::elf::Writer` methods return `u64` instead of `usize`.

Closes #841 