### PR TITLE
write/macho: add Encoder

### DIFF
--- a/src/write/macho/encoder.rs
+++ b/src/write/macho/encoder.rs
@@ -1,0 +1,583 @@
+use core::mem;
+
+use crate::endian::*;
+use crate::macho;
+use crate::write::util::{align, write_pod};
+use crate::write::{Error, Result, StringTable, WritableBuffer};
+
+/// Native endian version of [`macho::MachHeader64`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct MachHeader {
+    pub cputype: macho::CpuType,
+    pub cpusubtype: macho::CpuSubtype,
+    pub filetype: macho::FileType,
+    pub ncmds: u32,
+    pub sizeofcmds: u32,
+    pub flags: macho::FileFlags,
+}
+
+/// Native endian version of [`macho::SegmentCommand64`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct SegmentCommand {
+    pub segname: [u8; 16],
+    pub vmaddr: u64,
+    pub vmsize: u64,
+    pub fileoff: u64,
+    pub filesize: u64,
+    pub maxprot: macho::VmProt,
+    pub initprot: macho::VmProt,
+    pub nsects: u32,
+    pub flags: macho::SegmentFlags,
+}
+
+/// Native endian version of [`macho::Section64`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct SectionHeader {
+    pub sectname: [u8; 16],
+    pub segname: [u8; 16],
+    pub addr: u64,
+    pub size: u64,
+    pub offset: u32,
+    pub align: u32,
+    pub reloff: u32,
+    pub nreloc: u32,
+    pub flags: macho::SectionFlags,
+    pub reserved1: u32,
+    pub reserved2: u32,
+    pub reserved3: u32,
+}
+
+/// Native endian version of [`macho::SymtabCommand`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct SymtabCommand {
+    pub symoff: u32,
+    pub nsyms: u32,
+    pub stroff: u32,
+    pub strsize: u32,
+}
+
+/// Native endian version of [`macho::DysymtabCommand`].
+#[allow(missing_docs)]
+#[derive(Debug, Default, Clone)]
+pub struct DysymtabCommand {
+    pub ilocalsym: u32,
+    pub nlocalsym: u32,
+    pub iextdefsym: u32,
+    pub nextdefsym: u32,
+    pub iundefsym: u32,
+    pub nundefsym: u32,
+    pub tocoff: u32,
+    pub ntoc: u32,
+    pub modtaboff: u32,
+    pub nmodtab: u32,
+    pub extrefsymoff: u32,
+    pub nextrefsyms: u32,
+    pub indirectsymoff: u32,
+    pub nindirectsyms: u32,
+    pub extreloff: u32,
+    pub nextrel: u32,
+    pub locreloff: u32,
+    pub nlocrel: u32,
+}
+
+/// Native endian version of [`macho::Nlist64`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct Nlist {
+    pub n_strx: u32,
+    pub n_type: macho::SymbolFlags,
+    pub n_sect: u8,
+    pub n_desc: macho::SymbolDesc,
+    pub n_value: u64,
+}
+
+/// Native endian version of [`macho::DylibCommand`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct DylibCommand<'data> {
+    pub cmd: macho::LoadCommandType,
+    pub name: &'data [u8],
+    pub timestamp: u32,
+    pub current_version: macho::Version,
+    pub compatibility_version: macho::Version,
+}
+
+/// Native endian version of [`macho::BuildVersionCommand`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct BuildVersionCommand {
+    pub platform: macho::Platform,
+    pub minos: macho::Version,
+    pub sdk: macho::Version,
+    pub ntools: u32,
+}
+
+/// A helper for encoding headers and data when writing a Mach-O file.
+///
+/// None of the methods check for overflow when truncating file offsets, or when
+/// truncating addresses for 32-bit Mach-O. It is recommended that the caller keep
+/// track of the largest address and file offset, and perform a single overflow check.
+#[derive(Debug, Clone, Copy)]
+pub struct Encoder<E: Endian> {
+    endian: E,
+    is_64: bool,
+}
+
+impl<E: Endian> Encoder<E> {
+    /// Create a new `Encoder` for the given endianness and pointer width.
+    pub fn new(endian: E, is_64: bool) -> Self {
+        Encoder { endian, is_64 }
+    }
+
+    /// Return the endianness.
+    pub fn endian(self) -> E {
+        self.endian
+    }
+
+    /// Return true for 64-bit Mach-O.
+    pub fn is_64(self) -> bool {
+        self.is_64
+    }
+
+    /// Return the size in bytes of an address.
+    ///
+    /// This should be used as the file offset alignment for various structures such as
+    /// load commands, symbols, and relocations.
+    pub fn address_size(self) -> u64 {
+        if self.is_64 { 8 } else { 4 }
+    }
+
+    /// Return the size of the file header.
+    pub fn mach_header_size(self) -> u64 {
+        if self.is_64 {
+            mem::size_of::<macho::MachHeader64<Endianness>>() as u64
+        } else {
+            mem::size_of::<macho::MachHeader32<Endianness>>() as u64
+        }
+    }
+
+    /// Write the file header.
+    ///
+    /// The buffer should be at the start of the file.
+    pub fn mach_header<W: WritableBuffer + ?Sized>(self, buffer: &mut W, header: &MachHeader) {
+        let endian = self.endian;
+        if self.is_64 {
+            let magic = if endian.is_big_endian() {
+                macho::MH_MAGIC_64
+            } else {
+                macho::MH_CIGAM_64
+            };
+            let data = &macho::MachHeader64 {
+                magic: U32::new(BigEndian, magic),
+                cputype: U32::new(endian, header.cputype),
+                cpusubtype: U32::new(endian, header.cpusubtype),
+                filetype: U32::new(endian, header.filetype),
+                ncmds: U32::new(endian, header.ncmds),
+                sizeofcmds: U32::new(endian, header.sizeofcmds),
+                flags: U32::new(endian, header.flags),
+                reserved: U32::default(),
+            };
+            write_pod(buffer, data);
+        } else {
+            let magic = if endian.is_big_endian() {
+                macho::MH_MAGIC
+            } else {
+                macho::MH_CIGAM
+            };
+            let data = &macho::MachHeader32 {
+                magic: U32::new(BigEndian, magic),
+                cputype: U32::new(endian, header.cputype),
+                cpusubtype: U32::new(endian, header.cpusubtype),
+                filetype: U32::new(endian, header.filetype),
+                ncmds: U32::new(endian, header.ncmds),
+                sizeofcmds: U32::new(endian, header.sizeofcmds),
+                flags: U32::new(endian, header.flags),
+            };
+            write_pod(buffer, data);
+        }
+    }
+
+    /// Return the size of a raw load command.
+    ///
+    /// `data_size` is the number of bytes following the common load command header.
+    pub fn load_command_size(self, data_size: u64) -> u64 {
+        mem::size_of::<macho::LoadCommand<Endianness>>() as u64 + data_size
+    }
+
+    /// Write a raw load command.
+    ///
+    /// `data` is the bytes following the common load command header.
+    ///
+    /// No overflow check is performed for the command size.
+    pub fn load_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        cmd: macho::LoadCommandType,
+        data: &[u8],
+    ) {
+        let endian = self.endian;
+        let cmdsize = (mem::size_of::<macho::LoadCommand<Endianness>>() + data.len()) as u32;
+        let command = &macho::LoadCommand {
+            cmd: U32::new(endian, cmd),
+            cmdsize: U32::new(endian, cmdsize),
+        };
+        write_pod(buffer, command);
+        buffer.write_bytes(data);
+    }
+
+    /// Return the size of a segment command.
+    pub fn segment_command_size(self, nsects: u32) -> u64 {
+        (if self.is_64 {
+            mem::size_of::<macho::SegmentCommand64<Endianness>>() as u64
+        } else {
+            mem::size_of::<macho::SegmentCommand32<Endianness>>() as u64
+        }) + u64::from(nsects) * self.section_header_size()
+    }
+
+    /// Write a segment command.
+    ///
+    /// No overflow check is performed when truncating `vmaddr`, `vmsize`,
+    /// `fileoffset`, and `filesize` for 32-bit Mach-O.
+    pub fn segment_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        segment: &SegmentCommand,
+    ) {
+        let endian = self.endian;
+        let cmdsize = self.segment_command_size(segment.nsects) as u32;
+        if self.is_64 {
+            let data = &macho::SegmentCommand64 {
+                cmd: U32::new(endian, macho::LC_SEGMENT_64),
+                cmdsize: U32::new(endian, cmdsize),
+                segname: segment.segname,
+                vmaddr: U64::new(endian, segment.vmaddr),
+                vmsize: U64::new(endian, segment.vmsize),
+                fileoff: U64::new(endian, segment.fileoff),
+                filesize: U64::new(endian, segment.filesize),
+                maxprot: U32::new(endian, segment.maxprot),
+                initprot: U32::new(endian, segment.initprot),
+                nsects: U32::new(endian, segment.nsects),
+                flags: U32::new(endian, segment.flags),
+            };
+            write_pod(buffer, data);
+        } else {
+            let data = &macho::SegmentCommand32 {
+                cmd: U32::new(endian, macho::LC_SEGMENT),
+                cmdsize: U32::new(endian, cmdsize),
+                segname: segment.segname,
+                vmaddr: U32::new(endian, segment.vmaddr as u32),
+                vmsize: U32::new(endian, segment.vmsize as u32),
+                fileoff: U32::new(endian, segment.fileoff as u32),
+                filesize: U32::new(endian, segment.filesize as u32),
+                maxprot: U32::new(endian, segment.maxprot),
+                initprot: U32::new(endian, segment.initprot),
+                nsects: U32::new(endian, segment.nsects),
+                flags: U32::new(endian, segment.flags),
+            };
+            write_pod(buffer, data);
+        }
+    }
+
+    /// Return the size of a section header.
+    pub fn section_header_size(self) -> u64 {
+        if self.is_64 {
+            mem::size_of::<macho::Section64<Endianness>>() as u64
+        } else {
+            mem::size_of::<macho::Section32<Endianness>>() as u64
+        }
+    }
+
+    /// Write a section header.
+    ///
+    /// No overflow check is performed when truncating `addr` and `size`
+    /// for 32-bit Mach-O.
+    pub fn section_header<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        section: &SectionHeader,
+    ) {
+        let endian = self.endian;
+        if self.is_64 {
+            let data = &macho::Section64 {
+                sectname: section.sectname,
+                segname: section.segname,
+                addr: U64::new(endian, section.addr),
+                size: U64::new(endian, section.size),
+                offset: U32::new(endian, section.offset),
+                align: U32::new(endian, section.align),
+                reloff: U32::new(endian, section.reloff),
+                nreloc: U32::new(endian, section.nreloc),
+                flags: U32::new(endian, section.flags),
+                reserved1: U32::new(endian, section.reserved1),
+                reserved2: U32::new(endian, section.reserved2),
+                reserved3: U32::new(endian, section.reserved3),
+            };
+            write_pod(buffer, data);
+        } else {
+            let data = &macho::Section32 {
+                sectname: section.sectname,
+                segname: section.segname,
+                addr: U32::new(endian, section.addr as u32),
+                size: U32::new(endian, section.size as u32),
+                offset: U32::new(endian, section.offset),
+                align: U32::new(endian, section.align),
+                reloff: U32::new(endian, section.reloff),
+                nreloc: U32::new(endian, section.nreloc),
+                flags: U32::new(endian, section.flags),
+                reserved1: U32::new(endian, section.reserved1),
+                reserved2: U32::new(endian, section.reserved2),
+            };
+            write_pod(buffer, data);
+        }
+    }
+
+    /// Return the size of a relocation.
+    pub fn relocation_size(self) -> u64 {
+        mem::size_of::<macho::Relocation<Endianness>>() as u64
+    }
+
+    /// Write a relocation.
+    ///
+    /// No overflow check is performed when truncating `r_symbolnum` to 24 bits.
+    pub fn relocation<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        rel: &macho::RelocationInfo,
+    ) {
+        write_pod(buffer, &rel.relocation(self.endian));
+    }
+
+    /// Return the size of a symtab load command.
+    pub fn symtab_command_size(self) -> u64 {
+        mem::size_of::<macho::SymtabCommand<Endianness>>() as u64
+    }
+
+    /// Write a symtab load command.
+    pub fn symtab_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        symtab: &SymtabCommand,
+    ) {
+        let endian = self.endian;
+        let data = &macho::SymtabCommand {
+            cmd: U32::new(endian, macho::LC_SYMTAB),
+            cmdsize: U32::new(endian, self.symtab_command_size() as u32),
+            symoff: U32::new(endian, symtab.symoff),
+            nsyms: U32::new(endian, symtab.nsyms),
+            stroff: U32::new(endian, symtab.stroff),
+            strsize: U32::new(endian, symtab.strsize),
+        };
+        write_pod(buffer, data);
+    }
+
+    /// Return the size of a symbol.
+    pub fn nlist_size(self) -> u64 {
+        if self.is_64 {
+            mem::size_of::<macho::Nlist64<Endianness>>() as u64
+        } else {
+            mem::size_of::<macho::Nlist32<Endianness>>() as u64
+        }
+    }
+
+    /// Write a symbol.
+    ///
+    /// No overflow check is performed when truncating `n_value` for 32-bit Mach-O.
+    pub fn nlist<W: WritableBuffer + ?Sized>(self, buffer: &mut W, nlist: &Nlist) {
+        let endian = self.endian;
+        if self.is_64 {
+            let data = &macho::Nlist64 {
+                n_strx: U32::new(endian, nlist.n_strx),
+                n_type: nlist.n_type,
+                n_sect: nlist.n_sect,
+                n_desc: U16::new(endian, nlist.n_desc),
+                n_value: U64::new(endian, nlist.n_value),
+            };
+            write_pod(buffer, data);
+        } else {
+            let data = &macho::Nlist32 {
+                n_strx: U32::new(endian, nlist.n_strx),
+                n_type: nlist.n_type,
+                n_sect: nlist.n_sect,
+                n_desc: U16::new(endian, nlist.n_desc),
+                n_value: U32::new(endian, nlist.n_value as u32),
+            };
+            write_pod(buffer, data);
+        }
+    }
+
+    /// Write the data for a string table.
+    ///
+    /// The string table data is padded to a multiple of the address size.
+    ///
+    /// Returns the length of the written data.
+    pub fn strtab<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        strtab: &mut StringTable<'_>,
+    ) -> Result<u32> {
+        buffer.write_bytes(&[0]);
+        let len = strtab.write(buffer, 1)? as u64;
+        let aligned_len = align(len, self.address_size());
+        buffer.resize(buffer.len() + (aligned_len - len));
+        u32::try_from(aligned_len).map_err(|_| Error("string table size overflow".into()))
+    }
+
+    /// Return the size of a dynamic symtab load command.
+    pub fn dysymtab_command_size(self) -> u64 {
+        mem::size_of::<macho::DysymtabCommand<Endianness>>() as u64
+    }
+
+    /// Write a dynamic symtab load command.
+    pub fn dysymtab_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        dysymtab: &DysymtabCommand,
+    ) {
+        let endian = self.endian;
+        let data = &macho::DysymtabCommand {
+            cmd: U32::new(endian, macho::LC_DYSYMTAB),
+            cmdsize: U32::new(endian, self.dysymtab_command_size() as u32),
+            ilocalsym: U32::new(endian, dysymtab.ilocalsym),
+            nlocalsym: U32::new(endian, dysymtab.nlocalsym),
+            iextdefsym: U32::new(endian, dysymtab.iextdefsym),
+            nextdefsym: U32::new(endian, dysymtab.nextdefsym),
+            iundefsym: U32::new(endian, dysymtab.iundefsym),
+            nundefsym: U32::new(endian, dysymtab.nundefsym),
+            tocoff: U32::new(endian, dysymtab.tocoff),
+            ntoc: U32::new(endian, dysymtab.ntoc),
+            modtaboff: U32::new(endian, dysymtab.modtaboff),
+            nmodtab: U32::new(endian, dysymtab.nmodtab),
+            extrefsymoff: U32::new(endian, dysymtab.extrefsymoff),
+            nextrefsyms: U32::new(endian, dysymtab.nextrefsyms),
+            indirectsymoff: U32::new(endian, dysymtab.indirectsymoff),
+            nindirectsyms: U32::new(endian, dysymtab.nindirectsyms),
+            extreloff: U32::new(endian, dysymtab.extreloff),
+            nextrel: U32::new(endian, dysymtab.nextrel),
+            locreloff: U32::new(endian, dysymtab.locreloff),
+            nlocrel: U32::new(endian, dysymtab.nlocrel),
+        };
+        write_pod(buffer, data);
+    }
+
+    /// Return the size of an indirect symbol for a dynamic symtab load command.
+    pub fn indirect_symbol_size(self) -> u64 {
+        mem::size_of::<U32<Endianness>>() as u64
+    }
+
+    /// Write an indirect symbol for a dynamic symtab load command.
+    pub fn indirect_symbol<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        symbol: macho::IndirectSymbol,
+    ) {
+        write_pod(buffer, &U32::new(self.endian, symbol));
+    }
+
+    /// Return the size of a dylib command.
+    ///
+    /// `dylib_len` is the length of the dylib name excluding the null terminator.
+    pub fn dylib_command_size(self, dylib_len: usize) -> u64 {
+        align(
+            mem::size_of::<macho::DylibCommand<Endianness>>() as u64 + dylib_len as u64 + 1,
+            self.address_size(),
+        )
+    }
+
+    /// Write a dylib command.
+    pub fn dylib_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        dylib: &DylibCommand<'_>,
+    ) {
+        let offset = buffer.len();
+        let cmdsize = self.dylib_command_size(dylib.name.len());
+        let name_offset = mem::size_of::<macho::DylibCommand<Endianness>>() as u32;
+        let endian = self.endian;
+        let data = &macho::DylibCommand {
+            cmd: U32::new(endian, dylib.cmd),
+            cmdsize: U32::new(endian, cmdsize as u32),
+            dylib: macho::Dylib {
+                name: macho::LcStr {
+                    offset: U32::new(endian, name_offset),
+                },
+                timestamp: U32::new(endian, dylib.timestamp),
+                current_version: U32::new(endian, dylib.current_version),
+                compatibility_version: U32::new(endian, dylib.compatibility_version),
+            },
+        };
+        write_pod(buffer, data);
+        buffer.write_bytes(dylib.name);
+        buffer.resize(offset + cmdsize);
+    }
+
+    /// Return the size of a build version load command.
+    pub fn build_version_command_size(self, ntools: u32) -> u64 {
+        mem::size_of::<macho::BuildVersionCommand<Endianness>>() as u64
+            + u64::from(ntools) * mem::size_of::<macho::BuildToolVersion<Endianness>>() as u64
+    }
+
+    /// Write a build version load command.
+    pub fn build_version_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        version: &BuildVersionCommand,
+    ) {
+        let endian = self.endian;
+        let data = &macho::BuildVersionCommand {
+            cmd: U32::new(endian, macho::LC_BUILD_VERSION),
+            cmdsize: U32::new(
+                endian,
+                self.build_version_command_size(version.ntools) as u32,
+            ),
+            platform: U32::new(endian, version.platform),
+            minos: U32::new(endian, version.minos),
+            sdk: U32::new(endian, version.sdk),
+            ntools: U32::new(endian, version.ntools),
+        };
+        write_pod(buffer, data);
+    }
+
+    /// Write a build tool version.
+    ///
+    /// These should be written immediately following the load command.
+    pub fn build_tool_version<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        tool: macho::Tool,
+        version: macho::Version,
+    ) {
+        let endian = self.endian;
+        let data = &macho::BuildToolVersion {
+            tool: U32::new(endian, tool),
+            version: U32::new(endian, version),
+        };
+        write_pod(buffer, data);
+    }
+
+    /// Return the size of a load command referencing linkedit data.
+    pub fn linkedit_data_command_size(self) -> u64 {
+        mem::size_of::<macho::LinkeditDataCommand<Endianness>>() as u64
+    }
+
+    /// Write a load command referencing linkedit data.
+    pub fn linkedit_data_command<W: WritableBuffer + ?Sized>(
+        self,
+        buffer: &mut W,
+        cmd: macho::LoadCommandType,
+        dataoff: u32,
+        datasize: u32,
+    ) {
+        let endian = self.endian;
+        let data = &macho::LinkeditDataCommand {
+            cmd: U32::new(endian, cmd),
+            cmdsize: U32::new(endian, self.linkedit_data_command_size() as u32),
+            dataoff: U32::new(endian, dataoff),
+            datasize: U32::new(endian, datasize),
+        };
+        write_pod(buffer, data);
+    }
+}

--- a/src/write/macho/mod.rs
+++ b/src/write/macho/mod.rs
@@ -1,0 +1,10 @@
+//! Support for writing Mach-O files.
+//!
+//! Provides [`Encoder`] for low level writing of Mach-O files.
+//! This is also used to provide Mach-O support for [`write::Object`](crate::write::Object).
+
+mod encoder;
+pub use encoder::*;
+
+mod object;
+pub use object::*;

--- a/src/write/macho/object.rs
+++ b/src/write/macho/object.rs
@@ -1,23 +1,20 @@
-use core::mem;
-
-use crate::endian::*;
 use crate::macho;
+use crate::write::macho::encoder::*;
 use crate::write::string::*;
-use crate::write::util::*;
 use crate::write::*;
 
 #[derive(Default, Clone, Copy)]
 struct SectionOffsets {
-    index: usize,
+    index: u32,
     offset: u64,
     address: u64,
     reloc_offset: u64,
-    reloc_count: usize,
+    reloc_count: u32,
 }
 
 #[derive(Default, Clone, Copy)]
 struct SymbolOffsets {
-    index: usize,
+    index: u32,
     str_id: Option<StringId>,
 }
 
@@ -34,15 +31,6 @@ pub struct MachOBuildVersion {
     /// The SDK version as `X.Y.Z`, where `X.Y.Z` is encoded in nibbles as
     /// `xxxx.yy.zz`.
     pub sdk: macho::Version,
-}
-
-impl MachOBuildVersion {
-    fn cmdsize(&self) -> u32 {
-        // Same size for both endianness, and we don't have `ntools`.
-        let sz = mem::size_of::<macho::BuildVersionCommand<Endianness>>();
-        debug_assert!(sz <= u32::MAX as usize);
-        sz as u32
-    }
 }
 
 // Public methods.
@@ -444,61 +432,61 @@ impl<'a> Object<'a> {
     }
 
     pub(crate) fn macho_write(&self, buffer: &mut dyn WritableBuffer) -> Result<()> {
-        let address_size = self.architecture.address_size().unwrap();
-        let endian = self.endian;
-        let macho32 = MachO32 { endian };
-        let macho64 = MachO64 { endian };
-        let macho: &dyn MachO = match address_size {
-            AddressSize::U8 | AddressSize::U16 | AddressSize::U32 => &macho32,
-            AddressSize::U64 => &macho64,
+        struct Offset(u64);
+        impl Offset {
+            fn reserve(&mut self, size: u64, align_size: u64) -> u64 {
+                self.0 = align(self.0, align_size);
+                let offset = self.0;
+                self.0 += size;
+                offset
+            }
+        }
+        let is_64 = match self.architecture.address_size().unwrap() {
+            AddressSize::U8 | AddressSize::U16 | AddressSize::U32 => false,
+            AddressSize::U64 => true,
         };
-        let pointer_align = address_size.bytes() as u64;
+        let encoder = Encoder::new(self.endian, is_64);
+        let pointer_align = encoder.address_size();
 
         // Calculate offsets of everything, and build strtab.
-        let mut offset = 0;
-
-        // Calculate size of Mach-O header.
-        offset += macho.mach_header_size();
+        let mut offset = Offset(encoder.mach_header_size());
 
         // Calculate size of commands.
         let mut ncmds = 0;
-        let command_offset = offset;
+        let command_offset = offset.0;
 
         // Calculate size of segment command and section headers.
-        let segment_command_offset = offset;
-        let segment_command_len =
-            macho.segment_command_size() + self.sections.len() as u64 * macho.section_header_size();
-        offset += segment_command_len;
+        let nsects = self.sections.len() as u32;
+        if nsects > 255 {
+            return Err(Error(format!("Too many sections: {nsects:#x}")));
+        }
+        let segment_command_offset = offset.reserve(encoder.segment_command_size(nsects), 1);
         ncmds += 1;
 
         // Calculate size of build version.
-        let build_version_offset = offset;
-        if let Some(version) = &self.macho_build_version {
-            offset += version.cmdsize() as u64;
+        let mut build_version_offset = 0;
+        if self.macho_build_version.is_some() {
+            build_version_offset = offset.reserve(encoder.build_version_command_size(0), 1);
             ncmds += 1;
         }
 
         // Calculate size of symtab command.
-        let symtab_command_offset = offset;
-        let symtab_command_len = mem::size_of::<macho::SymtabCommand<Endianness>>() as u64;
-        offset += symtab_command_len;
+        let symtab_command_offset = offset.reserve(encoder.symtab_command_size(), 1);
         ncmds += 1;
 
         // Calculate size of dysymtab command.
-        let dysymtab_command_offset = offset;
-        let dysymtab_command_len = mem::size_of::<macho::DysymtabCommand<Endianness>>() as u64;
-        offset += dysymtab_command_len;
+        let dysymtab_command_offset = offset.reserve(encoder.dysymtab_command_size(), 1);
         ncmds += 1;
 
-        let sizeofcmds = offset - command_offset;
+        let sizeofcmds = offset.0 - command_offset;
 
         // Calculate size of section data.
         // Section data can immediately follow the load commands without any alignment padding.
-        let segment_file_offset = offset;
+        let segment_file_offset = offset.0;
         let mut section_offsets = vec![SectionOffsets::default(); self.sections.len()];
         let mut address = 0;
         for (index, section) in self.sections.iter().enumerate() {
-            section_offsets[index].index = 1 + index;
+            section_offsets[index].index = 1 + index as u32;
             if !section.is_bss() {
                 address = align(address, section.align);
                 section_offsets[index].address = address;
@@ -507,7 +495,7 @@ impl<'a> Object<'a> {
             }
         }
         let segment_file_size = address;
-        offset += address;
+        offset.reserve(address, 1);
         for (index, section) in self.sections.iter().enumerate() {
             if section.is_bss() {
                 debug_assert!(section.data.is_empty());
@@ -515,6 +503,9 @@ impl<'a> Object<'a> {
                 section_offsets[index].address = address;
                 address += section.size;
             }
+        }
+        if !is_64 && address > u64::from(u32::MAX) {
+            return Err(Error(format!("Segment vmsize overflow: {address:#x}")));
         }
 
         // Partition symbols and add symbol strings to strtab.
@@ -574,42 +565,39 @@ impl<'a> Object<'a> {
             symbol_offsets[index].index = nsyms;
             nsyms += 1;
         }
+        if nsyms > 1 << 24 {
+            return Err(Error(format!("Too many symbols: {nsyms:#x}")));
+        }
 
         // Calculate size of relocations.
         for (index, section) in self.sections.iter().enumerate() {
-            let count: usize = section
+            let count: u32 = section
                 .relocations
                 .iter()
                 .map(|reloc| {
-                    1 + usize::from(reloc.addend != 0) + usize::from(reloc.subtractor.is_some())
+                    1 + u32::from(reloc.addend != 0) + u32::from(reloc.subtractor.is_some())
                 })
                 .sum();
             if count != 0 {
-                offset = align(offset, pointer_align);
-                section_offsets[index].reloc_offset = offset;
+                section_offsets[index].reloc_offset =
+                    offset.reserve(count as u64 * encoder.relocation_size(), pointer_align);
                 section_offsets[index].reloc_count = count;
-                let len = count as u64 * mem::size_of::<macho::Relocation<Endianness>>() as u64;
-                offset += len;
             }
         }
 
-        // Calculate size of symtab.
-        offset = align(offset, pointer_align);
-        let symtab_offset = offset;
-        let symtab_len = nsyms as u64 * macho.nlist_size();
-        offset += symtab_len;
-
-        // Calculate size of strtab.
-        let strtab_offset = offset;
-        // Start with null name.
-        let mut strtab_data = vec![0];
-        strtab.write(&mut strtab_data, 1)?;
-        write_align(&mut strtab_data, pointer_align);
-        offset += strtab_data.len() as u64;
+        // Calculate size of symtab/strtab.
+        let symtab_offset = offset.reserve(u64::from(nsyms) * encoder.nlist_size(), pointer_align);
+        let mut strtab_data = Vec::new();
+        let strsize = encoder.strtab(&mut strtab_data, &mut strtab)?;
+        let strtab_offset = offset.reserve(u64::from(strsize), 1);
 
         // Start writing.
+        let reserved_len = offset.0;
+        if reserved_len > u64::from(u32::MAX) {
+            return Err(Error(format!("File size overflow: {reserved_len:#x}")));
+        }
         buffer
-            .reserve(offset)
+            .reserve(reserved_len)
             .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
 
         // Write file header.
@@ -650,35 +638,30 @@ impl<'a> Object<'a> {
         if self.macho_subsections_via_symbols {
             flags |= macho::MH_SUBSECTIONS_VIA_SYMBOLS;
         }
-        macho.write_mach_header(
-            buffer,
-            MachHeader {
-                cputype,
-                cpusubtype,
-                filetype: macho::MH_OBJECT,
-                ncmds,
-                sizeofcmds: sizeofcmds as u32,
-                flags,
-            },
-        );
+        let mach_header = &MachHeader {
+            cputype,
+            cpusubtype,
+            filetype: macho::MH_OBJECT,
+            ncmds,
+            sizeofcmds: sizeofcmds as u32,
+            flags,
+        };
+        encoder.mach_header(buffer, mach_header);
 
         // Write segment command.
         debug_assert_eq!(segment_command_offset, buffer.len());
-        macho.write_segment_command(
-            buffer,
-            SegmentCommand {
-                cmdsize: segment_command_len as u32,
-                segname: [0; 16],
-                vmaddr: 0,
-                vmsize: address,
-                fileoff: segment_file_offset,
-                filesize: segment_file_size,
-                maxprot: macho::VM_PROT_READ | macho::VM_PROT_WRITE | macho::VM_PROT_EXECUTE,
-                initprot: macho::VM_PROT_READ | macho::VM_PROT_WRITE | macho::VM_PROT_EXECUTE,
-                nsects: self.sections.len() as u32,
-                flags: macho::SegmentFlags(0),
-            },
-        );
+        let segment_command = &SegmentCommand {
+            segname: [0; 16],
+            vmaddr: 0,
+            vmsize: address,
+            fileoff: segment_file_offset,
+            filesize: segment_file_size,
+            maxprot: macho::VM_PROT_READ | macho::VM_PROT_WRITE | macho::VM_PROT_EXECUTE,
+            initprot: macho::VM_PROT_READ | macho::VM_PROT_WRITE | macho::VM_PROT_EXECUTE,
+            nsects,
+            flags: macho::SegmentFlags(0),
+        };
+        encoder.segment_command(buffer, segment_command);
 
         // Write section headers.
         for (index, section) in self.sections.iter().enumerate() {
@@ -709,77 +692,60 @@ impl<'a> Object<'a> {
                     section.kind
                 )));
             };
-            macho.write_section(
-                buffer,
-                SectionHeader {
-                    sectname,
-                    segname,
-                    addr: section_offsets[index].address,
-                    size: section.size,
-                    offset: section_offsets[index].offset as u32,
-                    align: section.align.trailing_zeros(),
-                    reloff: section_offsets[index].reloc_offset as u32,
-                    nreloc: section_offsets[index].reloc_count as u32,
-                    flags,
-                },
-            );
+            let section_header = &SectionHeader {
+                sectname,
+                segname,
+                addr: section_offsets[index].address,
+                size: section.size,
+                offset: section_offsets[index].offset as u32,
+                align: section.align.trailing_zeros(),
+                reloff: section_offsets[index].reloc_offset as u32,
+                nreloc: section_offsets[index].reloc_count as u32,
+                flags,
+                reserved1: 0,
+                reserved2: 0,
+                reserved3: 0,
+            };
+            encoder.section_header(buffer, section_header);
         }
 
         // Write build version.
         if let Some(version) = &self.macho_build_version {
             debug_assert_eq!(build_version_offset, buffer.len());
-            buffer.write(&macho::BuildVersionCommand {
-                cmd: U32::new(endian, macho::LC_BUILD_VERSION),
-                cmdsize: U32::new(endian, version.cmdsize()),
-                platform: U32::new(endian, version.platform),
-                minos: U32::new(endian, version.minos),
-                sdk: U32::new(endian, version.sdk),
-                ntools: U32::new(endian, 0),
-            });
+            let build_version_command = &BuildVersionCommand {
+                platform: version.platform,
+                minos: version.minos,
+                sdk: version.sdk,
+                ntools: 0,
+            };
+            encoder.build_version_command(buffer, build_version_command);
         }
 
         // Write symtab command.
         debug_assert_eq!(symtab_command_offset, buffer.len());
-        let symtab_command = macho::SymtabCommand {
-            cmd: U32::new(endian, macho::LC_SYMTAB),
-            cmdsize: U32::new(endian, symtab_command_len as u32),
-            symoff: U32::new(endian, symtab_offset as u32),
-            nsyms: U32::new(endian, nsyms as u32),
-            stroff: U32::new(endian, strtab_offset as u32),
-            strsize: U32::new(endian, strtab_data.len() as u32),
+        let symtab_command = &SymtabCommand {
+            symoff: symtab_offset as u32,
+            nsyms,
+            stroff: strtab_offset as u32,
+            strsize,
         };
-        buffer.write(&symtab_command);
+        encoder.symtab_command(buffer, symtab_command);
 
         // Write dysymtab command.
         debug_assert_eq!(dysymtab_command_offset, buffer.len());
-        let dysymtab_command = macho::DysymtabCommand {
-            cmd: U32::new(endian, macho::LC_DYSYMTAB),
-            cmdsize: U32::new(endian, dysymtab_command_len as u32),
-            ilocalsym: U32::new(endian, 0),
-            nlocalsym: U32::new(endian, local_symbols.len() as u32),
-            iextdefsym: U32::new(endian, local_symbols.len() as u32),
-            nextdefsym: U32::new(endian, external_symbols.len() as u32),
-            iundefsym: U32::new(
-                endian,
-                local_symbols.len() as u32 + external_symbols.len() as u32,
-            ),
-            nundefsym: U32::new(endian, undefined_symbols.len() as u32),
-            tocoff: U32::default(),
-            ntoc: U32::default(),
-            modtaboff: U32::default(),
-            nmodtab: U32::default(),
-            extrefsymoff: U32::default(),
-            nextrefsyms: U32::default(),
-            indirectsymoff: U32::default(),
-            nindirectsyms: U32::default(),
-            extreloff: U32::default(),
-            nextrel: U32::default(),
-            locreloff: U32::default(),
-            nlocrel: U32::default(),
+        let dysymtab_command = &DysymtabCommand {
+            ilocalsym: 0,
+            nlocalsym: local_symbols.len() as u32,
+            iextdefsym: local_symbols.len() as u32,
+            nextdefsym: external_symbols.len() as u32,
+            iundefsym: local_symbols.len() as u32 + external_symbols.len() as u32,
+            nundefsym: undefined_symbols.len() as u32,
+            ..Default::default()
         };
-        buffer.write(&dysymtab_command);
+        encoder.dysymtab_command(buffer, dysymtab_command);
 
         // Write section data.
+        debug_assert_eq!(segment_file_offset, buffer.len());
         for (index, section) in self.sections.iter().enumerate() {
             if !section.is_bss() {
                 buffer.resize(section_offsets[index].offset);
@@ -791,8 +757,7 @@ impl<'a> Object<'a> {
         // Write relocations.
         for (index, section) in self.sections.iter().enumerate() {
             if !section.relocations.is_empty() {
-                write_align(buffer, pointer_align);
-                debug_assert_eq!(section_offsets[index].reloc_offset, buffer.len());
+                buffer.resize(section_offsets[index].reloc_offset);
 
                 let mut write_reloc = |reloc: &RelocationInternal| {
                     let (r_type, r_pcrel, r_length) = if let RelocationFlags::MachO {
@@ -818,13 +783,13 @@ impl<'a> Object<'a> {
                         };
                         let reloc_info = macho::RelocationInfo {
                             r_address: reloc.offset as u32,
-                            r_symbolnum: symbol_offsets[subtractor.0].index as u32,
+                            r_symbolnum: symbol_offsets[subtractor.0].index,
                             r_pcrel: false,
                             r_length,
                             r_extern: true,
                             r_type,
                         };
-                        buffer.write(&reloc_info.relocation(endian));
+                        encoder.relocation(buffer, &reloc_info);
                     }
 
                     // Write explicit addend.
@@ -846,17 +811,17 @@ impl<'a> Object<'a> {
                             r_extern: false,
                             r_type,
                         };
-                        buffer.write(&reloc_info.relocation(endian));
+                        encoder.relocation(buffer, &reloc_info);
                     }
 
                     let r_extern;
                     let r_symbolnum;
                     let symbol = &self.symbols[reloc.symbol.0];
                     if symbol.kind == SymbolKind::Section {
-                        r_symbolnum = section_offsets[symbol.section.id().unwrap().0].index as u32;
+                        r_symbolnum = section_offsets[symbol.section.id().unwrap().0].index;
                         r_extern = false;
                     } else {
-                        r_symbolnum = symbol_offsets[reloc.symbol.0].index as u32;
+                        r_symbolnum = symbol_offsets[reloc.symbol.0].index;
                         r_extern = true;
                     }
 
@@ -868,7 +833,7 @@ impl<'a> Object<'a> {
                         r_extern,
                         r_type,
                     };
-                    buffer.write(&reloc_info.relocation(endian));
+                    encoder.relocation(buffer, &reloc_info);
                     Ok(())
                 };
 
@@ -897,8 +862,7 @@ impl<'a> Object<'a> {
         }
 
         // Write symtab.
-        write_align(buffer, pointer_align);
-        debug_assert_eq!(symtab_offset, buffer.len());
+        buffer.resize(symtab_offset);
         for index in local_symbols
             .iter()
             .copied()
@@ -929,257 +893,22 @@ impl<'a> Object<'a> {
                 .map(|id| strtab.get_offset(id))
                 .unwrap_or(0);
 
-            macho.write_nlist(
-                buffer,
-                Nlist {
-                    n_strx,
-                    n_type,
-                    n_sect: n_sect as u8,
-                    n_desc,
-                    n_value,
-                },
-            );
+            let nlist = &Nlist {
+                n_strx,
+                n_type,
+                n_sect: n_sect as u8,
+                n_desc,
+                n_value,
+            };
+            encoder.nlist(buffer, nlist);
         }
 
         // Write strtab.
         debug_assert_eq!(strtab_offset, buffer.len());
         buffer.write_bytes(&strtab_data);
 
-        debug_assert_eq!(offset, buffer.len());
+        debug_assert_eq!(reserved_len, buffer.len());
 
         Ok(())
-    }
-}
-
-struct MachHeader {
-    cputype: macho::CpuType,
-    cpusubtype: macho::CpuSubtype,
-    filetype: macho::FileType,
-    ncmds: u32,
-    sizeofcmds: u32,
-    flags: macho::FileFlags,
-}
-
-struct SegmentCommand {
-    cmdsize: u32,
-    segname: [u8; 16],
-    vmaddr: u64,
-    vmsize: u64,
-    fileoff: u64,
-    filesize: u64,
-    maxprot: macho::VmProt,
-    initprot: macho::VmProt,
-    nsects: u32,
-    flags: macho::SegmentFlags,
-}
-
-struct SectionHeader {
-    sectname: [u8; 16],
-    segname: [u8; 16],
-    addr: u64,
-    size: u64,
-    offset: u32,
-    align: u32,
-    reloff: u32,
-    nreloc: u32,
-    flags: macho::SectionFlags,
-}
-
-struct Nlist {
-    n_strx: u32,
-    n_type: macho::SymbolFlags,
-    n_sect: u8,
-    n_desc: macho::SymbolDesc,
-    n_value: u64,
-}
-
-trait MachO {
-    fn mach_header_size(&self) -> u64;
-    fn segment_command_size(&self) -> u64;
-    fn section_header_size(&self) -> u64;
-    fn nlist_size(&self) -> u64;
-    fn write_mach_header(&self, buffer: &mut dyn WritableBuffer, section: MachHeader);
-    fn write_segment_command(&self, buffer: &mut dyn WritableBuffer, segment: SegmentCommand);
-    fn write_section(&self, buffer: &mut dyn WritableBuffer, section: SectionHeader);
-    fn write_nlist(&self, buffer: &mut dyn WritableBuffer, nlist: Nlist);
-}
-
-struct MachO32<E> {
-    endian: E,
-}
-
-impl<E: Endian> MachO for MachO32<E> {
-    fn mach_header_size(&self) -> u64 {
-        mem::size_of::<macho::MachHeader32<E>>() as u64
-    }
-
-    fn segment_command_size(&self) -> u64 {
-        mem::size_of::<macho::SegmentCommand32<E>>() as u64
-    }
-
-    fn section_header_size(&self) -> u64 {
-        mem::size_of::<macho::Section32<E>>() as u64
-    }
-
-    fn nlist_size(&self) -> u64 {
-        mem::size_of::<macho::Nlist32<E>>() as u64
-    }
-
-    fn write_mach_header(&self, buffer: &mut dyn WritableBuffer, header: MachHeader) {
-        let endian = self.endian;
-        let magic = if endian.is_big_endian() {
-            macho::MH_MAGIC
-        } else {
-            macho::MH_CIGAM
-        };
-        let header = macho::MachHeader32 {
-            magic: U32::new(BigEndian, magic),
-            cputype: U32::new(endian, header.cputype),
-            cpusubtype: U32::new(endian, header.cpusubtype),
-            filetype: U32::new(endian, header.filetype),
-            ncmds: U32::new(endian, header.ncmds),
-            sizeofcmds: U32::new(endian, header.sizeofcmds),
-            flags: U32::new(endian, header.flags),
-        };
-        buffer.write(&header);
-    }
-
-    fn write_segment_command(&self, buffer: &mut dyn WritableBuffer, segment: SegmentCommand) {
-        let endian = self.endian;
-        let segment = macho::SegmentCommand32 {
-            cmd: U32::new(endian, macho::LC_SEGMENT),
-            cmdsize: U32::new(endian, segment.cmdsize),
-            segname: segment.segname,
-            vmaddr: U32::new(endian, segment.vmaddr as u32),
-            vmsize: U32::new(endian, segment.vmsize as u32),
-            fileoff: U32::new(endian, segment.fileoff as u32),
-            filesize: U32::new(endian, segment.filesize as u32),
-            maxprot: U32::new(endian, segment.maxprot),
-            initprot: U32::new(endian, segment.initprot),
-            nsects: U32::new(endian, segment.nsects),
-            flags: U32::new(endian, segment.flags),
-        };
-        buffer.write(&segment);
-    }
-
-    fn write_section(&self, buffer: &mut dyn WritableBuffer, section: SectionHeader) {
-        let endian = self.endian;
-        let section = macho::Section32 {
-            sectname: section.sectname,
-            segname: section.segname,
-            addr: U32::new(endian, section.addr as u32),
-            size: U32::new(endian, section.size as u32),
-            offset: U32::new(endian, section.offset),
-            align: U32::new(endian, section.align),
-            reloff: U32::new(endian, section.reloff),
-            nreloc: U32::new(endian, section.nreloc),
-            flags: U32::new(endian, section.flags),
-            reserved1: U32::default(),
-            reserved2: U32::default(),
-        };
-        buffer.write(&section);
-    }
-
-    fn write_nlist(&self, buffer: &mut dyn WritableBuffer, nlist: Nlist) {
-        let endian = self.endian;
-        let nlist = macho::Nlist32 {
-            n_strx: U32::new(endian, nlist.n_strx),
-            n_type: nlist.n_type,
-            n_sect: nlist.n_sect,
-            n_desc: U16::new(endian, nlist.n_desc),
-            n_value: U32::new(endian, nlist.n_value as u32),
-        };
-        buffer.write(&nlist);
-    }
-}
-
-struct MachO64<E> {
-    endian: E,
-}
-
-impl<E: Endian> MachO for MachO64<E> {
-    fn mach_header_size(&self) -> u64 {
-        mem::size_of::<macho::MachHeader64<E>>() as u64
-    }
-
-    fn segment_command_size(&self) -> u64 {
-        mem::size_of::<macho::SegmentCommand64<E>>() as u64
-    }
-
-    fn section_header_size(&self) -> u64 {
-        mem::size_of::<macho::Section64<E>>() as u64
-    }
-
-    fn nlist_size(&self) -> u64 {
-        mem::size_of::<macho::Nlist64<E>>() as u64
-    }
-
-    fn write_mach_header(&self, buffer: &mut dyn WritableBuffer, header: MachHeader) {
-        let endian = self.endian;
-        let magic = if endian.is_big_endian() {
-            macho::MH_MAGIC_64
-        } else {
-            macho::MH_CIGAM_64
-        };
-        let header = macho::MachHeader64 {
-            magic: U32::new(BigEndian, magic),
-            cputype: U32::new(endian, header.cputype),
-            cpusubtype: U32::new(endian, header.cpusubtype),
-            filetype: U32::new(endian, header.filetype),
-            ncmds: U32::new(endian, header.ncmds),
-            sizeofcmds: U32::new(endian, header.sizeofcmds),
-            flags: U32::new(endian, header.flags),
-            reserved: U32::default(),
-        };
-        buffer.write(&header);
-    }
-
-    fn write_segment_command(&self, buffer: &mut dyn WritableBuffer, segment: SegmentCommand) {
-        let endian = self.endian;
-        let segment = macho::SegmentCommand64 {
-            cmd: U32::new(endian, macho::LC_SEGMENT_64),
-            cmdsize: U32::new(endian, segment.cmdsize),
-            segname: segment.segname,
-            vmaddr: U64::new(endian, segment.vmaddr),
-            vmsize: U64::new(endian, segment.vmsize),
-            fileoff: U64::new(endian, segment.fileoff),
-            filesize: U64::new(endian, segment.filesize),
-            maxprot: U32::new(endian, segment.maxprot),
-            initprot: U32::new(endian, segment.initprot),
-            nsects: U32::new(endian, segment.nsects),
-            flags: U32::new(endian, segment.flags),
-        };
-        buffer.write(&segment);
-    }
-
-    fn write_section(&self, buffer: &mut dyn WritableBuffer, section: SectionHeader) {
-        let endian = self.endian;
-        let section = macho::Section64 {
-            sectname: section.sectname,
-            segname: section.segname,
-            addr: U64::new(endian, section.addr),
-            size: U64::new(endian, section.size),
-            offset: U32::new(endian, section.offset),
-            align: U32::new(endian, section.align),
-            reloff: U32::new(endian, section.reloff),
-            nreloc: U32::new(endian, section.nreloc),
-            flags: U32::new(endian, section.flags),
-            reserved1: U32::default(),
-            reserved2: U32::default(),
-            reserved3: U32::default(),
-        };
-        buffer.write(&section);
-    }
-
-    fn write_nlist(&self, buffer: &mut dyn WritableBuffer, nlist: Nlist) {
-        let endian = self.endian;
-        let nlist = macho::Nlist64 {
-            n_strx: U32::new(endian, nlist.n_strx),
-            n_type: nlist.n_type,
-            n_sect: nlist.n_sect,
-            n_desc: U16::new(endian, nlist.n_desc),
-            n_value: U64::new(endian, nlist.n_value),
-        };
-        buffer.write(&nlist);
     }
 }

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -32,7 +32,7 @@ pub use coff::CoffExportStyle;
 pub mod elf;
 
 #[cfg(feature = "macho")]
-mod macho;
+pub mod macho;
 #[cfg(feature = "macho")]
 pub use macho::MachOBuildVersion;
 

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -260,6 +260,7 @@ pub(crate) fn align(offset: u64, size: u64) -> u64 {
     (offset + (size - 1)) & !(size - 1)
 }
 
+#[allow(dead_code)]
 pub(crate) fn write_align<W: WritableBuffer + ?Sized>(buffer: &mut W, size: u64) {
     let new_len = align(buffer.len(), size);
     buffer.resize(new_len);


### PR DESCRIPTION
Use this for Mach-O support in write::Object.
    
This also adds overflow checks, using the same strategy as ELF: perform a single check for total file size, section count or symbol count.
