### PR TITLE
write: use u64 for file offsets

### DIFF
--- a/crates/examples/src/bin/elftoefi.rs
+++ b/crates/examples/src/bin/elftoefi.rs
@@ -371,7 +371,7 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(
     }
     writer.write_reloc_section();
 
-    debug_assert_eq!(writer.reserved_len() as usize, writer.len());
+    debug_assert_eq!(writer.reserved_len(), writer.len());
 
     Ok(out_data)
 }

--- a/crates/examples/src/bin/pecopy.rs
+++ b/crates/examples/src/bin/pecopy.rs
@@ -181,7 +181,7 @@ fn copy_file<Pe: ImageNtHeaders>(in_data: &[u8]) -> Result<Vec<u8>, Box<dyn Erro
         writer.write_certificate_table(&in_data[address as usize..][..size as usize]);
     }
 
-    debug_assert_eq!(writer.reserved_len() as usize, writer.len());
+    debug_assert_eq!(writer.reserved_len(), writer.len());
 
     Ok(out_data)
 }

--- a/crates/examples/src/elfcopy.rs
+++ b/crates/examples/src/elfcopy.rs
@@ -380,20 +380,20 @@ pub fn elfcopy<Elf: FileHeader<Endian = Endianness>>(
             match in_section.sh_type(endian) {
                 elf::SHT_PROGBITS | elf::SHT_NOTE | elf::SHT_INIT_ARRAY | elf::SHT_FINI_ARRAY => {
                     out_sections[i.0].offset = writer.reserve(
-                        in_section.sh_size(endian).into() as usize,
-                        in_section.sh_addralign(endian).into() as usize,
+                        in_section.sh_size(endian).into(),
+                        in_section.sh_addralign(endian).into(),
                     );
                 }
                 elf::SHT_GNU_ATTRIBUTES => {
-                    writer.reserve_gnu_attributes(gnu_attributes.len());
+                    writer.reserve_gnu_attributes(gnu_attributes.len() as u64);
                 }
                 _ => {}
             }
         }
     } else {
         // We don't support moving program headers.
-        assert_eq!(in_elf.e_phoff(endian).into(), writer.reserved_len() as u64);
-        writer.reserve_program_headers(in_segments.len() as u32);
+        assert_eq!(in_elf.e_phoff(endian).into(), writer.reserved_len());
+        writer.reserve_program_headers(in_segments.len());
 
         // Reserve alloc sections at original offsets.
         alloc_sections = in_sections
@@ -404,14 +404,13 @@ pub fn elfcopy<Elf: FileHeader<Endian = Endianness>>(
         // from their section headers.
         alloc_sections.sort_by_key(|(_, x)| x.sh_offset(endian).into());
         for (i, in_section) in alloc_sections.iter() {
-            writer.reserve_until(in_section.sh_offset(endian).into() as usize);
+            writer.reserve_until(in_section.sh_offset(endian).into());
             match in_section.sh_type(endian) {
                 elf::SHT_PROGBITS | elf::SHT_NOTE | elf::SHT_INIT_ARRAY | elf::SHT_FINI_ARRAY => {
-                    out_sections[i.0].offset =
-                        writer.reserve(in_section.sh_size(endian).into() as usize, 1);
+                    out_sections[i.0].offset = writer.reserve(in_section.sh_size(endian).into(), 1);
                 }
                 elf::SHT_NOBITS => {
-                    out_sections[i.0].offset = writer.reserved_len() as u64;
+                    out_sections[i.0].offset = writer.reserved_len();
                 }
                 elf::SHT_REL => {
                     let (rels, _link) = in_section.rel(endian, in_data)?.unwrap();
@@ -473,12 +472,12 @@ pub fn elfcopy<Elf: FileHeader<Endian = Endianness>>(
             match in_section.sh_type(endian) {
                 elf::SHT_PROGBITS | elf::SHT_NOTE => {
                     out_sections[i.0].offset = writer.reserve(
-                        in_section.sh_size(endian).into() as usize,
-                        in_section.sh_addralign(endian).into() as usize,
+                        in_section.sh_size(endian).into(),
+                        in_section.sh_addralign(endian).into(),
                     );
                 }
                 elf::SHT_GNU_ATTRIBUTES => {
-                    writer.reserve_gnu_attributes(gnu_attributes.len());
+                    writer.reserve_gnu_attributes(gnu_attributes.len() as u64);
                 }
                 _ => {}
             }
@@ -522,7 +521,7 @@ pub fn elfcopy<Elf: FileHeader<Endian = Endianness>>(
         for (i, in_section) in in_sections.iter().enumerate() {
             match in_section.sh_type(endian) {
                 elf::SHT_PROGBITS | elf::SHT_NOTE | elf::SHT_INIT_ARRAY | elf::SHT_FINI_ARRAY => {
-                    writer.write_align(in_section.sh_addralign(endian).into() as usize);
+                    writer.write_align(in_section.sh_addralign(endian).into());
                     debug_assert_eq!(out_sections[i].offset, writer.offset());
                     writer.write(in_section.data(endian, in_data)?);
                 }
@@ -722,7 +721,7 @@ pub fn elfcopy<Elf: FileHeader<Endian = Endianness>>(
             }
             match in_section.sh_type(endian) {
                 elf::SHT_PROGBITS | elf::SHT_NOTE => {
-                    writer.write_align(in_section.sh_addralign(endian).into() as usize);
+                    writer.write_align(in_section.sh_addralign(endian).into());
                     debug_assert_eq!(out_sections[i.0].offset, writer.offset());
                     writer.write(in_section.data(endian, in_data)?);
                 }

--- a/crates/rewrite/src/elf.rs
+++ b/crates/rewrite/src/elf.rs
@@ -736,7 +736,7 @@ fn move_sections(builder: &mut build::elf::Builder) -> Result<()> {
         }
 
         // Update the PT_PHDR segment to include the new program headers.
-        let size = builder.program_headers_size() as u64;
+        let size = builder.program_headers_size();
         for segment in &mut builder.segments {
             if segment.p_type != elf::PT_PHDR {
                 continue;
@@ -756,10 +756,9 @@ fn find_move_sections(
 
     let mut move_sections = Vec::new();
     let mut blocks = Vec::new();
-    let file_header_size = builder.file_header_size() as u64;
-    let program_headers_size = (builder.program_headers_size()
-        + added_segments * builder.encoder().program_header_size())
-        as u64;
+    let file_header_size = builder.file_header_size();
+    let program_headers_size = builder.program_headers_size()
+        + added_segments as u64 * builder.encoder().program_header_size();
     let interp = builder.interp_section();
 
     if let Some(segment) = builder.segments.find_load_segment_from_offset(0) {

--- a/src/build/elf.rs
+++ b/src/build/elf.rs
@@ -761,7 +761,7 @@ impl<'data> Builder<'data> {
         struct Offset(u64);
         impl Offset {
             fn reserve(&mut self, size: u64, align: u64) -> (u64, u64) {
-                self.0 = write::align_u64(self.0, align);
+                self.0 = write::align(self.0, align);
                 let offset = self.0;
                 self.0 += size;
                 (offset, size)
@@ -1146,7 +1146,7 @@ impl<'data> Builder<'data> {
         // Start reserving file ranges.
         let encoder = self.encoder();
         let address_size = u64::from(encoder.address_size());
-        let mut offset = Offset(encoder.file_header_size() as u64);
+        let mut offset = Offset(encoder.file_header_size());
 
         let mut dynsym_addr = None;
         let mut dynstr_addr = None;
@@ -1159,7 +1159,7 @@ impl<'data> Builder<'data> {
         let segment_num = self.segments.count() as u32;
         let mut e_phoff = 0;
         if segment_num != 0 {
-            let size = u64::from(segment_num) * encoder.program_header_size() as u64;
+            let size = u64::from(segment_num) * encoder.program_header_size();
             e_phoff = offset.reserve(size, address_size).0;
             // TODO: support program headers in other locations.
             if self.header.e_phoff != e_phoff {
@@ -1219,19 +1219,19 @@ impl<'data> Builder<'data> {
                     }
                     SectionData::DynamicRelocation(relocations) => {
                         let size = relocations.len() as u64
-                            * encoder.rel_size(section.sh_type == elf::SHT_RELA) as u64;
+                            * encoder.rel_size(section.sh_type == elf::SHT_RELA);
                         offset.reserve(size, address_size)
                     }
                     SectionData::Note(data) => {
                         offset.reserve(data.len() as u64, section.sh_addralign)
                     }
                     SectionData::Dynamic(dynamics) => {
-                        let size = (1 + dynamics.len() as u64) * encoder.dyn_size() as u64;
+                        let size = (1 + dynamics.len() as u64) * encoder.dyn_size();
                         offset.reserve(size, address_size)
                     }
                     SectionData::DynamicSymbol => {
                         dynsym_addr = Some(section.sh_addr);
-                        let size = u64::from(dynsym_num) * encoder.sym_size() as u64;
+                        let size = u64::from(dynsym_num) * encoder.sym_size();
                         offset.reserve(size, address_size)
                     }
                     SectionData::DynamicString => {
@@ -1241,7 +1241,7 @@ impl<'data> Builder<'data> {
                     SectionData::Hash => {
                         hash_addr = Some(section.sh_addr);
                         let size = encoder.hash_size(self.hash_bucket_count, hash_chain_count);
-                        offset.reserve(size as u64, write::elf::ALIGN_HASH.into())
+                        offset.reserve(size, write::elf::ALIGN_HASH)
                     }
                     SectionData::GnuHash => {
                         gnu_hash_addr = Some(section.sh_addr);
@@ -1250,22 +1250,22 @@ impl<'data> Builder<'data> {
                             self.gnu_hash_bucket_count,
                             gnu_hash_symbol_count,
                         );
-                        offset.reserve(size as u64, address_size)
+                        offset.reserve(size, address_size)
                     }
                     SectionData::GnuVersym => {
                         versym_addr = Some(section.sh_addr);
                         let size = encoder.gnu_versym_size(dynsym_num as usize);
-                        offset.reserve(size as u64, write::elf::ALIGN_GNU_VERSYM.into())
+                        offset.reserve(size, write::elf::ALIGN_GNU_VERSYM)
                     }
                     SectionData::GnuVerdef => {
                         verdef_addr = Some(section.sh_addr);
                         let size = encoder.gnu_verdef_size(verdef_count, verdaux_count);
-                        offset.reserve(size as u64, write::elf::ALIGN_GNU_VERDEF.into())
+                        offset.reserve(size, write::elf::ALIGN_GNU_VERDEF)
                     }
                     SectionData::GnuVerneed => {
                         verneed_addr = Some(section.sh_addr);
                         let size = encoder.gnu_verneed_size(verneed_count, vernaux_count);
-                        offset.reserve(size as u64, write::elf::ALIGN_GNU_VERNEED.into())
+                        offset.reserve(size, write::elf::ALIGN_GNU_VERNEED)
                     }
                     _ => {
                         return Err(Error(format!(
@@ -1314,7 +1314,7 @@ impl<'data> Builder<'data> {
         }
 
         if symtab_index != 0 {
-            let size = u64::from(sym_num) * encoder.sym_size() as u64;
+            let size = u64::from(sym_num) * encoder.sym_size();
             let range = offset.reserve(size, address_size);
             out_sections[symtab_index as usize - 1].set_range(range);
         }
@@ -1336,8 +1336,8 @@ impl<'data> Builder<'data> {
             let SectionData::Relocation(relocations) = &section.data else {
                 continue;
             };
-            let size = relocations.len() as u64
-                * encoder.rel_size(section.sh_type == elf::SHT_RELA) as u64;
+            let size =
+                relocations.len() as u64 * encoder.rel_size(section.sh_type == elf::SHT_RELA);
             out_section.set_range(offset.reserve(size, address_size));
         }
 
@@ -1346,7 +1346,7 @@ impl<'data> Builder<'data> {
             out_sections[shstrtab_index as usize - 1].set_range(range);
         }
         let e_shoff = if section_num != 0 {
-            let size = section_num as u64 * encoder.section_header_size() as u64;
+            let size = section_num as u64 * encoder.section_header_size();
             offset.reserve(size, address_size).0
         } else {
             0
@@ -1399,7 +1399,7 @@ impl<'data> Builder<'data> {
                     continue;
                 }
 
-                buffer.resize(out_section.offset as usize);
+                buffer.resize(out_section.offset);
                 match &section.data {
                     SectionData::Data(data) => {
                         buffer.write_bytes(data);
@@ -1627,18 +1627,18 @@ impl<'data> Builder<'data> {
             }
             match &section.data {
                 SectionData::Data(data) => {
-                    buffer.resize(out_section.offset as usize);
+                    buffer.resize(out_section.offset);
                     buffer.write_bytes(data);
                 }
                 SectionData::UninitializedData(_) => {
                     // Nothing to do.
                 }
                 SectionData::Note(data) => {
-                    buffer.resize(out_section.offset as usize);
+                    buffer.resize(out_section.offset);
                     buffer.write_bytes(data);
                 }
                 SectionData::Attributes(_) => {
-                    buffer.resize(out_section.offset as usize);
+                    buffer.resize(out_section.offset);
                     buffer.write_bytes(&out_section.attributes);
                 }
                 // These are handled elsewhere.
@@ -1659,7 +1659,7 @@ impl<'data> Builder<'data> {
         let mut symtab_shndx_data = Vec::new();
         if symtab_index != 0 {
             let out_section = &out_sections[symtab_index as usize - 1];
-            buffer.resize(out_section.offset as usize);
+            buffer.resize(out_section.offset);
             encoder.null_symbol(buffer);
             if need_symtab_shndx {
                 encoder.u32(&mut symtab_shndx_data, 0u32);
@@ -1683,12 +1683,12 @@ impl<'data> Builder<'data> {
         }
         if symtab_shndx_index != 0 {
             let out_section = &out_sections[symtab_shndx_index as usize - 1];
-            buffer.resize(out_section.offset as usize);
+            buffer.resize(out_section.offset);
             buffer.write_bytes(&symtab_shndx_data);
         }
         if strtab_index != 0 {
             let out_section = &out_sections[strtab_index as usize - 1];
-            buffer.resize(out_section.offset as usize);
+            buffer.resize(out_section.offset);
             buffer.write_bytes(&strtab_data);
         }
 
@@ -1701,7 +1701,7 @@ impl<'data> Builder<'data> {
             let SectionData::Relocation(relocations) = &section.data else {
                 continue;
             };
-            buffer.resize(out_section.offset as usize);
+            buffer.resize(out_section.offset);
             for rel in relocations {
                 let r_sym = if let Some(id) = rel.symbol {
                     out_syms_index[id.0]
@@ -1720,12 +1720,12 @@ impl<'data> Builder<'data> {
 
         if shstrtab_index != 0 {
             let out_section = &out_sections[shstrtab_index as usize - 1];
-            buffer.resize(out_section.offset as usize);
+            buffer.resize(out_section.offset);
             buffer.write_bytes(&shstrtab_data);
         }
 
         if e_shoff != 0 {
-            buffer.resize(e_shoff as usize);
+            buffer.resize(e_shoff);
             encoder.null_section_header(buffer, &layout);
         }
         for out_section in &out_sections {
@@ -1804,7 +1804,7 @@ impl<'data> Builder<'data> {
             }
             encoder.section_header(buffer, &header);
         }
-        debug_assert_eq!(offset.0, buffer.len() as u64);
+        debug_assert_eq!(offset.0, buffer.len());
         Ok(())
     }
 
@@ -1967,21 +1967,21 @@ impl<'data> Builder<'data> {
     }
 
     /// Calculate the size of the file header.
-    pub fn file_header_size(&self) -> usize {
+    pub fn file_header_size(&self) -> u64 {
         self.encoder().file_header_size()
     }
 
     /// Calculate the size of the program headers.
-    pub fn program_headers_size(&self) -> usize {
-        self.segments.count() * self.encoder().program_header_size()
+    pub fn program_headers_size(&self) -> u64 {
+        self.segments.count() as u64 * self.encoder().program_header_size()
     }
 
     /// Calculate the size of the dynamic symbol table.
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`].
-    pub fn dynamic_symbol_size(&self) -> usize {
-        (1 + self.dynamic_symbols.count()) * self.encoder().sym_size()
+    pub fn dynamic_symbol_size(&self) -> u64 {
+        (1 + self.dynamic_symbols.count() as u64) * self.encoder().sym_size()
     }
 
     /// Calculate the size of the dynamic string table.
@@ -1991,7 +1991,7 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`] and [`Self::delete_unused_versions`].
-    pub fn dynamic_string_size(&self) -> usize {
+    pub fn dynamic_string_size(&self) -> u64 {
         let mut dynstr = write::StringTable::default();
         for section in &self.sections {
             if let SectionData::Dynamic(dynamics) = &section.data {
@@ -2030,7 +2030,7 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`].
-    pub fn hash_size(&self) -> usize {
+    pub fn hash_size(&self) -> u64 {
         let chain_count = 1 + self.dynamic_symbols.count();
         self.encoder()
             .hash_size(self.hash_bucket_count, chain_count as u32)
@@ -2040,7 +2040,7 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`].
-    pub fn gnu_hash_size(&self) -> usize {
+    pub fn gnu_hash_size(&self) -> u64 {
         let symbol_count = self.dynamic_symbols.count_defined();
         self.encoder().gnu_hash_size(
             self.gnu_hash_bloom_count,
@@ -2053,7 +2053,7 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`] and [`Self::delete_unused_versions`].
-    pub fn gnu_versym_size(&self) -> usize {
+    pub fn gnu_versym_size(&self) -> u64 {
         let symbol_count = 1 + self.dynamic_symbols.count();
         self.encoder().gnu_versym_size(symbol_count)
     }
@@ -2062,7 +2062,7 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`] and [`Self::delete_unused_versions`].
-    pub fn gnu_verdef_size(&self) -> usize {
+    pub fn gnu_verdef_size(&self) -> u64 {
         let mut verdef_count = 0;
         let mut verdaux_count = 0;
         if self.version_base.is_some() {
@@ -2084,7 +2084,7 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`] and [`Self::delete_unused_versions`].
-    pub fn gnu_verneed_size(&self) -> usize {
+    pub fn gnu_verneed_size(&self) -> u64 {
         let verneed_count = self.version_files.count();
         let mut vernaux_count = 0;
         for version in &self.versions {
@@ -2102,21 +2102,23 @@ impl<'data> Builder<'data> {
     ///
     /// To get an accurate result, you may need to first call
     /// [`Self::delete_orphan_symbols`] and [`Self::delete_unused_versions`].
-    pub fn section_size(&self, section: &Section<'_>) -> usize {
+    pub fn section_size(&self, section: &Section<'_>) -> u64 {
         if section.delete || !section.is_alloc() {
             return 0;
         }
         match &section.data {
-            SectionData::Data(data) => data.len(),
-            SectionData::UninitializedData(len) => *len as usize,
+            SectionData::Data(data) => data.len() as u64,
+            SectionData::UninitializedData(len) => *len,
             SectionData::Relocation(relocations) => {
-                relocations.len() * self.encoder().rel_size(section.sh_type == elf::SHT_RELA)
+                relocations.len() as u64 * self.encoder().rel_size(section.sh_type == elf::SHT_RELA)
             }
             SectionData::DynamicRelocation(relocations) => {
-                relocations.len() * self.encoder().rel_size(section.sh_type == elf::SHT_RELA)
+                relocations.len() as u64 * self.encoder().rel_size(section.sh_type == elf::SHT_RELA)
             }
-            SectionData::Note(data) => data.len(),
-            SectionData::Dynamic(dynamics) => (1 + dynamics.len()) * self.encoder().dyn_size(),
+            SectionData::Note(data) => data.len() as u64,
+            SectionData::Dynamic(dynamics) => {
+                (1 + dynamics.len() as u64) * self.encoder().dyn_size()
+            }
             SectionData::DynamicString => self.dynamic_string_size(),
             SectionData::DynamicSymbol => self.dynamic_symbol_size(),
             SectionData::Hash => self.hash_size(),
@@ -2145,7 +2147,7 @@ impl<'data> Builder<'data> {
             if section.delete || !section.is_alloc() {
                 continue;
             }
-            self.sections.get_mut(id).sh_size = self.section_size(section) as u64;
+            self.sections.get_mut(id).sh_size = self.section_size(section);
         }
     }
 

--- a/src/write/coff/writer.rs
+++ b/src/write/coff/writer.rs
@@ -27,7 +27,7 @@ use crate::write::{Error, Result, WritableBuffer};
 #[allow(missing_debug_implementations)]
 pub struct Writer<'a> {
     buffer: &'a mut dyn WritableBuffer,
-    len: usize,
+    len: u64,
 
     section_num: u16,
 
@@ -60,13 +60,13 @@ impl<'a> Writer<'a> {
     }
 
     /// Return the current file length that has been reserved.
-    pub fn reserved_len(&self) -> usize {
+    pub fn reserved_len(&self) -> u64 {
         self.len
     }
 
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.buffer.len()
     }
 
@@ -75,7 +75,7 @@ impl<'a> Writer<'a> {
     /// Returns the aligned offset of the start of the range.
     ///
     /// `align_start` must be a power of two.
-    pub fn reserve(&mut self, len: usize, align_start: usize) -> u32 {
+    pub fn reserve(&mut self, len: u64, align_start: u64) -> u32 {
         if align_start > 1 {
             self.len = util::align(self.len, align_start);
         }
@@ -85,7 +85,7 @@ impl<'a> Writer<'a> {
     }
 
     /// Write alignment padding bytes.
-    pub fn write_align(&mut self, align_start: usize) {
+    pub fn write_align(&mut self, align_start: u64) {
         if align_start > 1 {
             util::write_align(self.buffer, align_start);
         }
@@ -97,13 +97,13 @@ impl<'a> Writer<'a> {
     }
 
     /// Reserve the file range up to the given file offset.
-    pub fn reserve_until(&mut self, offset: usize) {
+    pub fn reserve_until(&mut self, offset: u64) {
         debug_assert!(self.len <= offset);
         self.len = offset;
     }
 
     /// Write padding up to the given file offset.
-    pub fn pad_until(&mut self, offset: usize) {
+    pub fn pad_until(&mut self, offset: u64) {
         debug_assert!(self.buffer.len() <= offset);
         self.buffer.resize(offset);
     }
@@ -113,7 +113,7 @@ impl<'a> Writer<'a> {
     /// This must be at the start of the file.
     pub fn reserve_file_header(&mut self) {
         debug_assert_eq!(self.len, 0);
-        self.reserve(mem::size_of::<pe::ImageFileHeader>(), 1);
+        self.reserve(mem::size_of::<pe::ImageFileHeader>() as u64, 1);
     }
 
     /// Write the file header.
@@ -149,7 +149,7 @@ impl<'a> Writer<'a> {
         debug_assert_eq!(self.section_num, 0);
         self.section_num = section_num;
         self.reserve(
-            section_num as usize * mem::size_of::<pe::ImageSectionHeader>(),
+            section_num as u64 * mem::size_of::<pe::ImageSectionHeader>() as u64,
             1,
         );
     }
@@ -224,7 +224,7 @@ impl<'a> Writer<'a> {
             return 0;
         }
         // TODO: not sure what alignment is required here, but this seems to match LLVM
-        self.reserve(len, 4)
+        self.reserve(len as u64, 4)
     }
 
     /// Write the alignment bytes prior to section data.
@@ -256,7 +256,7 @@ impl<'a> Writer<'a> {
             return;
         }
         self.write_section_align();
-        self.buffer.resize(self.buffer.len() + len);
+        self.buffer.resize(self.buffer.len() + len as u64);
     }
 
     /// Reserve a file range for the given number of relocations.
@@ -272,7 +272,10 @@ impl<'a> Writer<'a> {
         if count > 0xffff {
             count += 1;
         }
-        self.reserve(count * mem::size_of::<pe::ImageRelocation>(), 1)
+        self.reserve(
+            count as u64 * mem::size_of::<pe::ImageRelocation>() as u64,
+            1,
+        )
     }
 
     /// Write a relocation containing the count if required.
@@ -353,7 +356,7 @@ impl<'a> Writer<'a> {
         debug_assert!(aux_len >= name.len());
         let old_len = self.buffer.len();
         self.buffer.write_bytes(name);
-        self.buffer.resize(old_len + aux_len);
+        self.buffer.resize(old_len + aux_len as u64);
     }
 
     /// Reserve an auxiliary symbol for a section.
@@ -443,18 +446,19 @@ impl<'a> Writer<'a> {
     /// Returns an error if the string table could not be finalized.
     pub fn reserve_symtab_strtab(&mut self) -> Result<()> {
         debug_assert_eq!(self.symtab_offset, 0);
-        self.symtab_offset = self.reserve(self.symtab_num as usize * pe::IMAGE_SIZEOF_SYMBOL, 1);
+        self.symtab_offset =
+            self.reserve(self.symtab_num as u64 * pe::IMAGE_SIZEOF_SYMBOL as u64, 1);
 
         debug_assert_eq!(self.strtab_offset, 0);
         // First 4 bytes of strtab are the length.
         self.strtab_len = self.strtab.write(4, &mut self.strtab_data)?;
-        self.strtab_offset = self.reserve(self.strtab_len as usize, 1);
+        self.strtab_offset = self.reserve(self.strtab_len as u64, 1);
         Ok(())
     }
 
     /// Write the string table.
     pub fn write_strtab(&mut self) {
-        debug_assert_eq!(self.strtab_offset, self.buffer.len() as u32);
+        debug_assert_eq!(self.strtab_offset as u64, self.buffer.len());
         self.buffer.write_bytes(&u32::to_le_bytes(self.strtab_len));
         self.buffer.write_bytes(&self.strtab_data);
     }

--- a/src/write/elf/encoder.rs
+++ b/src/write/elf/encoder.rs
@@ -10,15 +10,15 @@ use crate::write::util::{write_align, write_pod, write_pod_slice};
 use crate::write::{self, Error, Result, WritableBuffer};
 
 /// Alignment for .symtab_shndx.
-pub const ALIGN_SYMTAB_SHNDX: u8 = 4;
+pub const ALIGN_SYMTAB_SHNDX: u64 = 4;
 /// Alignment for .hash
-pub const ALIGN_HASH: u8 = 4;
+pub const ALIGN_HASH: u64 = 4;
 /// Alignment for .gnu.version
-pub const ALIGN_GNU_VERSYM: u8 = 2;
+pub const ALIGN_GNU_VERSYM: u64 = 2;
 /// Alignment for .gnu.version_d
-pub const ALIGN_GNU_VERDEF: u8 = 4;
+pub const ALIGN_GNU_VERDEF: u64 = 4;
 /// Alignment for .gnu.version_r
-pub const ALIGN_GNU_VERNEED: u8 = 4;
+pub const ALIGN_GNU_VERNEED: u64 = 4;
 
 /// Native endian version of [`elf::FileHeader64`].
 #[allow(missing_docs)]
@@ -218,16 +218,16 @@ impl<E: Endian> Encoder<E> {
     ///
     /// Returns the file offset after the padding.
     pub fn address_align<W: WritableBuffer + ?Sized>(self, buffer: &mut W) -> u64 {
-        write_align(buffer, self.address_size() as usize);
-        buffer.len() as u64
+        write_align(buffer, self.address_size().into());
+        buffer.len()
     }
 
     /// Return the size of the file header.
-    pub fn file_header_size(self) -> usize {
+    pub fn file_header_size(self) -> u64 {
         if self.is_64 {
-            mem::size_of::<elf::FileHeader64<Endianness>>()
+            mem::size_of::<elf::FileHeader64<Endianness>>() as u64
         } else {
-            mem::size_of::<elf::FileHeader32<Endianness>>()
+            mem::size_of::<elf::FileHeader32<Endianness>>() as u64
         }
     }
 
@@ -331,11 +331,11 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a program header.
-    pub fn program_header_size(self) -> usize {
+    pub fn program_header_size(self) -> u64 {
         if self.is_64 {
-            mem::size_of::<elf::ProgramHeader64<Endianness>>()
+            mem::size_of::<elf::ProgramHeader64<Endianness>>() as u64
         } else {
-            mem::size_of::<elf::ProgramHeader32<Endianness>>()
+            mem::size_of::<elf::ProgramHeader32<Endianness>>() as u64
         }
     }
 
@@ -376,11 +376,11 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a section header.
-    pub fn section_header_size(self) -> usize {
+    pub fn section_header_size(self) -> u64 {
         if self.is_64 {
-            mem::size_of::<elf::SectionHeader64<Endianness>>()
+            mem::size_of::<elf::SectionHeader64<Endianness>>() as u64
         } else {
-            mem::size_of::<elf::SectionHeader32<Endianness>>()
+            mem::size_of::<elf::SectionHeader32<Endianness>>() as u64
         }
     }
 
@@ -514,7 +514,7 @@ impl<E: Endian> Encoder<E> {
             sh_link: strtab,
             sh_info: num_local,
             sh_addralign: self.address_size().into(),
-            sh_entsize: self.sym_size() as u64,
+            sh_entsize: self.sym_size(),
             ..SectionHeader::default()
         }
     }
@@ -527,7 +527,7 @@ impl<E: Endian> Encoder<E> {
         SectionHeader {
             sh_type: elf::SHT_SYMTAB_SHNDX,
             sh_link: symtab,
-            sh_addralign: ALIGN_SYMTAB_SHNDX as u64,
+            sh_addralign: ALIGN_SYMTAB_SHNDX,
             sh_entsize: 4,
             ..SectionHeader::default()
         }
@@ -544,7 +544,7 @@ impl<E: Endian> Encoder<E> {
             sh_link: dynstr,
             sh_info: num_local,
             sh_addralign: self.address_size().into(),
-            sh_entsize: self.sym_size() as u64,
+            sh_entsize: self.sym_size(),
             ..SectionHeader::default()
         }
     }
@@ -559,7 +559,7 @@ impl<E: Endian> Encoder<E> {
             sh_flags: elf::SHF_WRITE | elf::SHF_ALLOC,
             sh_link: dynstr,
             sh_addralign: self.address_size().into(),
-            sh_entsize: self.dyn_size() as u64,
+            sh_entsize: self.dyn_size(),
             ..SectionHeader::default()
         }
     }
@@ -573,7 +573,7 @@ impl<E: Endian> Encoder<E> {
             sh_type: elf::SHT_HASH,
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynsym,
-            sh_addralign: ALIGN_HASH as u64,
+            sh_addralign: ALIGN_HASH,
             sh_entsize: 4,
             ..SectionHeader::default()
         }
@@ -603,7 +603,7 @@ impl<E: Endian> Encoder<E> {
             sh_type: elf::SHT_GNU_VERSYM,
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynsym,
-            sh_addralign: ALIGN_GNU_VERSYM as u64,
+            sh_addralign: ALIGN_GNU_VERSYM,
             sh_entsize: 2,
             ..SectionHeader::default()
         }
@@ -619,7 +619,7 @@ impl<E: Endian> Encoder<E> {
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynstr,
             sh_info: verdef_count,
-            sh_addralign: ALIGN_GNU_VERDEF as u64,
+            sh_addralign: ALIGN_GNU_VERDEF,
             ..SectionHeader::default()
         }
     }
@@ -634,7 +634,7 @@ impl<E: Endian> Encoder<E> {
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynstr,
             sh_info: verneed_count,
-            sh_addralign: ALIGN_GNU_VERNEED as u64,
+            sh_addralign: ALIGN_GNU_VERNEED,
             ..SectionHeader::default()
         }
     }
@@ -661,7 +661,7 @@ impl<E: Endian> Encoder<E> {
             sh_type: if is_rela { elf::SHT_RELA } else { elf::SHT_REL },
             sh_flags: elf::SHF_INFO_LINK,
             sh_addralign: self.address_size().into(),
-            sh_entsize: self.rel_size(is_rela) as u64,
+            sh_entsize: self.rel_size(is_rela),
             ..SectionHeader::default()
         }
     }
@@ -673,7 +673,7 @@ impl<E: Endian> Encoder<E> {
         SectionHeader {
             sh_type: elf::SHT_RELA,
             sh_addralign: self.address_size().into(),
-            sh_entsize: self.relr_size() as u64,
+            sh_entsize: self.relr_size(),
             ..SectionHeader::default()
         }
     }
@@ -693,11 +693,11 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a symbol.
-    pub fn sym_size(self) -> usize {
+    pub fn sym_size(self) -> u64 {
         if self.is_64 {
-            mem::size_of::<elf::Sym64<Endianness>>()
+            mem::size_of::<elf::Sym64<Endianness>>() as u64
         } else {
-            mem::size_of::<elf::Sym32<Endianness>>()
+            mem::size_of::<elf::Sym32<Endianness>>() as u64
         }
     }
 
@@ -766,28 +766,28 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a relocation entry.
-    pub fn rel_size(self, is_rela: bool) -> usize {
+    pub fn rel_size(self, is_rela: bool) -> u64 {
         if self.is_64 {
             if is_rela {
-                mem::size_of::<elf::Rela64<Endianness>>()
+                mem::size_of::<elf::Rela64<Endianness>>() as u64
             } else {
-                mem::size_of::<elf::Rel64<Endianness>>()
+                mem::size_of::<elf::Rel64<Endianness>>() as u64
             }
         } else {
             if is_rela {
-                mem::size_of::<elf::Rela32<Endianness>>()
+                mem::size_of::<elf::Rela32<Endianness>>() as u64
             } else {
-                mem::size_of::<elf::Rel32<Endianness>>()
+                mem::size_of::<elf::Rel32<Endianness>>() as u64
             }
         }
     }
 
     /// Return the size of a relative relocation entry.
-    pub fn relr_size(self) -> usize {
+    pub fn relr_size(self) -> u64 {
         if self.is_64 {
-            mem::size_of::<elf::Relr64<Endianness>>()
+            mem::size_of::<elf::Relr64<Endianness>>() as u64
         } else {
-            mem::size_of::<elf::Relr32<Endianness>>()
+            mem::size_of::<elf::Relr32<Endianness>>() as u64
         }
     }
 
@@ -830,11 +830,11 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a dynamic entry.
-    pub fn dyn_size(self) -> usize {
+    pub fn dyn_size(self) -> u64 {
         if self.is_64 {
-            mem::size_of::<elf::Dyn64<Endianness>>()
+            mem::size_of::<elf::Dyn64<Endianness>>() as u64
         } else {
-            mem::size_of::<elf::Dyn32<Endianness>>()
+            mem::size_of::<elf::Dyn32<Endianness>>() as u64
         }
     }
 
@@ -872,10 +872,10 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a hash table.
-    pub fn hash_size(self, bucket_count: u32, chain_count: u32) -> usize {
-        mem::size_of::<elf::HashHeader<Endianness>>()
-            + bucket_count as usize * 4
-            + chain_count as usize * 4
+    pub fn hash_size(self, bucket_count: u32, chain_count: u32) -> u64 {
+        mem::size_of::<elf::HashHeader<Endianness>>() as u64
+            + bucket_count as u64 * 4
+            + chain_count as u64 * 4
     }
 
     /// Write a SysV hash table.
@@ -909,12 +909,12 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU hash table.
-    pub fn gnu_hash_size(self, bloom_count: u32, bucket_count: u32, symbol_count: u32) -> usize {
+    pub fn gnu_hash_size(self, bloom_count: u32, bucket_count: u32, symbol_count: u32) -> u64 {
         let bloom_size = if self.is_64 { 8 } else { 4 };
-        mem::size_of::<elf::GnuHashHeader<Endianness>>()
-            + bloom_count as usize * bloom_size
-            + bucket_count as usize * 4
-            + symbol_count as usize * 4
+        mem::size_of::<elf::GnuHashHeader<Endianness>>() as u64
+            + bloom_count as u64 * bloom_size
+            + bucket_count as u64 * 4
+            + symbol_count as u64 * 4
     }
 
     /// Write a GNU hash section.
@@ -1000,8 +1000,8 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU symbol version section.
-    pub fn gnu_versym_size(self, symbol_count: usize) -> usize {
-        symbol_count * 2
+    pub fn gnu_versym_size(self, symbol_count: usize) -> u64 {
+        symbol_count as u64 * 2
     }
 
     /// Write a symbol version entry.
@@ -1010,9 +1010,9 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU version definition section.
-    pub fn gnu_verdef_size(self, verdef_count: usize, verdaux_count: usize) -> usize {
-        verdef_count * mem::size_of::<elf::Verdef<Endianness>>()
-            + verdaux_count * mem::size_of::<elf::Verdaux<Endianness>>()
+    pub fn gnu_verdef_size(self, verdef_count: usize, verdaux_count: usize) -> u64 {
+        verdef_count as u64 * mem::size_of::<elf::Verdef<Endianness>>() as u64
+            + verdaux_count as u64 * mem::size_of::<elf::Verdaux<Endianness>>() as u64
     }
 
     /// Write a version definition entry.
@@ -1078,9 +1078,9 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU version dependency section.
-    pub fn gnu_verneed_size(self, verneed_count: usize, vernaux_count: usize) -> usize {
-        verneed_count * mem::size_of::<elf::Verneed<Endianness>>()
-            + vernaux_count * mem::size_of::<elf::Vernaux<Endianness>>()
+    pub fn gnu_verneed_size(self, verneed_count: usize, vernaux_count: usize) -> u64 {
+        verneed_count as u64 * mem::size_of::<elf::Verneed<Endianness>>() as u64
+            + vernaux_count as u64 * mem::size_of::<elf::Vernaux<Endianness>>() as u64
     }
 
     /// Write a version needed entry.

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -42,12 +42,12 @@ impl<'a> Object<'a> {
         let n_name = b"GNU\0";
         data.extend_from_slice(pod::bytes_of(&elf::NoteHeader32 {
             n_namesz: U32::new(self.endian, n_name.len() as u32),
-            n_descsz: U32::new(self.endian, util::align(3 * 4, align) as u32),
+            n_descsz: U32::new(self.endian, util::align_u32(3 * 4, align as u32)),
             n_type: U32::new(self.endian, elf::NT_GNU_PROPERTY_TYPE_0),
         }));
         data.extend_from_slice(n_name);
         // This happens to already be aligned correctly.
-        debug_assert_eq!(util::align(data.len(), align), data.len());
+        debug_assert_eq!(util::align(data.len() as u64, align), data.len() as u64);
         data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, property)));
         // Value size
         data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, 4u32)));
@@ -55,7 +55,7 @@ impl<'a> Object<'a> {
         util::write_align(&mut data, align);
 
         let section = self.section_id(StandardSection::GnuProperty);
-        self.append_section_data(section, &data, align as u64);
+        self.append_section_data(section, &data, align);
     }
 }
 
@@ -638,7 +638,7 @@ impl<'a> Object<'a> {
         let mut section_offsets = Vec::with_capacity(self.sections.len());
         for (section, reloc_name) in self.sections.iter().zip(reloc_names.iter()) {
             let index = writer.reserve_section_index();
-            let offset = writer.reserve(section.data.len(), section.align as usize);
+            let offset = writer.reserve(section.data.len() as u64, section.align);
             let str_id = writer.add_section_name(&section.name);
             let mut reloc_str_id = None;
             if !section.relocations.is_empty() {
@@ -776,7 +776,7 @@ impl<'a> Object<'a> {
             }
         }
         for (index, section) in self.sections.iter().enumerate() {
-            writer.write_align(section.align as usize);
+            writer.write_align(section.align);
             debug_assert_eq!(section_offsets[index].offset, writer.offset());
             writer.write(&section.data);
         }

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -104,8 +104,8 @@ pub struct Writer<'a, M: Mode = TwoPhase> {
 
     dynamic_str_id: Option<StringId>,
     dynamic_offset: u64,
-    dynamic_num: usize,
-    written_dynamic_num: usize,
+    dynamic_num: u64,
+    written_dynamic_num: u64,
 
     hash_str_id: Option<StringId>,
     hash_offset: u64,
@@ -237,19 +237,19 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.buffer.len()
     }
 
     /// Return the file offset of the next write.
     pub fn offset(&self) -> u64 {
-        self.buffer.len() as u64
+        self.buffer.len()
     }
 
     /// Write alignment padding bytes.
     ///
     /// Returns the file offset after the padding.
-    pub fn write_align(&mut self, align_start: usize) -> u64 {
+    pub fn write_align(&mut self, align_start: u64) -> u64 {
         if align_start > 1 {
             util::write_align(self.buffer, align_start);
         }
@@ -266,8 +266,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Write padding up to the given file offset.
     pub fn pad_until(&mut self, offset: u64) {
         debug_assert!(self.offset() <= offset);
-        debug_assert!(offset <= usize::MAX as u64);
-        self.buffer.resize(offset as usize);
+        self.buffer.resize(offset);
     }
 
     /// Write the file header.
@@ -469,7 +468,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         let index = self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(self.symtab_str_id),
             sh_offset: self.symtab_offset,
-            sh_size: self.symtab_num as u64 * self.encoder.sym_size() as u64,
+            sh_size: self.symtab_num as u64 * self.encoder.sym_size(),
             ..self
                 .encoder
                 .symtab_section_header(self.strtab_index.0, num_local)
@@ -486,7 +485,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             self.symtab_shndx_data = Vec::new();
             return 0;
         }
-        let offset = self.write_align(ALIGN_SYMTAB_SHNDX.into());
+        let offset = self.write_align(ALIGN_SYMTAB_SHNDX);
         M::set_offset(&mut self.symtab_shndx_offset, offset);
         M::set_section_name(
             &mut self.symtab_shndx_str_id,
@@ -615,7 +614,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_name: self.section_name_offset(self.dynsym_str_id),
             sh_addr,
             sh_offset: self.dynsym_offset,
-            sh_size: self.dynsym_num as u64 * self.encoder.sym_size() as u64,
+            sh_size: self.dynsym_num as u64 * self.encoder.sym_size(),
             ..self
                 .encoder
                 .dynsym_section_header(self.dynstr_index.0, num_local)
@@ -666,7 +665,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_name: self.section_name_offset(self.dynamic_str_id),
             sh_addr,
             sh_offset: self.dynamic_offset,
-            sh_size: (self.dynamic_num * self.encoder.dyn_size()) as u64,
+            sh_size: self.dynamic_num * self.encoder.dyn_size(),
             ..self.encoder.dynamic_section_header(self.dynstr_index.0)
         });
     }
@@ -683,7 +682,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     where
         F: Fn(u32) -> Option<u32>,
     {
-        let offset = self.write_align(ALIGN_HASH.into());
+        let offset = self.write_align(ALIGN_HASH);
         M::set_offset(&mut self.hash_offset, offset);
         M::set_section_name(&mut self.hash_str_id, &mut self.shstrtab, b".hash");
         self.encoder
@@ -780,7 +779,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.gnu_versym_offset) {
             return 0;
         }
-        let offset = self.write_align(ALIGN_GNU_VERSYM.into());
+        let offset = self.write_align(ALIGN_GNU_VERSYM);
         M::set_offset(&mut self.gnu_versym_offset, offset);
         M::set_section_name(
             &mut self.gnu_versym_str_id,
@@ -812,7 +811,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_name: self.section_name_offset(self.gnu_versym_str_id),
             sh_addr,
             sh_offset: self.gnu_versym_offset,
-            sh_size: self.encoder.gnu_versym_size(self.gnu_versym_num as usize) as u64,
+            sh_size: self.encoder.gnu_versym_size(self.gnu_versym_num as usize),
             ..self.encoder.gnu_versym_section_header(self.dynsym_index.0)
         });
     }
@@ -825,7 +824,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.gnu_verdef_offset) {
             return 0;
         }
-        let offset = self.write_align(ALIGN_GNU_VERDEF.into());
+        let offset = self.write_align(ALIGN_GNU_VERDEF);
         M::set_offset(&mut self.gnu_verdef_offset, offset);
         M::set_section_name(
             &mut self.gnu_verdef_str_id,
@@ -891,8 +890,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         }
         let sh_size = self
             .encoder
-            .gnu_verdef_size(self.gnu_verdef_count as usize, self.gnu_verdaux_count)
-            as u64;
+            .gnu_verdef_size(self.gnu_verdef_count as usize, self.gnu_verdaux_count);
         self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(self.gnu_verdef_str_id),
             sh_addr,
@@ -912,7 +910,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.gnu_verneed_offset) {
             return 0;
         }
-        let offset = self.write_align(ALIGN_GNU_VERNEED.into());
+        let offset = self.write_align(ALIGN_GNU_VERNEED);
         M::set_offset(&mut self.gnu_verneed_offset, offset);
         M::set_section_name(
             &mut self.gnu_verneed_str_id,
@@ -959,8 +957,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         }
         let sh_size = self
             .encoder
-            .gnu_verneed_size(self.gnu_verneed_count as usize, self.gnu_vernaux_count)
-            as u64;
+            .gnu_verneed_size(self.gnu_verneed_count as usize, self.gnu_vernaux_count);
         self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(self.gnu_verneed_str_id),
             sh_addr,
@@ -1047,7 +1044,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(Some(name)),
             sh_offset: offset,
-            sh_size: (count * self.encoder.rel_size(is_rela)) as u64,
+            sh_size: count as u64 * self.encoder.rel_size(is_rela),
             sh_link: symtab.0,
             sh_info: section.0,
             ..self.encoder.relocation_section_header(is_rela)
@@ -1061,13 +1058,13 @@ impl<'a, M: Mode> Writer<'a, M> {
     pub fn write_relative_relocation_section_header(
         &mut self,
         name: StringId,
-        offset: usize,
-        size: usize,
+        offset: u64,
+        size: u64,
     ) {
         self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(Some(name)),
-            sh_offset: offset as u64,
-            sh_size: size as u64,
+            sh_offset: offset,
+            sh_size: size,
             ..self.encoder.relative_relocation_section_header()
         });
     }
@@ -1230,13 +1227,13 @@ impl<'a> Writer<'a, SinglePhase> {
         // file_header_size is always a multiple of address size, so no alignment
         // padding is required.
         let offset = self.offset();
-        debug_assert_eq!(offset, self.encoder.file_header_size() as u64);
+        debug_assert_eq!(offset, self.encoder.file_header_size());
         SinglePhase::set_offset(&mut self.layout.e_phoff, offset);
         SinglePhase::set_count(&mut self.layout.segment_num, count);
         self.written_segment_num = count;
-        let size = count as usize * self.encoder.program_header_size();
+        let size = u64::from(count) * self.encoder.program_header_size();
         self.buffer.resize(self.buffer.len() + size);
-        (offset, size as u64)
+        (offset, size)
     }
 
     /// Write the file header and program headers to the given buffer.
@@ -1386,7 +1383,7 @@ impl<'a> Writer<'a, SinglePhase> {
 /// with checking this.
 #[derive(Debug)]
 pub struct TwoPhase {
-    len: usize,
+    len: u64,
     shstrtab_data: Vec<u8>,
     strtab_data: Vec<u8>,
     dynstr_data: Vec<u8>,
@@ -1447,7 +1444,7 @@ impl<'a> Writer<'a, TwoPhase> {
     }
 
     /// Return the current file length that has been reserved.
-    pub fn reserved_len(&self) -> usize {
+    pub fn reserved_len(&self) -> u64 {
         self.mode.len
     }
 
@@ -1456,17 +1453,17 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Returns the aligned offset of the start of the range.
     ///
     /// `align_start` must be a power of two.
-    pub fn reserve(&mut self, len: usize, align_start: usize) -> u64 {
+    pub fn reserve(&mut self, len: u64, align_start: u64) -> u64 {
         if align_start > 1 {
             self.mode.len = util::align(self.mode.len, align_start);
         }
         let offset = self.mode.len;
         self.mode.len += len;
-        offset as u64
+        offset
     }
 
     /// Reserve the file range up to the given file offset.
-    pub fn reserve_until(&mut self, offset: usize) {
+    pub fn reserve_until(&mut self, offset: u64) {
         debug_assert!(self.mode.len <= offset);
         self.mode.len = offset;
     }
@@ -1485,14 +1482,14 @@ impl<'a> Writer<'a, TwoPhase> {
     /// the section table; this is checked in `write_file_header`.
     ///
     /// Does nothing if `num` is zero.
-    pub fn reserve_program_headers(&mut self, num: u32) {
+    pub fn reserve_program_headers(&mut self, num: usize) {
         debug_assert_eq!(self.layout.e_phoff, 0);
         if num == 0 {
             return;
         }
-        self.layout.segment_num = num;
+        self.layout.segment_num = num as u32;
         self.layout.e_phoff = self.reserve(
-            num as usize * self.encoder.program_header_size(),
+            num as u64 * self.encoder.program_header_size(),
             self.encoder.address_size().into(),
         );
     }
@@ -1538,7 +1535,7 @@ impl<'a> Writer<'a, TwoPhase> {
             return;
         }
         self.layout.e_shoff = self.reserve(
-            self.layout.section_num as usize * self.encoder.section_header_size(),
+            self.layout.section_num as u64 * self.encoder.section_header_size(),
             self.encoder.address_size().into(),
         );
     }
@@ -1560,7 +1557,7 @@ impl<'a> Writer<'a, TwoPhase> {
         // Start with null section name.
         self.mode.shstrtab_data = vec![0];
         self.shstrtab_size = self.shstrtab.write(1, &mut self.mode.shstrtab_data)?;
-        self.shstrtab_offset = self.reserve(self.shstrtab_size as usize, 1);
+        self.shstrtab_offset = self.reserve(self.shstrtab_size as u64, 1);
         Ok(())
     }
 
@@ -1613,7 +1610,7 @@ impl<'a> Writer<'a, TwoPhase> {
         // Start with null string.
         self.mode.strtab_data = vec![0];
         self.strtab_size = self.strtab.write(1, &mut self.mode.strtab_data)?;
-        self.strtab_offset = self.reserve(self.strtab_size as usize, 1);
+        self.strtab_offset = self.reserve(self.strtab_size as u64, 1);
         Ok(())
     }
 
@@ -1707,7 +1704,7 @@ impl<'a> Writer<'a, TwoPhase> {
             return;
         }
         self.symtab_offset = self.reserve(
-            self.symtab_num as usize * self.encoder.sym_size(),
+            self.symtab_num as u64 * self.encoder.sym_size(),
             self.encoder.address_size().into(),
         );
     }
@@ -1750,8 +1747,7 @@ impl<'a> Writer<'a, TwoPhase> {
         if !self.symtab_shndx_needed() {
             return;
         }
-        self.symtab_shndx_offset =
-            self.reserve(self.symtab_num as usize * 4, ALIGN_SYMTAB_SHNDX.into());
+        self.symtab_shndx_offset = self.reserve(self.symtab_num as u64 * 4, ALIGN_SYMTAB_SHNDX);
         self.symtab_shndx_data.reserve(self.symtab_num as usize * 4);
     }
 
@@ -1796,7 +1792,7 @@ impl<'a> Writer<'a, TwoPhase> {
         // Start with null string.
         self.mode.dynstr_data = vec![0];
         self.dynstr_size = self.dynstr.write(1, &mut self.mode.dynstr_data)?;
-        self.dynstr_offset = self.reserve(self.dynstr_size as usize, 1);
+        self.dynstr_offset = self.reserve(self.dynstr_size as u64, 1);
         Ok(self.dynstr_offset)
     }
 
@@ -1901,7 +1897,7 @@ impl<'a> Writer<'a, TwoPhase> {
             return 0;
         }
         self.dynsym_offset = self.reserve(
-            self.dynsym_num as usize * self.encoder.sym_size(),
+            self.dynsym_num as u64 * self.encoder.sym_size(),
             self.encoder.address_size().into(),
         );
         self.dynsym_offset
@@ -1931,9 +1927,9 @@ impl<'a> Writer<'a, TwoPhase> {
         if dynamic_num == 0 {
             return 0;
         }
-        self.dynamic_num = dynamic_num;
+        self.dynamic_num = dynamic_num as u64;
         self.dynamic_offset = self.reserve(
-            dynamic_num * self.encoder.dyn_size(),
+            self.dynamic_num * self.encoder.dyn_size(),
             self.encoder.address_size().into(),
         );
         self.dynamic_offset
@@ -1954,8 +1950,8 @@ impl<'a> Writer<'a, TwoPhase> {
     /// not the total number of symbols.
     pub fn reserve_hash(&mut self, bucket_count: u32, symbol_count: u32) -> u64 {
         let size = self.encoder.hash_size(bucket_count, symbol_count);
-        self.hash_offset = self.reserve(size, ALIGN_HASH.into());
-        self.hash_size = size as u64;
+        self.hash_offset = self.reserve(size, ALIGN_HASH);
+        self.hash_size = size;
         self.hash_offset
     }
 
@@ -1982,7 +1978,7 @@ impl<'a> Writer<'a, TwoPhase> {
             .encoder
             .gnu_hash_size(bloom_count, bucket_count, symbol_count);
         self.gnu_hash_offset = self.reserve(size, self.encoder.address_size().into());
-        self.gnu_hash_size = size as u64;
+        self.gnu_hash_size = size;
         self.gnu_hash_offset
     }
 
@@ -2006,7 +2002,7 @@ impl<'a> Writer<'a, TwoPhase> {
         }
         self.gnu_versym_num = self.dynsym_num;
         let size = self.encoder.gnu_versym_size(self.gnu_versym_num as usize);
-        self.gnu_versym_offset = self.reserve(size, ALIGN_GNU_VERSYM.into());
+        self.gnu_versym_offset = self.reserve(size, ALIGN_GNU_VERSYM);
         self.gnu_versym_offset
     }
 
@@ -2029,7 +2025,7 @@ impl<'a> Writer<'a, TwoPhase> {
             return 0;
         }
         let size = self.encoder.gnu_verdef_size(verdef_count, verdaux_count);
-        self.gnu_verdef_offset = self.reserve(size, ALIGN_GNU_VERDEF.into());
+        self.gnu_verdef_offset = self.reserve(size, ALIGN_GNU_VERDEF);
         self.gnu_verdef_count = verdef_count as u16;
         self.gnu_verdaux_count = verdaux_count;
         self.gnu_verdef_remaining = self.gnu_verdef_count;
@@ -2062,7 +2058,7 @@ impl<'a> Writer<'a, TwoPhase> {
             return 0;
         }
         let size = self.encoder.gnu_verneed_size(verneed_count, vernaux_count);
-        self.gnu_verneed_offset = self.reserve(size, ALIGN_GNU_VERNEED.into());
+        self.gnu_verneed_offset = self.reserve(size, ALIGN_GNU_VERNEED);
         self.gnu_verneed_count = verneed_count as u16;
         self.gnu_vernaux_count = vernaux_count;
         self.gnu_verneed_remaining = self.gnu_verneed_count;
@@ -2098,12 +2094,12 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// Returns the file offset of the reserved range.
     /// Returns 0 if `gnu_attributes_size` is zero.
-    pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: usize) -> u64 {
+    pub fn reserve_gnu_attributes(&mut self, gnu_attributes_size: u64) -> u64 {
         debug_assert_eq!(self.gnu_attributes_offset, 0);
         if gnu_attributes_size == 0 {
             return 0;
         }
-        self.gnu_attributes_size = gnu_attributes_size as u64;
+        self.gnu_attributes_size = gnu_attributes_size;
         self.gnu_attributes_offset = self.reserve(gnu_attributes_size, 1);
         self.gnu_attributes_offset
     }
@@ -2113,7 +2109,7 @@ impl<'a> Writer<'a, TwoPhase> {
     /// Returns the offset of the range.
     pub fn reserve_relocations(&mut self, count: usize, is_rela: bool) -> u64 {
         self.reserve(
-            count * self.encoder.rel_size(is_rela),
+            count as u64 * self.encoder.rel_size(is_rela),
             self.encoder.address_size().into(),
         )
     }
@@ -2124,6 +2120,6 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// Returns the offset of the range.
     pub fn reserve_comdat(&mut self, count: usize) -> u64 {
-        self.reserve((count + 1) * 4, 4)
+        self.reserve((count as u64 + 1) * 4, 4)
     }
 }

--- a/src/write/macho.rs
+++ b/src/write/macho.rs
@@ -9,9 +9,9 @@ use crate::write::*;
 #[derive(Default, Clone, Copy)]
 struct SectionOffsets {
     index: usize,
-    offset: usize,
+    offset: u64,
     address: u64,
-    reloc_offset: usize,
+    reloc_offset: u64,
     reloc_count: usize,
 }
 
@@ -452,7 +452,7 @@ impl<'a> Object<'a> {
             AddressSize::U8 | AddressSize::U16 | AddressSize::U32 => &macho32,
             AddressSize::U64 => &macho64,
         };
-        let pointer_align = address_size.bytes() as usize;
+        let pointer_align = address_size.bytes() as u64;
 
         // Calculate offsets of everything, and build strtab.
         let mut offset = 0;
@@ -467,26 +467,26 @@ impl<'a> Object<'a> {
         // Calculate size of segment command and section headers.
         let segment_command_offset = offset;
         let segment_command_len =
-            macho.segment_command_size() + self.sections.len() * macho.section_header_size();
+            macho.segment_command_size() + self.sections.len() as u64 * macho.section_header_size();
         offset += segment_command_len;
         ncmds += 1;
 
         // Calculate size of build version.
         let build_version_offset = offset;
         if let Some(version) = &self.macho_build_version {
-            offset += version.cmdsize() as usize;
+            offset += version.cmdsize() as u64;
             ncmds += 1;
         }
 
         // Calculate size of symtab command.
         let symtab_command_offset = offset;
-        let symtab_command_len = mem::size_of::<macho::SymtabCommand<Endianness>>();
+        let symtab_command_len = mem::size_of::<macho::SymtabCommand<Endianness>>() as u64;
         offset += symtab_command_len;
         ncmds += 1;
 
         // Calculate size of dysymtab command.
         let dysymtab_command_offset = offset;
-        let dysymtab_command_len = mem::size_of::<macho::DysymtabCommand<Endianness>>();
+        let dysymtab_command_len = mem::size_of::<macho::DysymtabCommand<Endianness>>() as u64;
         offset += dysymtab_command_len;
         ncmds += 1;
 
@@ -500,18 +500,18 @@ impl<'a> Object<'a> {
         for (index, section) in self.sections.iter().enumerate() {
             section_offsets[index].index = 1 + index;
             if !section.is_bss() {
-                address = align_u64(address, section.align);
+                address = align(address, section.align);
                 section_offsets[index].address = address;
-                section_offsets[index].offset = segment_file_offset + address as usize;
+                section_offsets[index].offset = segment_file_offset + address;
                 address += section.size;
             }
         }
-        let segment_file_size = address as usize;
-        offset += address as usize;
+        let segment_file_size = address;
+        offset += address;
         for (index, section) in self.sections.iter().enumerate() {
             if section.is_bss() {
                 debug_assert!(section.data.is_empty());
-                address = align_u64(address, section.align);
+                address = align(address, section.align);
                 section_offsets[index].address = address;
                 address += section.size;
             }
@@ -588,7 +588,7 @@ impl<'a> Object<'a> {
                 offset = align(offset, pointer_align);
                 section_offsets[index].reloc_offset = offset;
                 section_offsets[index].reloc_count = count;
-                let len = count * mem::size_of::<macho::Relocation<Endianness>>();
+                let len = count as u64 * mem::size_of::<macho::Relocation<Endianness>>() as u64;
                 offset += len;
             }
         }
@@ -596,7 +596,7 @@ impl<'a> Object<'a> {
         // Calculate size of symtab.
         offset = align(offset, pointer_align);
         let symtab_offset = offset;
-        let symtab_len = nsyms * macho.nlist_size();
+        let symtab_len = nsyms as u64 * macho.nlist_size();
         offset += symtab_len;
 
         // Calculate size of strtab.
@@ -605,7 +605,7 @@ impl<'a> Object<'a> {
         let mut strtab_data = vec![0];
         strtab.write(1, &mut strtab_data)?;
         write_align(&mut strtab_data, pointer_align);
-        offset += strtab_data.len();
+        offset += strtab_data.len() as u64;
 
         // Start writing.
         buffer
@@ -671,8 +671,8 @@ impl<'a> Object<'a> {
                 segname: [0; 16],
                 vmaddr: 0,
                 vmsize: address,
-                fileoff: segment_file_offset as u64,
-                filesize: segment_file_size as u64,
+                fileoff: segment_file_offset,
+                filesize: segment_file_size,
                 maxprot: macho::VM_PROT_READ | macho::VM_PROT_WRITE | macho::VM_PROT_EXECUTE,
                 initprot: macho::VM_PROT_READ | macho::VM_PROT_WRITE | macho::VM_PROT_EXECUTE,
                 nsects: self.sections.len() as u32,
@@ -994,10 +994,10 @@ struct Nlist {
 }
 
 trait MachO {
-    fn mach_header_size(&self) -> usize;
-    fn segment_command_size(&self) -> usize;
-    fn section_header_size(&self) -> usize;
-    fn nlist_size(&self) -> usize;
+    fn mach_header_size(&self) -> u64;
+    fn segment_command_size(&self) -> u64;
+    fn section_header_size(&self) -> u64;
+    fn nlist_size(&self) -> u64;
     fn write_mach_header(&self, buffer: &mut dyn WritableBuffer, section: MachHeader);
     fn write_segment_command(&self, buffer: &mut dyn WritableBuffer, segment: SegmentCommand);
     fn write_section(&self, buffer: &mut dyn WritableBuffer, section: SectionHeader);
@@ -1009,20 +1009,20 @@ struct MachO32<E> {
 }
 
 impl<E: Endian> MachO for MachO32<E> {
-    fn mach_header_size(&self) -> usize {
-        mem::size_of::<macho::MachHeader32<E>>()
+    fn mach_header_size(&self) -> u64 {
+        mem::size_of::<macho::MachHeader32<E>>() as u64
     }
 
-    fn segment_command_size(&self) -> usize {
-        mem::size_of::<macho::SegmentCommand32<E>>()
+    fn segment_command_size(&self) -> u64 {
+        mem::size_of::<macho::SegmentCommand32<E>>() as u64
     }
 
-    fn section_header_size(&self) -> usize {
-        mem::size_of::<macho::Section32<E>>()
+    fn section_header_size(&self) -> u64 {
+        mem::size_of::<macho::Section32<E>>() as u64
     }
 
-    fn nlist_size(&self) -> usize {
-        mem::size_of::<macho::Nlist32<E>>()
+    fn nlist_size(&self) -> u64 {
+        mem::size_of::<macho::Nlist32<E>>() as u64
     }
 
     fn write_mach_header(&self, buffer: &mut dyn WritableBuffer, header: MachHeader) {
@@ -1098,20 +1098,20 @@ struct MachO64<E> {
 }
 
 impl<E: Endian> MachO for MachO64<E> {
-    fn mach_header_size(&self) -> usize {
-        mem::size_of::<macho::MachHeader64<E>>()
+    fn mach_header_size(&self) -> u64 {
+        mem::size_of::<macho::MachHeader64<E>>() as u64
     }
 
-    fn segment_command_size(&self) -> usize {
-        mem::size_of::<macho::SegmentCommand64<E>>()
+    fn segment_command_size(&self) -> u64 {
+        mem::size_of::<macho::SegmentCommand64<E>>() as u64
     }
 
-    fn section_header_size(&self) -> usize {
-        mem::size_of::<macho::Section64<E>>()
+    fn section_header_size(&self) -> u64 {
+        mem::size_of::<macho::Section64<E>>() as u64
     }
 
-    fn nlist_size(&self) -> usize {
-        mem::size_of::<macho::Nlist64<E>>()
+    fn nlist_size(&self) -> u64 {
+        mem::size_of::<macho::Nlist64<E>>() as u64
     }
 
     fn write_mach_header(&self, buffer: &mut dyn WritableBuffer, header: MachHeader) {

--- a/src/write/pe.rs
+++ b/src/write/pe.rs
@@ -22,7 +22,7 @@ pub struct Writer<'a> {
     file_alignment: u32,
 
     buffer: &'a mut dyn WritableBuffer,
-    len: u32,
+    len: u64,
     virtual_len: u32,
     headers_len: u32,
 
@@ -113,13 +113,13 @@ impl<'a> Writer<'a> {
     }
 
     /// Return the current file length that has been reserved.
-    pub fn reserved_len(&self) -> u32 {
+    pub fn reserved_len(&self) -> u64 {
         self.len
     }
 
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.buffer.len()
     }
 
@@ -128,11 +128,11 @@ impl<'a> Writer<'a> {
     /// Returns the aligned offset of the start of the range.
     pub fn reserve(&mut self, len: u32, align_start: u32) -> u32 {
         if len == 0 {
-            return self.len;
+            return self.len as u32;
         }
         self.reserve_align(align_start);
-        let offset = self.len;
-        self.len += len;
+        let offset = self.len as u32;
+        self.len += len as u64;
         offset
     }
 
@@ -150,12 +150,12 @@ impl<'a> Writer<'a> {
 
     /// Reserve alignment padding bytes.
     pub fn reserve_align(&mut self, align_start: u32) {
-        self.len = util::align_u32(self.len, align_start);
+        self.len = util::align(self.len, align_start as u64);
     }
 
     /// Write alignment padding bytes.
     pub fn write_align(&mut self, align_start: u32) {
-        util::write_align(self.buffer, align_start as usize);
+        util::write_align(self.buffer, align_start as u64);
     }
 
     /// Write padding up to the next multiple of file alignment.
@@ -165,14 +165,14 @@ impl<'a> Writer<'a> {
 
     /// Reserve the file range up to the given file offset.
     pub fn reserve_until(&mut self, offset: u32) {
-        debug_assert!(self.len <= offset);
-        self.len = offset;
+        debug_assert!(self.len <= offset as u64);
+        self.len = offset as u64;
     }
 
     /// Write padding up to the given file offset.
     pub fn pad_until(&mut self, offset: u32) {
-        debug_assert!(self.buffer.len() <= offset as usize);
-        self.buffer.resize(offset as usize);
+        debug_assert!(self.buffer.len() <= offset as u64);
+        self.buffer.resize(offset as u64);
     }
 
     /// Reserve the range for the DOS header.
@@ -193,7 +193,7 @@ impl<'a> Writer<'a> {
 
         // Start writing.
         self.buffer
-            .reserve(self.len as usize)
+            .reserve(self.len)
             .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
 
         self.buffer.write(dos_header);
@@ -436,8 +436,8 @@ impl<'a> Writer<'a> {
         );
         // Padding before sections must be included in headers_len.
         self.reserve_align(self.file_alignment);
-        self.headers_len = self.len;
-        self.reserve_virtual(self.len);
+        self.headers_len = self.len as u32;
+        self.reserve_virtual(self.len as u32);
     }
 
     /// Write the section headers.

--- a/src/write/string.rs
+++ b/src/write/string.rs
@@ -163,22 +163,22 @@ impl<'a> StringTable<'a> {
     /// this should be 1 for ELF, to account for the initial
     /// null byte.
     #[cfg(all(feature = "build_core", feature = "elf"))]
-    pub(crate) fn size(&self, base: usize) -> usize {
+    pub(crate) fn size(&self, base: u32) -> u64 {
         if self.in_order {
-            debug_assert_eq!(self.base as usize, base);
-            return self.size as usize;
+            debug_assert_eq!(self.base, base);
+            return self.size;
         }
 
         // TODO: cache this result?
         let mut ids: Vec<_> = (0..self.strings.len()).collect();
         sort(&mut ids, 1, &self.strings);
 
-        let mut size = base;
+        let mut size = base as u64;
         let mut previous = &[][..];
         for id in ids {
             let string = self.strings.get_index(id).unwrap();
             if !previous.ends_with(string) {
-                size += string.len() + 1;
+                size += string.len() as u64 + 1;
                 previous = string;
             }
         }

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -11,18 +11,18 @@ pub trait WritableBuffer {
     ///
     /// This is called often, so implementors should track this value
     /// themselves if determining the length is an expensive operation.
-    fn len(&self) -> usize;
+    fn len(&self) -> u64;
 
     /// Reserves specified number of bytes in the buffer.
     ///
     /// If called, this will be called exactly once before any writes, and the given size
     /// is the exact total number of bytes that will be written. Writers that target
     /// [`GrowableBuffer`] may skip this call, but it is required for other writers.
-    fn reserve(&mut self, size: usize) -> Result<(), ()>;
+    fn reserve(&mut self, size: u64) -> Result<(), ()>;
 
     /// Writes zero bytes at the end of the buffer until the buffer
     /// has the specified length.
-    fn resize(&mut self, new_len: usize);
+    fn resize(&mut self, new_len: u64);
 
     /// Writes the specified slice of bytes at the end of the buffer.
     fn write_bytes(&mut self, val: &[u8]);
@@ -90,21 +90,22 @@ impl GrowableBuffer for Vec<u8> {
 
 impl WritableBuffer for Vec<u8> {
     #[inline]
-    fn len(&self) -> usize {
-        self.len()
+    fn len(&self) -> u64 {
+        self.len() as u64
     }
 
     #[inline]
-    fn reserve(&mut self, size: usize) -> Result<(), ()> {
+    fn reserve(&mut self, size: u64) -> Result<(), ()> {
         debug_assert!(self.is_empty());
+        let size = usize::try_from(size).map_err(|_| ())?;
         self.reserve(size);
         Ok(())
     }
 
     #[inline]
-    fn resize(&mut self, new_len: usize) {
-        debug_assert!(new_len >= self.len());
-        self.resize(new_len, 0);
+    fn resize(&mut self, new_len: u64) {
+        debug_assert!(new_len as usize >= self.len());
+        self.resize(new_len as usize, 0);
     }
 
     #[inline]
@@ -124,7 +125,7 @@ impl WritableBuffer for Vec<u8> {
 #[derive(Debug)]
 pub struct StreamingBuffer<W> {
     writer: W,
-    len: usize,
+    len: u64,
     result: Result<(), io::Error>,
 }
 
@@ -169,20 +170,20 @@ impl<W: io::Write> GrowableBuffer for StreamingBuffer<W> {
 #[cfg(feature = "std")]
 impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {
     #[inline]
-    fn len(&self) -> usize {
+    fn len(&self) -> u64 {
         self.len
     }
 
     #[inline]
-    fn reserve(&mut self, _size: usize) -> Result<(), ()> {
+    fn reserve(&mut self, _size: u64) -> Result<(), ()> {
         Ok(())
     }
 
     #[inline]
-    fn resize(&mut self, new_len: usize) {
+    fn resize(&mut self, new_len: u64) {
         debug_assert!(self.len <= new_len);
         while self.len < new_len {
-            let write_amt = (new_len - self.len).min(1024);
+            let write_amt = (new_len - self.len).min(1024) as usize;
             self.write_bytes(&[0; 1024][..write_amt]);
         }
     }
@@ -194,7 +195,7 @@ impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {
         }
         // Callers depend on `len` being equal to the total requested writes,
         // even if those writes failed.
-        self.len += val.len();
+        self.len += val.len() as u64;
     }
 }
 
@@ -267,21 +268,17 @@ pub(crate) fn write_sleb128(buf: &mut Vec<u8>, mut val: i64) -> usize {
     }
 }
 
-pub(crate) fn align(offset: usize, size: usize) -> usize {
-    (offset + (size - 1)) & !(size - 1)
-}
-
 #[allow(dead_code)]
 pub(crate) fn align_u32(offset: u32, size: u32) -> u32 {
     (offset + (size - 1)) & !(size - 1)
 }
 
 #[allow(dead_code)]
-pub(crate) fn align_u64(offset: u64, size: u64) -> u64 {
+pub(crate) fn align(offset: u64, size: u64) -> u64 {
     (offset + (size - 1)) & !(size - 1)
 }
 
-pub(crate) fn write_align<W: WritableBuffer + ?Sized>(buffer: &mut W, size: usize) {
+pub(crate) fn write_align<W: WritableBuffer + ?Sized>(buffer: &mut W, size: u64) {
     let new_len = align(buffer.len(), size);
     buffer.resize(new_len);
 }

--- a/src/write/xcoff.rs
+++ b/src/write/xcoff.rs
@@ -9,8 +9,8 @@ use crate::xcoff;
 #[derive(Default, Clone, Copy)]
 struct SectionOffsets {
     address: u64,
-    data_offset: usize,
-    reloc_offset: usize,
+    data_offset: u64,
+    reloc_offset: u64,
 }
 
 #[derive(Default, Clone, Copy)]
@@ -226,17 +226,17 @@ impl<'a> Object<'a> {
 
         let (hdr_size, sechdr_size, rel_size, sym_size) = if is_64 {
             (
-                mem::size_of::<xcoff::FileHeader64>(),
-                mem::size_of::<xcoff::SectionHeader64>(),
-                mem::size_of::<xcoff::Rel64>(),
-                mem::size_of::<xcoff::Symbol64>(),
+                mem::size_of::<xcoff::FileHeader64>() as u64,
+                mem::size_of::<xcoff::SectionHeader64>() as u64,
+                mem::size_of::<xcoff::Rel64>() as u64,
+                mem::size_of::<xcoff::Symbol64>() as u64,
             )
         } else {
             (
-                mem::size_of::<xcoff::FileHeader32>(),
-                mem::size_of::<xcoff::SectionHeader32>(),
-                mem::size_of::<xcoff::Rel32>(),
-                mem::size_of::<xcoff::Symbol32>(),
+                mem::size_of::<xcoff::FileHeader32>() as u64,
+                mem::size_of::<xcoff::SectionHeader32>() as u64,
+                mem::size_of::<xcoff::Rel32>() as u64,
+                mem::size_of::<xcoff::Symbol32>() as u64,
             )
         };
 
@@ -249,19 +249,19 @@ impl<'a> Object<'a> {
         // XCOFF file header.
         offset += hdr_size;
         // Section headers.
-        offset += self.sections.len() * sechdr_size;
+        offset += self.sections.len() as u64 * sechdr_size;
 
         // Calculate size of section data.
         let mut section_offsets = vec![SectionOffsets::default(); self.sections.len()];
         for (index, section) in self.sections.iter().enumerate() {
-            let len = section.data.len();
+            let len = section.data.len() as u64;
             let sectype = section.kind;
             // Section address should be 0 for all sections except the .text, .data, and .bss sections.
             if sectype == SectionKind::Data
                 || sectype == SectionKind::Text
                 || sectype == SectionKind::UninitializedData
             {
-                section_offsets[index].address = address as u64;
+                section_offsets[index].address = address;
                 address += len;
                 address = align(address, 4);
             } else {
@@ -279,7 +279,7 @@ impl<'a> Object<'a> {
 
         // Calculate size of relocations.
         for (index, section) in self.sections.iter().enumerate() {
-            let count = section.relocations.len();
+            let count = section.relocations.len() as u64;
             if count != 0 {
                 section_offsets[index].reloc_offset = offset;
                 offset += count * rel_size;
@@ -342,7 +342,7 @@ impl<'a> Object<'a> {
             }
         }
         let symtab_offset = offset;
-        let symtab_len = symtab_count * sym_size;
+        let symtab_len = symtab_count as u64 * sym_size;
         offset += symtab_len;
 
         // Calculate size of strtab.
@@ -350,7 +350,7 @@ impl<'a> Object<'a> {
         let mut strtab_data = Vec::new();
         // First 4 bytes of strtab are the length.
         let strtab_len = strtab.write(4, &mut strtab_data)?;
-        offset += strtab_len as usize;
+        offset += strtab_len as u64;
 
         // Start writing.
         buffer
@@ -367,7 +367,7 @@ impl<'a> Object<'a> {
                 f_magic: xcoff::MAGIC_64.into(),
                 f_nscns: (self.sections.len() as u16).into(),
                 f_timdat: 0.into(),
-                f_symptr: (symtab_offset as u64).into(),
+                f_symptr: symtab_offset.into(),
                 f_nsyms: (symtab_count as u32).into(),
                 f_opthdr: 0.into(),
                 f_flags: f_flags.into(),

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -48,7 +48,7 @@ fn phnum_overflow() {
 
         let object = read::elf::ElfFile64::<Endianness>::parse(&*bytes).unwrap();
         assert_eq!(object.architecture(), Architecture::X86_64);
-        assert_eq!(object.elf_program_headers().len(), count as usize);
+        assert_eq!(object.elf_program_headers().len(), count);
     }
 
     // Error if missing section headers.


### PR DESCRIPTION
The goal is to reduce the amount of casts required by API users, and make it easier to correctly handle overflow later (not implemented by this commit).

usize is still used in many places for counts.

Breaking changes:

- WritableBuffer trait method signatures
- various low level writer APIs