### PR TITLE
write/elf: Encoder address size cleanups

### DIFF
--- a/src/build/elf.rs
+++ b/src/build/elf.rs
@@ -1136,7 +1136,7 @@ impl<'data> Builder<'data> {
         }
 
         let encoder = self.encoder();
-        let address_size = u64::from(encoder.address_size());
+        let address_size = encoder.address_size();
 
         // Build string tables.
         let mut shstrtab_data = Vec::new();
@@ -1372,7 +1372,7 @@ impl<'data> Builder<'data> {
         encoder.file_header(buffer, &header, &layout)?;
 
         if !self.segments.is_empty() {
-            encoder.address_align(buffer);
+            buffer.resize(e_phoff);
             for segment in &self.segments {
                 encoder.program_header(
                     buffer,

--- a/src/write/elf/encoder.rs
+++ b/src/write/elf/encoder.rs
@@ -6,7 +6,7 @@ use crate::Wrap;
 use crate::elf;
 use crate::endian::*;
 use crate::pod;
-use crate::write::util::{write_align, write_pod, write_pod_slice};
+use crate::write::util::{write_pod, write_pod_slice};
 use crate::write::{self, Error, Result, StringTable, WritableBuffer};
 
 /// Alignment for .symtab_shndx.
@@ -207,19 +207,11 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size in bytes of an address for the ELF class.
-    pub fn address_size(self) -> u8 {
-        if self.is_64 { 8 } else { 4 }
-    }
-
-    /// Write alignment padding bytes corresponding to the ELF class.
-    ///
-    /// Required for: program headers, section headers, symbols, dynamics, relocations,
+    /// This should be used as the file offset alignment for various structures
+    /// such as program headers, section headers, symbols, dynamics, relocations,
     /// and .gnu.hash.
-    ///
-    /// Returns the file offset after the padding.
-    pub fn address_align<W: WritableBuffer + ?Sized>(self, buffer: &mut W) -> u64 {
-        write_align(buffer, self.address_size().into());
-        buffer.len()
+    pub fn address_size(self) -> u64 {
+        if self.is_64 { 8 } else { 4 }
     }
 
     /// Return the size of the file header.
@@ -513,7 +505,7 @@ impl<E: Endian> Encoder<E> {
             sh_type: elf::SHT_SYMTAB,
             sh_link: strtab,
             sh_info: num_local,
-            sh_addralign: self.address_size().into(),
+            sh_addralign: self.address_size(),
             sh_entsize: self.sym_size(),
             ..SectionHeader::default()
         }
@@ -543,7 +535,7 @@ impl<E: Endian> Encoder<E> {
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynstr,
             sh_info: num_local,
-            sh_addralign: self.address_size().into(),
+            sh_addralign: self.address_size(),
             sh_entsize: self.sym_size(),
             ..SectionHeader::default()
         }
@@ -558,7 +550,7 @@ impl<E: Endian> Encoder<E> {
             sh_type: elf::SHT_DYNAMIC,
             sh_flags: elf::SHF_WRITE | elf::SHF_ALLOC,
             sh_link: dynstr,
-            sh_addralign: self.address_size().into(),
+            sh_addralign: self.address_size(),
             sh_entsize: self.dyn_size(),
             ..SectionHeader::default()
         }
@@ -588,7 +580,7 @@ impl<E: Endian> Encoder<E> {
             sh_type: elf::SHT_GNU_HASH,
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynsym,
-            sh_addralign: self.address_size().into(),
+            sh_addralign: self.address_size(),
             sh_entsize: if self.is_64 { 0 } else { 4 },
             ..SectionHeader::default()
         }
@@ -660,7 +652,7 @@ impl<E: Endian> Encoder<E> {
         SectionHeader {
             sh_type: if is_rela { elf::SHT_RELA } else { elf::SHT_REL },
             sh_flags: elf::SHF_INFO_LINK,
-            sh_addralign: self.address_size().into(),
+            sh_addralign: self.address_size(),
             sh_entsize: self.rel_size(is_rela),
             ..SectionHeader::default()
         }
@@ -672,7 +664,7 @@ impl<E: Endian> Encoder<E> {
     pub fn relative_relocation_section_header(self) -> SectionHeader {
         SectionHeader {
             sh_type: elf::SHT_RELA,
-            sh_addralign: self.address_size().into(),
+            sh_addralign: self.address_size(),
             sh_entsize: self.relr_size(),
             ..SectionHeader::default()
         }

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -292,7 +292,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.layout.e_phoff) {
             return 0;
         }
-        let offset = self.write_align(self.encoder.address_size().into());
+        let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.layout.e_phoff, offset);
         offset
     }
@@ -316,7 +316,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.layout.e_shoff) {
             return 0;
         }
-        let offset = self.write_align(self.encoder.address_size().into());
+        let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.layout.e_shoff, offset);
         self.encoder.null_section_header(self.buffer, &self.layout);
         self.written_section_num = 1;
@@ -420,7 +420,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.symtab_offset) {
             return 0;
         }
-        let offset = self.write_align(self.encoder.address_size().into());
+        let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.symtab_offset, offset);
         M::set_section_name(&mut self.symtab_str_id, &mut self.shstrtab, b".symtab");
 
@@ -575,7 +575,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.dynsym_offset) {
             return 0;
         }
-        let offset = self.write_align(self.encoder.address_size().into());
+        let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.dynsym_offset, offset);
         M::set_section_name(&mut self.dynsym_str_id, &mut self.shstrtab, b".dynsym");
 
@@ -630,7 +630,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         if !M::need_offset(self.dynamic_offset) {
             return 0;
         }
-        let offset = self.write_align(self.encoder.address_size().into());
+        let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.dynamic_offset, offset);
         M::set_section_name(&mut self.dynamic_str_id, &mut self.shstrtab, b".dynamic");
         offset
@@ -731,7 +731,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     where
         F: Fn(u32) -> u32,
     {
-        let offset = self.write_align(self.encoder.address_size().into());
+        let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.gnu_hash_offset, offset);
         M::set_section_name(&mut self.gnu_hash_str_id, &mut self.shstrtab, b".gnu.hash");
 
@@ -1011,7 +1011,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Returns the file offset after the padding.
     pub fn write_align_relocation(&mut self) -> u64 {
-        self.write_align(self.encoder.address_size().into())
+        self.write_align(self.encoder.address_size())
     }
 
     /// Write a relocation.
@@ -1481,7 +1481,7 @@ impl<'a> Writer<'a, TwoPhase> {
         self.layout.segment_num = num as u32;
         self.layout.e_phoff = self.reserve(
             num as u64 * self.encoder.program_header_size(),
-            self.encoder.address_size().into(),
+            self.encoder.address_size(),
         );
     }
 
@@ -1527,7 +1527,7 @@ impl<'a> Writer<'a, TwoPhase> {
         }
         self.layout.e_shoff = self.reserve(
             self.layout.section_num as u64 * self.encoder.section_header_size(),
-            self.encoder.address_size().into(),
+            self.encoder.address_size(),
         );
     }
 
@@ -1696,7 +1696,7 @@ impl<'a> Writer<'a, TwoPhase> {
         }
         self.symtab_offset = self.reserve(
             self.symtab_num as u64 * self.encoder.sym_size(),
-            self.encoder.address_size().into(),
+            self.encoder.address_size(),
         );
     }
 
@@ -1889,7 +1889,7 @@ impl<'a> Writer<'a, TwoPhase> {
         }
         self.dynsym_offset = self.reserve(
             self.dynsym_num as u64 * self.encoder.sym_size(),
-            self.encoder.address_size().into(),
+            self.encoder.address_size(),
         );
         self.dynsym_offset
     }
@@ -1921,7 +1921,7 @@ impl<'a> Writer<'a, TwoPhase> {
         self.dynamic_num = dynamic_num as u64;
         self.dynamic_offset = self.reserve(
             self.dynamic_num * self.encoder.dyn_size(),
-            self.encoder.address_size().into(),
+            self.encoder.address_size(),
         );
         self.dynamic_offset
     }
@@ -1968,7 +1968,7 @@ impl<'a> Writer<'a, TwoPhase> {
         let size = self
             .encoder
             .gnu_hash_size(bloom_count, bucket_count, symbol_count);
-        self.gnu_hash_offset = self.reserve(size, self.encoder.address_size().into());
+        self.gnu_hash_offset = self.reserve(size, self.encoder.address_size());
         self.gnu_hash_size = size;
         self.gnu_hash_offset
     }
@@ -2101,7 +2101,7 @@ impl<'a> Writer<'a, TwoPhase> {
     pub fn reserve_relocations(&mut self, count: usize, is_rela: bool) -> u64 {
         self.reserve(
             count as u64 * self.encoder.rel_size(is_rela),
-            self.encoder.address_size().into(),
+            self.encoder.address_size(),
         )
     }
 


### PR DESCRIPTION
Change Encoder::address_size to u64 to avoid conversions in callers, and remove unneeded Encoder::address_align.