### PR TITLE
write/elf: overflow checks

### DIFF
--- a/crates/examples/src/elfcopy.rs
+++ b/crates/examples/src/elfcopy.rs
@@ -393,7 +393,7 @@ pub fn elfcopy<Elf: FileHeader<Endian = Endianness>>(
     } else {
         // We don't support moving program headers.
         assert_eq!(in_elf.e_phoff(endian).into(), writer.reserved_len());
-        writer.reserve_program_headers(in_segments.len());
+        writer.reserve_program_headers(in_segments.len() as u32);
 
         // Reserve alloc sections at original offsets.
         alloc_sections = in_sections

--- a/src/build/elf.rs
+++ b/src/build/elf.rs
@@ -773,6 +773,12 @@ impl<'data> Builder<'data> {
         self.delete_unused_versions();
 
         // Find metadata sections, and assign section indices.
+        let section_num = if self.sections.is_empty() {
+            0
+        } else {
+            // Code below depends on this check.
+            u32::try_from(1 + self.sections.count()).map_err(|_| Error::new("Too many sections"))?
+        };
         let mut shstrtab_index = 0;
         let mut symtab_index = 0;
         let mut symtab_shndx_index = 0;
@@ -786,16 +792,8 @@ impl<'data> Builder<'data> {
         let mut gnu_verneed_index = 0;
         let mut out_sections = Vec::with_capacity(self.sections.len());
         let mut out_sections_index = vec![0; self.sections.len()];
-        let mut section_num = 0;
-        if !self.sections.is_empty() {
-            section_num = 1;
-        }
         let mut shstrtab = write::StringTable::new();
-        for section in &self.sections {
-            let index = section_num;
-            out_sections_index[section.id.0] = index;
-            section_num += 1;
-
+        for (section, index) in self.sections.iter().zip(1..) {
             match &section.data {
                 SectionData::Data(_)
                 | SectionData::UninitializedData(_)
@@ -884,6 +882,7 @@ impl<'data> Builder<'data> {
                 size: 0,
                 attributes: Vec::new(),
             });
+            out_sections_index[section.id.0] = index;
         }
 
         // Add dynamic strings to string table.
@@ -899,6 +898,13 @@ impl<'data> Builder<'data> {
         }
 
         // Assign dynamic symbol indices and add symbol names to string table.
+        let dynsym_num = if dynsym_index == 0 && self.dynamic_symbols.is_empty() {
+            0
+        } else {
+            // Code below depends on this check, even if dynsym_index == 0.
+            u32::try_from(1 + self.dynamic_symbols.count())
+                .map_err(|_| Error::new("Too many dynamic symbols"))?
+        };
         let mut out_dynsyms = Vec::with_capacity(self.dynamic_symbols.len());
         // Local symbols must come before global.
         let local_symbols = self
@@ -936,8 +942,9 @@ impl<'data> Builder<'data> {
             .take_while(|sym| self.dynamic_symbols.get(sym.id).st_bind() == elf::STB_LOCAL)
             .count();
         // We must sort for GNU hash before allocating symbol indices.
-        let mut gnu_hash_symbol_count = 0;
-        if gnu_hash_index != 0 {
+        let gnu_hash_symbol_count = if gnu_hash_index == 0 {
+            0
+        } else {
             if self.gnu_hash_bucket_count == 0 {
                 return Err(Error::new(".gnu.hash bucket count is zero"));
             }
@@ -946,31 +953,27 @@ impl<'data> Builder<'data> {
                 None => (0, 0),
                 Some(hash) => (1, hash % self.gnu_hash_bucket_count),
             });
-            gnu_hash_symbol_count = out_dynsyms
+            out_dynsyms
                 .iter()
                 .skip(num_local_dynamic)
                 .skip_while(|sym| sym.gnu_hash.is_none())
-                .count() as u32;
-        }
+                .count() as u32
+        };
+        let num_local_dynamic = num_local_dynamic as u32;
         let mut out_dynsyms_index = vec![0; self.dynamic_symbols.len()];
-        let mut dynsym_num = 0u32;
-        if dynsym_index != 0 {
-            dynsym_num = 1;
-        }
-        for out_dynsym in &mut out_dynsyms {
-            out_dynsyms_index[out_dynsym.id.0] = dynsym_num;
-            dynsym_num += 1;
+        for (out_dynsym, index) in out_dynsyms.iter().zip(1..) {
+            out_dynsyms_index[out_dynsym.id.0] = index;
         }
 
         // Hash parameters.
         let hash_index_base = 1; // Null symbol.
-        let hash_chain_count = hash_index_base + out_dynsyms.len() as u32;
+        let hash_chain_count = dynsym_num;
 
         // GNU hash parameters.
         let gnu_hash_index_base = if gnu_hash_symbol_count == 0 {
             0
         } else {
-            out_dynsyms.len() as u32 - gnu_hash_symbol_count
+            dynsym_num - 1 - gnu_hash_symbol_count
         };
         let gnu_hash_table = write::elf::GnuHashTable {
             bucket_count: self.gnu_hash_bucket_count,
@@ -981,6 +984,12 @@ impl<'data> Builder<'data> {
         };
 
         // Assign symbol indices and add names to string table.
+        let sym_num = if symtab_index == 0 && self.symbols.is_empty() {
+            0
+        } else {
+            // Code below depends on this check, even if symtab_index == 0.
+            u32::try_from(1 + self.symbols.count()).map_err(|_| Error::new("Too many symbols"))?
+        };
         let mut out_syms = Vec::with_capacity(self.symbols.len());
         let mut strtab = write::StringTable::new();
         let mut need_symtab_shndx = symtab_shndx_index != 0;
@@ -1012,18 +1021,18 @@ impl<'data> Builder<'data> {
         let num_local = out_syms
             .iter()
             .take_while(|sym| self.symbols.get(sym.id).st_bind() == elf::STB_LOCAL)
-            .count();
+            .count() as u32;
         let mut out_syms_index = vec![0; self.symbols.len()];
-        let mut sym_num = 0;
-        if symtab_index != 0 {
-            sym_num = 1;
-        }
-        for out_sym in out_syms.iter_mut() {
-            out_syms_index[out_sym.id.0] = sym_num;
-            sym_num += 1;
+        for (out_sym, index) in out_syms.iter().zip(1..) {
+            out_syms_index[out_sym.id.0] = index;
         }
 
         // Count the versions and add version strings.
+        // len() instead of count() because we use version.id directly as the index
+        // (leaving gaps for deleted versions).
+        if VERSION_ID_BASE + self.versions.len() - 1 > usize::from(elf::VERSYM_VERSION) {
+            return Err(Error::new("Too many versions"));
+        }
         let mut verdef_count = 0;
         let mut verdaux_count = 0;
         let mut verdef_shared_base = false;
@@ -1157,8 +1166,9 @@ impl<'data> Builder<'data> {
         let mut verdef_addr = None;
         let mut verneed_addr = None;
 
-        let segment_num = self.segments.count() as u32;
         let mut e_phoff = 0;
+        let segment_num =
+            u32::try_from(self.segments.count()).map_err(|_| Error::new("Too many segments"))?;
         if segment_num != 0 {
             let size = u64::from(segment_num) * encoder.program_header_size();
             e_phoff = offset.reserve(size, address_size).0;
@@ -1255,7 +1265,7 @@ impl<'data> Builder<'data> {
                     }
                     SectionData::GnuVersym => {
                         versym_addr = Some(section.sh_addr);
-                        let size = encoder.gnu_versym_size(dynsym_num as usize);
+                        let size = encoder.gnu_versym_size(dynsym_num);
                         offset.reserve(size, write::elf::ALIGN_GNU_VERSYM)
                     }
                     SectionData::GnuVerdef => {
@@ -1352,6 +1362,17 @@ impl<'data> Builder<'data> {
         } else {
             0
         };
+
+        // Finished layout.
+        let reserved_len = offset.0;
+        // If the total length fits in 32-bit, then none of the u32 file size casts below
+        // need checking.
+        if !self.is_64 && reserved_len > u64::from(u32::MAX) {
+            return Err(Error(format!("File size overflow: {reserved_len:#x}")));
+        }
+        buffer
+            .reserve(reserved_len)
+            .map_err(|_| Error(format!("Cannot allocate buffer length {reserved_len:#x}")))?;
 
         // Start writing.
         let header = write::elf::FileHeader {
@@ -1556,6 +1577,9 @@ impl<'data> Builder<'data> {
                         for version in &self.versions {
                             if let VersionData::Def(def) = &version.data {
                                 count -= 1;
+                                let aux_count = u16::try_from(def.names.len()).map_err(|_| {
+                                    Error::new("Too many auxiliary version definitions")
+                                })?;
                                 let mut names = def.names.iter();
                                 let name = names.next().ok_or_else(|| {
                                     Error(format!("Missing SHT_GNU_VERDEF name {}", version.id.0))
@@ -1563,8 +1587,8 @@ impl<'data> Builder<'data> {
                                 let verdef = write::elf::Verdef {
                                     version: elf::VER_DEF_CURRENT,
                                     flags: def.flags,
-                                    index: elf::VersionIndex(version.id.0 as u16),
-                                    aux_count: def.names.len() as u16,
+                                    index: version.id.index(),
+                                    aux_count,
                                     name: dynstr.get_offset(dynstr.get_id(name)),
                                     hash: elf::hash(name),
                                 };
@@ -1586,9 +1610,13 @@ impl<'data> Builder<'data> {
                         for file in &self.version_files {
                             let out_file = &out_version_files[file.id.0];
                             count -= 1;
+                            let aux_count =
+                                u16::try_from(out_file.versions.len()).map_err(|_| {
+                                    Error::new("Too many auxiliary version dependencies")
+                                })?;
                             let verneed = write::elf::Verneed {
                                 version: elf::VER_NEED_CURRENT,
-                                aux_count: out_file.versions.len() as u16,
+                                aux_count,
                                 file: dynstr.get_offset(dynstr.get_id(&file.name)),
                             };
                             encoder.gnu_verneed(buffer, count != 0, &verneed);
@@ -1601,7 +1629,7 @@ impl<'data> Builder<'data> {
                                     debug_assert_eq!(*id, version.id);
                                     let vernaux = write::elf::Vernaux {
                                         flags: need.flags,
-                                        index: elf::VersionIndex(version.id.0 as u16),
+                                        index: version.id.index(),
                                         name: dynstr.get_offset(dynstr.get_id(&need.name)),
                                         hash: elf::hash(&need.name),
                                     };
@@ -1776,25 +1804,23 @@ impl<'data> Builder<'data> {
                     }
                 }
                 SectionData::SectionString => encoder.strtab_section_header(),
-                SectionData::Symbol => {
-                    encoder.symtab_section_header(strtab_index, 1 + num_local as u32)
-                }
+                SectionData::Symbol => encoder.symtab_section_header(strtab_index, 1 + num_local),
                 SectionData::SymbolSectionIndex => {
                     encoder.symtab_shndx_section_header(symtab_index)
                 }
                 SectionData::String => encoder.strtab_section_header(),
                 SectionData::DynamicString => encoder.dynstr_section_header(),
                 SectionData::DynamicSymbol => {
-                    encoder.dynsym_section_header(dynstr_index, 1 + num_local_dynamic as u32)
+                    encoder.dynsym_section_header(dynstr_index, 1 + num_local_dynamic)
                 }
                 SectionData::Hash => encoder.hash_section_header(dynsym_index),
                 SectionData::GnuHash => encoder.gnu_hash_section_header(dynsym_index),
                 SectionData::GnuVersym => encoder.gnu_versym_section_header(dynsym_index),
                 SectionData::GnuVerdef => {
-                    encoder.gnu_verdef_section_header(dynstr_index, verdef_count as u32)
+                    encoder.gnu_verdef_section_header(dynstr_index, verdef_count)
                 }
                 SectionData::GnuVerneed => {
-                    encoder.gnu_verneed_section_header(dynstr_index, verneed_count as u32)
+                    encoder.gnu_verneed_section_header(dynstr_index, verneed_count)
                 }
             };
             header.sh_name = shstrtab.maybe_get_offset(out_section.name);
@@ -1805,7 +1831,7 @@ impl<'data> Builder<'data> {
             }
             encoder.section_header(buffer, &header);
         }
-        debug_assert_eq!(offset.0, buffer.len());
+        debug_assert_eq!(reserved_len, buffer.len());
         Ok(())
     }
 
@@ -2056,7 +2082,7 @@ impl<'data> Builder<'data> {
     /// [`Self::delete_orphan_symbols`] and [`Self::delete_unused_versions`].
     pub fn gnu_versym_size(&self) -> u64 {
         let symbol_count = 1 + self.dynamic_symbols.count();
-        self.encoder().gnu_versym_size(symbol_count)
+        self.encoder().gnu_versym_size(symbol_count as u32)
     }
 
     /// Calculate the size of the GNU version definition section.
@@ -2094,7 +2120,7 @@ impl<'data> Builder<'data> {
             }
         }
         self.encoder()
-            .gnu_verneed_size(verneed_count, vernaux_count)
+            .gnu_verneed_size(verneed_count as u16, vernaux_count)
     }
 
     /// Calculate the memory size of a section.
@@ -3103,7 +3129,7 @@ pub struct VersionDef<'data> {
 
 impl<'data> VersionDef<'data> {
     /// Optimise for the common case where the first version is the same as the base version.
-    fn is_shared(&self, index: usize, base: Option<&ByteString<'_>>) -> bool {
+    fn is_shared(&self, index: u16, base: Option<&ByteString<'_>>) -> bool {
         index == 1 && self.names.len() == 1 && self.names.first() == base
     }
 }

--- a/src/write/elf/encoder.rs
+++ b/src/write/elf/encoder.rs
@@ -162,6 +162,10 @@ pub struct Vernaux {
 }
 
 /// A helper for encoding headers and data when writing an ELF file.
+///
+/// None of the methods check for overflow when truncating addresses and file offsets for
+/// 32-bit ELF. It is recommended that the caller keep track of the largest address and
+/// file offset, and perform a single overflow check.
 #[derive(Debug, Clone, Copy)]
 pub struct Encoder<E: Endian> {
     endian: E,
@@ -207,6 +211,7 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size in bytes of an address for the ELF class.
+    ///
     /// This should be used as the file offset alignment for various structures
     /// such as program headers, section headers, symbols, dynamics, relocations,
     /// and .gnu.hash.
@@ -226,6 +231,12 @@ impl<E: Endian> Encoder<E> {
     /// Write the file header.
     ///
     /// The buffer should be at the start of the file.
+    ///
+    /// `layout.segment_num`, `layout.section_num`, and `layout.shstrtab_index`
+    /// are replaced with the appropriate sentinel values if overflow occurs.
+    ///
+    /// No overflow check is performed when truncating `e_entry`, `e_phoff`,
+    /// and `e_shoff` for 32-bit ELF.
     pub fn file_header<W: WritableBuffer + ?Sized>(
         self,
         buffer: &mut W,
@@ -334,6 +345,9 @@ impl<E: Endian> Encoder<E> {
     /// Write a program header.
     ///
     /// The buffer should already be aligned to `address_size`.
+    ///
+    /// No overflow check is performed when truncating `p_offset`, `p_vaddr`,
+    /// `p_paddr`, `p_filesz`, `p_memsz` and `p_align` for 32-bit ELF.
     pub fn program_header<W: WritableBuffer + ?Sized>(
         self,
         buffer: &mut W,
@@ -436,6 +450,9 @@ impl<E: Endian> Encoder<E> {
     /// Write a section header.
     ///
     /// The buffer should already be aligned to `address_size`.
+    ///
+    /// No overflow check is performed when truncating `sh_addr`, `sh_offset`,
+    /// `sh_size`, `sh_addralign`, and `sh_entsize` for 32-bit ELF.
     pub fn section_header<W: WritableBuffer + ?Sized>(
         self,
         buffer: &mut W,
@@ -605,12 +622,12 @@ impl<E: Endian> Encoder<E> {
     ///
     /// `sh_link` is set to `dynstr`. `sh_info` is set to `verdef_count`.
     /// The caller must set `sh_name`, `sh_addr`, `sh_offset`, and `sh_size`.
-    pub fn gnu_verdef_section_header(self, dynstr: u32, verdef_count: u32) -> SectionHeader {
+    pub fn gnu_verdef_section_header(self, dynstr: u32, verdef_count: u16) -> SectionHeader {
         SectionHeader {
             sh_type: elf::SHT_GNU_VERDEF,
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynstr,
-            sh_info: verdef_count,
+            sh_info: verdef_count.into(),
             sh_addralign: ALIGN_GNU_VERDEF,
             ..SectionHeader::default()
         }
@@ -620,12 +637,12 @@ impl<E: Endian> Encoder<E> {
     ///
     /// `sh_link` is set to `dynstr`. `sh_info` is set to `verneed_count`.
     /// The caller must set `sh_name`, `sh_addr`, `sh_offset`, and `sh_size`.
-    pub fn gnu_verneed_section_header(self, dynstr: u32, verneed_count: u32) -> SectionHeader {
+    pub fn gnu_verneed_section_header(self, dynstr: u32, verneed_count: u16) -> SectionHeader {
         SectionHeader {
             sh_type: elf::SHT_GNU_VERNEED,
             sh_flags: elf::SHF_ALLOC,
             sh_link: dynstr,
-            sh_info: verneed_count,
+            sh_info: verneed_count.into(),
             sh_addralign: ALIGN_GNU_VERNEED,
             ..SectionHeader::default()
         }
@@ -721,6 +738,9 @@ impl<E: Endian> Encoder<E> {
     /// Returns the extended symbol index if overflow occurred.
     ///
     /// The buffer should already be aligned to `address_size`.
+    ///
+    /// No overflow check is performed when truncating `st_value` and `st_size`
+    /// for 32-bit ELF.
     pub fn symbol<W: WritableBuffer + ?Sized>(self, buffer: &mut W, sym: &Sym) -> Option<u32> {
         let st_shndx = if let Some(section) = sym.section {
             elf::SymbolSection::new(section)
@@ -798,6 +818,9 @@ impl<E: Endian> Encoder<E> {
     /// Write a relocation.
     ///
     /// The buffer should already be aligned to `address_size`.
+    ///
+    /// No overflow check is performed when truncating `r_offset`, `r_sym`, `r_type`,
+    /// and `r_addend` for 32-bit ELF.
     pub fn relocation<W: WritableBuffer + ?Sized>(self, buffer: &mut W, is_rela: bool, rel: &Rel) {
         let endian = self.endian;
         if self.is_64 {
@@ -878,8 +901,8 @@ impl<E: Endian> Encoder<E> {
     /// Return the size of a hash table.
     pub fn hash_size(self, bucket_count: u32, chain_count: u32) -> u64 {
         mem::size_of::<elf::HashHeader<Endianness>>() as u64
-            + bucket_count as u64 * 4
-            + chain_count as u64 * 4
+            + u64::from(bucket_count) * 4
+            + u64::from(chain_count) * 4
     }
 
     /// Write a SysV hash table.
@@ -916,9 +939,9 @@ impl<E: Endian> Encoder<E> {
     pub fn gnu_hash_size(self, bloom_count: u32, bucket_count: u32, symbol_count: u32) -> u64 {
         let bloom_size = if self.is_64 { 8 } else { 4 };
         mem::size_of::<elf::GnuHashHeader<Endianness>>() as u64
-            + bloom_count as u64 * bloom_size
-            + bucket_count as u64 * 4
-            + symbol_count as u64 * 4
+            + u64::from(bloom_count) * bloom_size
+            + u64::from(bucket_count) * 4
+            + u64::from(symbol_count) * 4
     }
 
     /// Write a GNU hash section.
@@ -1004,8 +1027,8 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU symbol version section.
-    pub fn gnu_versym_size(self, symbol_count: usize) -> u64 {
-        symbol_count as u64 * 2
+    pub fn gnu_versym_size(self, symbol_count: u32) -> u64 {
+        u64::from(symbol_count) * 2
     }
 
     /// Write a symbol version entry.
@@ -1014,8 +1037,8 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU version definition section.
-    pub fn gnu_verdef_size(self, verdef_count: usize, verdaux_count: usize) -> u64 {
-        verdef_count as u64 * mem::size_of::<elf::Verdef<Endianness>>() as u64
+    pub fn gnu_verdef_size(self, verdef_count: u16, verdaux_count: usize) -> u64 {
+        u64::from(verdef_count) * mem::size_of::<elf::Verdef<Endianness>>() as u64
             + verdaux_count as u64 * mem::size_of::<elf::Verdaux<Endianness>>() as u64
     }
 
@@ -1028,7 +1051,7 @@ impl<E: Endian> Encoder<E> {
     ) {
         let vd_next = if next {
             mem::size_of::<elf::Verdef<Endianness>>() as u32
-                + verdef.aux_count as u32 * mem::size_of::<elf::Verdaux<Endianness>>() as u32
+                + u32::from(verdef.aux_count) * mem::size_of::<elf::Verdaux<Endianness>>() as u32
         } else {
             0
         };
@@ -1082,8 +1105,8 @@ impl<E: Endian> Encoder<E> {
     }
 
     /// Return the size of a GNU version dependency section.
-    pub fn gnu_verneed_size(self, verneed_count: usize, vernaux_count: usize) -> u64 {
-        verneed_count as u64 * mem::size_of::<elf::Verneed<Endianness>>() as u64
+    pub fn gnu_verneed_size(self, verneed_count: u16, vernaux_count: usize) -> u64 {
+        u64::from(verneed_count) * mem::size_of::<elf::Verneed<Endianness>>() as u64
             + vernaux_count as u64 * mem::size_of::<elf::Vernaux<Endianness>>() as u64
     }
 
@@ -1096,7 +1119,7 @@ impl<E: Endian> Encoder<E> {
     ) {
         let vn_next = if next {
             mem::size_of::<elf::Verneed<Endianness>>() as u32
-                + verneed.aux_count as u32 * mem::size_of::<elf::Vernaux<Endianness>>() as u32
+                + u32::from(verneed.aux_count) * mem::size_of::<elf::Vernaux<Endianness>>() as u32
         } else {
             0
         };
@@ -1147,8 +1170,8 @@ impl<E: Endian> Encoder<E> {
 pub struct AttributesWriter {
     endian: Endianness,
     data: Vec<u8>,
-    subsection_offset: usize,
-    subsubsection_offset: usize,
+    subsection_offset: u32,
+    subsubsection_offset: u32,
 }
 
 impl AttributesWriter {
@@ -1162,11 +1185,15 @@ impl AttributesWriter {
         }
     }
 
+    fn offset(&self) -> u32 {
+        self.data.len() as u32
+    }
+
     /// Start a new subsection with the given vendor name.
     pub fn start_subsection(&mut self, vendor: &[u8]) {
         debug_assert_eq!(self.subsection_offset, 0);
         debug_assert_eq!(self.subsubsection_offset, 0);
-        self.subsection_offset = self.data.len();
+        self.subsection_offset = self.offset();
         self.data.extend_from_slice(&[0; 4]);
         self.data.extend_from_slice(vendor);
         self.data.push(0);
@@ -1178,9 +1205,9 @@ impl AttributesWriter {
     pub fn end_subsection(&mut self) {
         debug_assert_ne!(self.subsection_offset, 0);
         debug_assert_eq!(self.subsubsection_offset, 0);
-        let length = self.data.len() - self.subsection_offset;
-        self.data[self.subsection_offset..][..4]
-            .copy_from_slice(pod::bytes_of(&U32::new(self.endian, length as u32)));
+        let length = self.offset() - self.subsection_offset;
+        self.data[self.subsection_offset as usize..][..4]
+            .copy_from_slice(pod::bytes_of(&U32::new(self.endian, length)));
         self.subsection_offset = 0;
     }
 
@@ -1188,7 +1215,7 @@ impl AttributesWriter {
     pub fn start_subsubsection(&mut self, tag: elf::AttributeTag) {
         debug_assert_ne!(self.subsection_offset, 0);
         debug_assert_eq!(self.subsubsection_offset, 0);
-        self.subsubsection_offset = self.data.len();
+        self.subsubsection_offset = self.offset();
         self.data.push(tag.0);
         self.data.extend_from_slice(&[0; 4]);
     }
@@ -1249,9 +1276,9 @@ impl AttributesWriter {
     pub fn end_subsubsection(&mut self) {
         debug_assert_ne!(self.subsection_offset, 0);
         debug_assert_ne!(self.subsubsection_offset, 0);
-        let length = self.data.len() - self.subsubsection_offset;
-        self.data[self.subsubsection_offset + 1..][..4]
-            .copy_from_slice(pod::bytes_of(&U32::new(self.endian, length as u32)));
+        let length = self.offset() - self.subsubsection_offset;
+        self.data[self.subsubsection_offset as usize + 1..][..4]
+            .copy_from_slice(pod::bytes_of(&U32::new(self.endian, length)));
         self.subsubsection_offset = 0;
     }
 
@@ -1259,6 +1286,7 @@ impl AttributesWriter {
     pub fn data(self) -> Vec<u8> {
         debug_assert_eq!(self.subsection_offset, 0);
         debug_assert_eq!(self.subsubsection_offset, 0);
+        debug_assert!((self.data.len() as u64) < (u32::MAX as u64));
         self.data
     }
 }

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -37,25 +37,28 @@ impl<'a> Object<'a> {
             return;
         }
 
-        let align = if self.elf_is_64() { 8 } else { 4 };
+        let address_size = if self.elf_is_64() { 8 } else { 4 };
         let mut data = Vec::with_capacity(32);
         let n_name = b"GNU\0";
         data.extend_from_slice(pod::bytes_of(&elf::NoteHeader32 {
             n_namesz: U32::new(self.endian, n_name.len() as u32),
-            n_descsz: U32::new(self.endian, util::align_u32(3 * 4, align as u32)),
+            n_descsz: U32::new(self.endian, align_u32(3 * 4, address_size)),
             n_type: U32::new(self.endian, elf::NT_GNU_PROPERTY_TYPE_0),
         }));
         data.extend_from_slice(n_name);
         // This happens to already be aligned correctly.
-        debug_assert_eq!(util::align(data.len() as u64, align), data.len() as u64);
+        debug_assert_eq!(
+            align(data.len() as u64, address_size.into()),
+            data.len() as u64
+        );
         data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, property)));
         // Value size
         data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, 4u32)));
         data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, value)));
-        util::write_align(&mut data, align);
+        write_align(&mut data, address_size.into());
 
         let section = self.section_id(StandardSection::GnuProperty);
-        self.append_section_data(section, &data, align);
+        self.append_section_data(section, &data, address_size.into());
     }
 }
 

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -31,7 +31,11 @@ mod private {
     #[allow(private_interfaces)]
     pub trait ModeSealed {
         fn string_table() -> StringTable<'static>;
-        fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()>;
+        fn reserve(
+            &self,
+            buffer: &mut dyn WritableBuffer,
+            encoder: Encoder<Endianness>,
+        ) -> Result<()>;
         fn need_offset(offset: u64) -> bool;
         fn set_offset(dest: &mut u64, offset: u64);
         fn set_size(dest: &mut u64, size: u64);
@@ -277,7 +281,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     pub fn write_file_header(&mut self, header: &FileHeader) -> Result<()> {
         debug_assert_eq!(self.buffer.len(), 0);
 
-        self.mode.reserve(self.buffer)?;
+        self.mode.reserve(self.buffer, self.encoder)?;
         self.header = header.clone();
         self.encoder.set_machine(header.e_machine);
         self.encoder
@@ -811,7 +815,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_name: self.section_name_offset(self.gnu_versym_str_id),
             sh_addr,
             sh_offset: self.gnu_versym_offset,
-            sh_size: self.encoder.gnu_versym_size(self.gnu_versym_num as usize),
+            sh_size: self.encoder.gnu_versym_size(self.gnu_versym_num),
             ..self.encoder.gnu_versym_section_header(self.dynsym_index.0)
         });
     }
@@ -843,7 +847,7 @@ impl<'a, M: Mode> Writer<'a, M> {
 
         debug_assert_ne!(verdef.aux_count, 0);
         self.gnu_verdaux_remaining = verdef.aux_count;
-        self.written_verdaux_count += verdef.aux_count as usize;
+        self.written_verdaux_count += usize::from(verdef.aux_count);
         M::set_count(&mut self.gnu_verdaux_count, self.written_verdaux_count);
 
         self.encoder
@@ -890,7 +894,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         }
         let sh_size = self
             .encoder
-            .gnu_verdef_size(self.gnu_verdef_count as usize, self.gnu_verdaux_count);
+            .gnu_verdef_size(self.gnu_verdef_count, self.gnu_verdaux_count);
         self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(self.gnu_verdef_str_id),
             sh_addr,
@@ -898,7 +902,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_size,
             ..self
                 .encoder
-                .gnu_verdef_section_header(self.dynstr_index.0, self.gnu_verdef_count.into())
+                .gnu_verdef_section_header(self.dynstr_index.0, self.gnu_verdef_count)
         });
     }
 
@@ -929,7 +933,7 @@ impl<'a, M: Mode> Writer<'a, M> {
 
         if verneed.aux_count != 0 {
             self.gnu_vernaux_remaining = verneed.aux_count;
-            self.written_vernaux_count += verneed.aux_count as usize;
+            self.written_vernaux_count += usize::from(verneed.aux_count);
             M::set_count(&mut self.gnu_vernaux_count, self.written_vernaux_count);
         };
 
@@ -957,7 +961,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         }
         let sh_size = self
             .encoder
-            .gnu_verneed_size(self.gnu_verneed_count as usize, self.gnu_vernaux_count);
+            .gnu_verneed_size(self.gnu_verneed_count, self.gnu_vernaux_count);
         self.write_section_header(&SectionHeader {
             sh_name: self.section_name_offset(self.gnu_verneed_str_id),
             sh_addr,
@@ -965,7 +969,7 @@ impl<'a, M: Mode> Writer<'a, M> {
             sh_size,
             ..self
                 .encoder
-                .gnu_verneed_section_header(self.dynstr_index.0, self.gnu_verneed_count.into())
+                .gnu_verneed_section_header(self.dynstr_index.0, self.gnu_verneed_count)
         });
     }
 
@@ -1146,7 +1150,11 @@ impl ModeSealed for SinglePhase {
         StringTable::new_in_order(1)
     }
 
-    fn reserve(&self, _buffer: &mut dyn WritableBuffer) -> Result<()> {
+    fn reserve(
+        &self,
+        _buffer: &mut dyn WritableBuffer,
+        _encoder: Encoder<Endianness>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -1201,6 +1209,10 @@ impl<'a> Writer<'a, SinglePhase> {
     /// header. You must manually copy the resulting `buffer` contents to the start of the
     /// original buffer after dropping the `Writer`.
     pub fn write_file_header_to(&mut self, buffer: &mut dyn WritableBuffer) -> Result<()> {
+        let len = self.offset();
+        if !self.encoder.is_64() && len > u64::from(u32::MAX) {
+            return Err(Error(format!("File size overflow: {len:#x}")));
+        }
         if self.layout.section_num >= elf::SHN_LORESERVE.into() {
             // The null section header was written before section_num was known,
             // so it won't contain the overflow value.
@@ -1250,9 +1262,8 @@ impl<'a> Writer<'a, SinglePhase> {
         buffer: &mut dyn WritableBuffer,
         program_headers: &[ProgramHeader],
     ) -> Result<()> {
-        debug_assert_eq!(program_headers.len() as u32, self.layout.segment_num);
-        self.encoder
-            .file_header(buffer, &self.header, &self.layout)?;
+        debug_assert_eq!(program_headers.len(), self.layout.segment_num as usize);
+        self.write_file_header_to(buffer)?;
         for header in program_headers {
             self.encoder.program_header(buffer, header);
         }
@@ -1387,9 +1398,13 @@ impl ModeSealed for TwoPhase {
         StringTable::new()
     }
 
-    fn reserve(&self, buffer: &mut dyn WritableBuffer) -> Result<()> {
+    fn reserve(&self, buffer: &mut dyn WritableBuffer, encoder: Encoder<Endianness>) -> Result<()> {
+        let len = self.len;
+        if !encoder.is_64() && len > u64::from(u32::MAX) {
+            return Err(Error(format!("File size overflow: {len:#x}")));
+        }
         buffer
-            .reserve(self.len)
+            .reserve(len)
             .map_err(|_| Error(String::from("Cannot allocate buffer")))
     }
 
@@ -1473,12 +1488,12 @@ impl<'a> Writer<'a, TwoPhase> {
     /// the section table; this is checked in `write_file_header`.
     ///
     /// Does nothing if `num` is zero.
-    pub fn reserve_program_headers(&mut self, num: usize) {
+    pub fn reserve_program_headers(&mut self, num: u32) {
         debug_assert_eq!(self.layout.e_phoff, 0);
         if num == 0 {
             return;
         }
-        self.layout.segment_num = num as u32;
+        self.layout.segment_num = num;
         self.layout.e_phoff = self.reserve(
             num as u64 * self.encoder.program_header_size(),
             self.encoder.address_size(),
@@ -1992,7 +2007,7 @@ impl<'a> Writer<'a, TwoPhase> {
             return 0;
         }
         self.gnu_versym_num = self.dynsym_num;
-        let size = self.encoder.gnu_versym_size(self.gnu_versym_num as usize);
+        let size = self.encoder.gnu_versym_size(self.gnu_versym_num);
         self.gnu_versym_offset = self.reserve(size, ALIGN_GNU_VERSYM);
         self.gnu_versym_offset
     }
@@ -2010,14 +2025,14 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// Returns the file offset of the reserved range.
     /// Returns 0 if `verdef_count` is zero.
-    pub fn reserve_gnu_verdef(&mut self, verdef_count: usize, verdaux_count: usize) -> u64 {
+    pub fn reserve_gnu_verdef(&mut self, verdef_count: u16, verdaux_count: usize) -> u64 {
         debug_assert_eq!(self.gnu_verdef_offset, 0);
         if verdef_count == 0 {
             return 0;
         }
         let size = self.encoder.gnu_verdef_size(verdef_count, verdaux_count);
         self.gnu_verdef_offset = self.reserve(size, ALIGN_GNU_VERDEF);
-        self.gnu_verdef_count = verdef_count as u16;
+        self.gnu_verdef_count = verdef_count;
         self.gnu_verdaux_count = verdaux_count;
         self.gnu_verdef_remaining = self.gnu_verdef_count;
         self.gnu_verdef_offset
@@ -2043,14 +2058,14 @@ impl<'a> Writer<'a, TwoPhase> {
     ///
     /// Returns the file offset of the reserved range.
     /// Returns 0 if `verneed_count` is zero.
-    pub fn reserve_gnu_verneed(&mut self, verneed_count: usize, vernaux_count: usize) -> u64 {
+    pub fn reserve_gnu_verneed(&mut self, verneed_count: u16, vernaux_count: usize) -> u64 {
         debug_assert_eq!(self.gnu_verneed_offset, 0);
         if verneed_count == 0 {
             return 0;
         }
         let size = self.encoder.gnu_verneed_size(verneed_count, vernaux_count);
         self.gnu_verneed_offset = self.reserve(size, ALIGN_GNU_VERNEED);
-        self.gnu_verneed_count = verneed_count as u16;
+        self.gnu_verneed_count = verneed_count;
         self.gnu_vernaux_count = vernaux_count;
         self.gnu_verneed_remaining = self.gnu_verneed_count;
         self.gnu_verneed_offset

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -48,7 +48,7 @@ fn phnum_overflow() {
 
         let object = read::elf::ElfFile64::<Endianness>::parse(&*bytes).unwrap();
         assert_eq!(object.architecture(), Architecture::X86_64);
-        assert_eq!(object.elf_program_headers().len(), count);
+        assert_eq!(object.elf_program_headers().len(), count as usize);
     }
 
     // Error if missing section headers.


### PR DESCRIPTION
The general strategy is to check the maximum for a value instead of checking every conversion.

Where possible, change functions to use narrower types when we require the caller to have already validated. The exception is for values that have different widths for 32-bit and 64-bit ELF.

The status is:

- Encoder types are narrowed where possible, and documented for others
- Writer checks file size, and has narrowed types for caller provided counts, but doesn't check accumulators for its own counts
- Builder checks file size and all table counts

Part of #849 