### PR TITLE
write/object: small cleanups

### DIFF
--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -1,10 +1,11 @@
 use alloc::vec::Vec;
 
+use crate::elf;
+use crate::endian::U32;
 use crate::write::elf::encoder::*;
 use crate::write::elf::writer::*;
 use crate::write::string::StringId;
 use crate::write::*;
-use crate::{elf, pod};
 
 #[derive(Clone, Copy)]
 struct ComdatOffsets {
@@ -40,21 +41,22 @@ impl<'a> Object<'a> {
         let address_size = if self.elf_is_64() { 8 } else { 4 };
         let mut data = Vec::with_capacity(32);
         let n_name = b"GNU\0";
-        data.extend_from_slice(pod::bytes_of(&elf::NoteHeader32 {
+        let header = &elf::NoteHeader32 {
             n_namesz: U32::new(self.endian, n_name.len() as u32),
             n_descsz: U32::new(self.endian, align_u32(3 * 4, address_size)),
             n_type: U32::new(self.endian, elf::NT_GNU_PROPERTY_TYPE_0),
-        }));
+        };
+        write_pod(&mut data, header);
         data.extend_from_slice(n_name);
         // This happens to already be aligned correctly.
         debug_assert_eq!(
             align(data.len() as u64, address_size.into()),
             data.len() as u64
         );
-        data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, property)));
+        write_pod(&mut data, &U32::new(self.endian, property));
         // Value size
-        data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, 4u32)));
-        data.extend_from_slice(pod::bytes_of(&U32::new(self.endian, value)));
+        write_pod(&mut data, &U32::new(self.endian, 4u32));
+        write_pod(&mut data, &U32::new(self.endian, value));
         write_align(&mut data, address_size.into());
 
         let section = self.section_id(StandardSection::GnuProperty);

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -19,7 +19,7 @@ use hashbrown::HashMap;
 #[cfg(feature = "std")]
 use std::{boxed::Box, collections::HashMap, error, io};
 
-use crate::endian::{Endianness, U32, U64};
+use crate::endian::{Endian, Endianness};
 
 pub use crate::common::*;
 
@@ -777,10 +777,16 @@ impl<'a> Object<'a> {
             _ => unimplemented!(),
         };
         let data = self.sections[section.0].data_mut();
-        let offset = relocation.offset as usize;
+        let mut write_bytes = |src: &[u8]| -> Option<()> {
+            let offset = usize::try_from(relocation.offset).ok()?;
+            data.get_mut(offset..)?
+                .get_mut(..src.len())?
+                .copy_from_slice(src);
+            Some(())
+        };
         match size {
-            32 => data.write_at(offset, &U32::new(self.endian, relocation.addend as u32)),
-            64 => data.write_at(offset, &U64::new(self.endian, relocation.addend as u64)),
+            32 => write_bytes(&self.endian.write_u32(relocation.addend as u32)),
+            64 => write_bytes(&self.endian.write_u64(relocation.addend as u64)),
             _ => {
                 return Err(Error(format!(
                     "unimplemented relocation addend {:?}",
@@ -788,7 +794,7 @@ impl<'a> Object<'a> {
                 )));
             }
         }
-        .map_err(|_| {
+        .ok_or_else(|| {
             Error(format!(
                 "invalid relocation offset {}+{} (max {})",
                 relocation.offset,

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -199,24 +199,6 @@ impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {
     }
 }
 
-/// A trait for mutable byte slices.
-///
-/// It provides convenience methods for `Pod` types.
-pub(crate) trait BytesMut {
-    fn write_at<T: Pod>(self, offset: usize, val: &T) -> Result<(), ()>;
-}
-
-impl<'a> BytesMut for &'a mut [u8] {
-    #[inline]
-    fn write_at<T: Pod>(self, offset: usize, val: &T) -> Result<(), ()> {
-        let src = bytes_of(val);
-        let dest = self.get_mut(offset..).ok_or(())?;
-        let dest = dest.get_mut(..src.len()).ok_or(())?;
-        dest.copy_from_slice(src);
-        Ok(())
-    }
-}
-
 /// Write an unsigned number using the LEB128 encoding to a buffer.
 ///
 /// Returns the number of bytes written.
@@ -291,30 +273,4 @@ pub(crate) fn write_pod<T: Pod, W: WritableBuffer + ?Sized>(buffer: &mut W, val:
 #[allow(dead_code)]
 pub(crate) fn write_pod_slice<T: Pod, W: WritableBuffer + ?Sized>(buffer: &mut W, val: &[T]) {
     buffer.write_bytes(bytes_of_slice(val))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bytes_mut() {
-        let data = vec![0x01, 0x23, 0x45, 0x67];
-
-        let mut bytes = data.clone();
-        bytes.extend_from_slice(bytes_of(&u16::to_be(0x89ab)));
-        assert_eq!(bytes, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab]);
-
-        let mut bytes = data.clone();
-        assert_eq!(bytes.write_at(0, &u16::to_be(0x89ab)), Ok(()));
-        assert_eq!(bytes, [0x89, 0xab, 0x45, 0x67]);
-
-        let mut bytes = data.clone();
-        assert_eq!(bytes.write_at(2, &u16::to_be(0x89ab)), Ok(()));
-        assert_eq!(bytes, [0x01, 0x23, 0x89, 0xab]);
-
-        assert_eq!(bytes.write_at(3, &u16::to_be(0x89ab)), Err(()));
-        assert_eq!(bytes.write_at(4, &u16::to_be(0x89ab)), Err(()));
-        assert_eq!([].write_at(0, &u32::to_be(0x89ab)), Err(()));
-    }
 }


### PR DESCRIPTION
Remove use of BytesMut in Object::write_relocation_addend since it was the only user.

Also use write_pod in Object::add_elf_gnu_property_u32 since it was already using write_align.