### PR TITLE
read/macho: handle section file offsets larger than 32-bit

### DIFF
--- a/src/build/macho.rs
+++ b/src/build/macho.rs
@@ -310,9 +310,11 @@ impl<'data> Builder<'data> {
         R: ReadRef<'data>,
     {
         let id = self.sections.next_id();
+        // TODO: reuse MachOFile::parse_sections
+        let offset = section.offset(endian).into();
         let size = section.size(endian).into();
-        let section_data = if section.file_range(endian).is_some() {
-            SectionData::Data(section.data(endian, data)?.into())
+        let section_data = if section.file_range(endian, offset).is_some() {
+            SectionData::Data(section.data(endian, data, offset)?.into())
         } else {
             SectionData::UninitializedData(size as u32)
         };

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -75,10 +75,7 @@ where
             while let Ok(Some(command)) = commands.next() {
                 if let Some((segment, section_data)) = Mach::Segment::from_command(command)? {
                     segments.push(MachOSegmentInternal { segment, data });
-                    for section in segment.sections(endian, section_data)? {
-                        let index = SectionIndex(sections.len() + 1);
-                        sections.push(MachOSectionInternal::parse(index, section, data));
-                    }
+                    Self::parse_sections(endian, data, segment, section_data, &mut sections)?;
                 } else if let Some(symtab) = command.symtab()? {
                     symbols = symtab.symbols(endian, data)?;
                 }
@@ -128,11 +125,7 @@ where
                         linkedit_data = Some(data);
                     }
                     segments.push(MachOSegmentInternal { segment, data });
-
-                    for section in segment.sections(endian, section_data)? {
-                        let index = SectionIndex(sections.len() + 1);
-                        sections.push(MachOSectionInternal::parse(index, section, data));
-                    }
+                    Self::parse_sections(endian, data, segment, section_data, &mut sections)?;
                 } else if let Some(st) = command.symtab()? {
                     symtab = Some(st);
                 }
@@ -155,6 +148,45 @@ where
             sections,
             symbols,
         })
+    }
+
+    fn parse_sections(
+        endian: Mach::Endian,
+        data: R,
+        segment: &Mach::Segment,
+        section_data: &'data [u8],
+        sections: &mut Vec<MachOSectionInternal<'data, Mach, R>>,
+    ) -> Result<()> {
+        let segment_fileoff: u64 = segment.fileoff(endian).into();
+        let segment_end = segment_fileoff.wrapping_add(segment.filesize(endian).into());
+        let overflow_possible = segment_end > u32::MAX as u64;
+        let mut prev_offset = segment_fileoff;
+
+        for section in segment.sections(endian, section_data)? {
+            let mut offset = u64::from(section.offset(endian));
+
+            // Section headers only have 32-bit file offsets, which can overflow in files
+            // larger than 4GB. When that is possible, reconstruct the full offset by
+            // assuming sections are ordered by file offset.
+            // This is a refinement of the algorithm used by LLVM.
+            if overflow_possible {
+                if let Some((_, size)) = section.file_range(endian, offset) {
+                    offset |= prev_offset & 0xffff_ffff_0000_0000;
+                    if offset < prev_offset {
+                        offset = offset.wrapping_add(0x1_0000_0000);
+                    }
+                    let section_end = offset.wrapping_add(size);
+                    if section_end > segment_end {
+                        return Err(Error("Unsupported Mach-O large section offsets"));
+                    }
+                    prev_offset = section_end;
+                }
+            }
+
+            let index = SectionIndex(sections.len() + 1);
+            sections.push(MachOSectionInternal::parse(index, section, data, offset));
+        }
+        Ok(())
     }
 
     /// Return the section at the given index.

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -99,7 +99,7 @@ where
     fn bytes(&self) -> Result<&'data [u8]> {
         self.internal
             .section
-            .data(self.file.endian, self.internal.data)
+            .data(self.file.endian, self.internal.data, self.internal.offset)
             .read_error("Invalid Mach-O section size or offset")
     }
 
@@ -153,7 +153,9 @@ where
 
     #[inline]
     fn file_range(&self) -> Option<(u64, u64)> {
-        self.internal.section.file_range(self.file.endian)
+        self.internal
+            .section
+            .file_range(self.file.endian, self.internal.offset)
     }
 
     #[inline]
@@ -240,10 +242,19 @@ pub(super) struct MachOSectionInternal<'data, Mach: MachHeader, R: ReadRef<'data
     /// This is required for dyld caches, where this may be a different subcache
     /// from the file containing the Mach-O load commands.
     pub data: R,
+    /// The file offset of the section.
+    ///
+    /// Used instead of `section.offset()` to handle file offsets greater than 32-bit.
+    pub offset: u64,
 }
 
 impl<'data, Mach: MachHeader, R: ReadRef<'data>> MachOSectionInternal<'data, Mach, R> {
-    pub(super) fn parse(index: SectionIndex, section: &'data Mach::Section, data: R) -> Self {
+    pub(super) fn parse(
+        index: SectionIndex,
+        section: &'data Mach::Section,
+        data: R,
+        offset: u64,
+    ) -> Self {
         // TODO: we don't validate flags, should we?
         let kind = match (section.segment_name(), section.name()) {
             (b"__TEXT", b"__text") => SectionKind::Text,
@@ -269,6 +280,7 @@ impl<'data, Mach: MachHeader, R: ReadRef<'data>> MachOSectionInternal<'data, Mac
             kind,
             section,
             data,
+            offset,
         }
     }
 }
@@ -283,6 +295,9 @@ pub trait Section: Debug + Pod {
     fn segname(&self) -> &[u8; 16];
     fn addr(&self, endian: Self::Endian) -> Self::Word;
     fn size(&self, endian: Self::Endian) -> Self::Word;
+    /// The file offset of the section.
+    ///
+    /// Note that for offsets larger than 32-bit this will be truncated.
     fn offset(&self, endian: Self::Endian) -> u32;
     fn align(&self, endian: Self::Endian) -> u32;
     fn reloff(&self, endian: Self::Endian) -> u32;
@@ -316,20 +331,33 @@ pub trait Section: Debug + Pod {
 
     /// Return the offset and size of the section in the file.
     ///
+    /// `offset` must be the section file offset. Note that for file offsets larger than
+    /// `u32::MAX`, [`Self::offset`] will be truncated, so you will need to determine the
+    /// offset in another way. `(section.addr - segment.vmaddr) + segment.fileoff` is
+    /// equivalent for well-formed files. Alternatively, you could track the file offset
+    /// of consecutive sections to determine when overflow occurs.
+    ///
     /// Returns `None` for sections that have no data in the file.
-    fn file_range(&self, endian: Self::Endian) -> Option<(u64, u64)> {
+    fn file_range(&self, endian: Self::Endian, offset: u64) -> Option<(u64, u64)> {
         match self.section_type(endian) {
             macho::S_ZEROFILL | macho::S_GB_ZEROFILL | macho::S_THREAD_LOCAL_ZEROFILL => None,
-            _ => Some((self.offset(endian).into(), self.size(endian).into())),
+            _ => Some((offset, self.size(endian).into())),
         }
     }
 
     /// Return the section data.
     ///
+    /// `offset` must be the section file offset. See [`Self::file_range`].
+    ///
     /// Returns `Ok(&[])` if the section has no data.
     /// Returns `Err` for invalid values.
-    fn data<'data, R: ReadRef<'data>>(&self, endian: Self::Endian, data: R) -> Result<&'data [u8]> {
-        if let Some((offset, size)) = self.file_range(endian) {
+    fn data<'data, R: ReadRef<'data>>(
+        &self,
+        endian: Self::Endian,
+        data: R,
+        offset: u64,
+    ) -> Result<&'data [u8]> {
+        if let Some((offset, size)) = self.file_range(endian, offset) {
             data.read_bytes_at(offset, size)
                 .read_error("Invalid Mach-O section size or offset")
         } else {


### PR DESCRIPTION
See https://github.com/gimli-rs/gimli/issues/890

Breaking change: add `offset_bias` parameter to `read::macho::Section` methods