### PR TITLE
Add support for Mach-O ARM64_RELOC_POINTER_TO_GOT

### DIFF
--- a/crates/examples/testfiles/macho/reloc-aarch64.o.objdump
+++ b/crates/examples/testfiles/macho/reloc-aarch64.o.objdump
@@ -28,7 +28,7 @@ __text relocations
 (0, Relocation { kind: PltRelative, encoding: AArch64Call, size: 1a, target: Symbol(SymbolIndex(3)), addend: 0, implicit_addend: true, flags: MachO { r_type: 2, r_pcrel: true, r_length: 2 } })
 
 __data relocations
-(1c, Relocation { kind: Unknown, encoding: Unknown, size: 20, target: Symbol(SymbolIndex(3)), addend: 0, implicit_addend: true, flags: MachO { r_type: 7, r_pcrel: true, r_length: 2 } })
+(1c, Relocation { kind: GotRelative, encoding: Generic, size: 20, target: Symbol(SymbolIndex(3)), addend: 0, implicit_addend: true, flags: MachO { r_type: 7, r_pcrel: true, r_length: 2 } })
 (14, Relocation { kind: Unknown, encoding: Unknown, size: 40, target: Symbol(SymbolIndex(3)), addend: 0, implicit_addend: true, flags: MachO { r_type: 7, r_pcrel: false, r_length: 3 } })
 (10, Relocation { kind: Absolute, encoding: Generic, size: 20, target: Symbol(SymbolIndex(3)), subtractor: SymbolIndex(4), addend: 0, implicit_addend: true, flags: MachO { r_type: 0, r_pcrel: false, r_length: 2 } })
 (8, Relocation { kind: Absolute, encoding: Generic, size: 40, target: Symbol(SymbolIndex(3)), subtractor: SymbolIndex(4), addend: 0, implicit_addend: true, flags: MachO { r_type: 0, r_pcrel: false, r_length: 3 } })

--- a/src/read/macho/relocation.rs
+++ b/src/read/macho/relocation.rs
@@ -69,6 +69,7 @@ where
                             size = 26;
                             (K::PltRelative, E::AArch64Call)
                         }
+                        (macho::ARM64_RELOC_POINTER_TO_GOT, true) => (K::GotRelative, g),
                         (macho::ARM64_RELOC_ADDEND, _) => {
                             paired_addend = i64::from(reloc.r_symbolnum)
                                 .wrapping_shl(64 - 24)

--- a/src/write/macho/object.rs
+++ b/src/write/macho/object.rs
@@ -357,6 +357,7 @@ impl<'a> Object<'a> {
                 (K::PltRelative, E::Generic | E::AArch64Call) => {
                     (true, macho::ARM64_RELOC_BRANCH26)
                 }
+                (K::GotRelative, E::Generic) => (true, macho::ARM64_RELOC_POINTER_TO_GOT),
                 _ => return unsupported_reloc(),
             },
             Architecture::PowerPc | Architecture::PowerPc64 => match kind {

--- a/tests/round_trip/reloc.rs
+++ b/tests/round_trip/reloc.rs
@@ -317,6 +317,7 @@ fn reloc_round_trip() {
             vec![
                 elf_r(A::X86_64, elf::R_X86_64_GOTPCREL),
                 macho_r(A::X86_64, macho::X86_64_RELOC_GOT, true, 2),
+                macho_r(A::Aarch64, macho::ARM64_RELOC_POINTER_TO_GOT, true, 2),
             ],
             vec![],
         ),


### PR DESCRIPTION
In addition to the automated test, I manually ran the `objdump` example against proper `objdump` which showed equivalent output for a variety of files. 