### PR TITLE
Add write::CountingBuffer

### DIFF
--- a/src/build/elf.rs
+++ b/src/build/elf.rs
@@ -12,7 +12,7 @@ use crate::build::{ByteString, Bytes, Error, Id, IdPrivate, Item, Result, Table}
 use crate::elf;
 use crate::read::elf::{FileHeader, ProgramHeader, Rela, SectionHeader, Sym};
 use crate::read::{self, FileKind, ReadRef};
-use crate::write;
+use crate::write::{self, WritableBuffer};
 
 /// A builder for reading, modifying, and then writing ELF files.
 ///
@@ -1373,6 +1373,7 @@ impl<'data> Builder<'data> {
         buffer
             .reserve(reserved_len)
             .map_err(|_| Error(format!("Cannot allocate buffer length {reserved_len:#x}")))?;
+        let buffer = &mut write::CountingBuffer::new(buffer);
 
         // Start writing.
         let header = write::elf::FileHeader {
@@ -1831,7 +1832,7 @@ impl<'data> Builder<'data> {
             }
             encoder.section_header(buffer, &header);
         }
-        debug_assert_eq!(reserved_len, buffer.len());
+        debug_assert_eq!(reserved_len, buffer.count());
         Ok(())
     }
 

--- a/src/build/macho.rs
+++ b/src/build/macho.rs
@@ -8,7 +8,7 @@ use crate::endian::{Endianness, U32};
 use crate::macho;
 use crate::read::macho::{MachHeader, Nlist};
 use crate::read::{self, FileKind, ReadRef};
-use crate::write;
+use crate::write::{self, WritableBuffer};
 
 /// A builder for reading, modifying, and then writing Mach-O files.
 ///
@@ -822,6 +822,7 @@ impl<'data> Builder<'data> {
         buffer
             .reserve(reserved_len)
             .map_err(|_| Error(format!("Cannot allocate buffer length {reserved_len:#x}")))?;
+        let buffer = &mut write::CountingBuffer::new(buffer);
 
         // Start writing.
         encoder.mach_header(
@@ -1091,7 +1092,7 @@ impl<'data> Builder<'data> {
             }
         }
 
-        debug_assert_eq!(stroff, buffer.len());
+        debug_assert_eq!(stroff, buffer.count());
         buffer.write_bytes(&strtab_data);
 
         // Write code signature.
@@ -1104,7 +1105,7 @@ impl<'data> Builder<'data> {
             }
         }
 
-        debug_assert_eq!(reserved_len, buffer.len());
+        debug_assert_eq!(reserved_len, buffer.count());
         Ok(())
     }
 

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -685,7 +685,6 @@ impl<'a> Object<'a> {
             writer.write_section(&section.data);
 
             if !section.relocations.is_empty() {
-                //debug_assert_eq!(section_offsets[index].reloc_offset, buffer.len());
                 writer.write_relocations_count(section.relocations.len());
                 for reloc in &section.relocations {
                     let typ = if let RelocationFlags::Coff { typ } = reloc.flags {

--- a/src/write/coff/writer.rs
+++ b/src/write/coff/writer.rs
@@ -6,7 +6,7 @@ use core::mem;
 use crate::pe;
 use crate::write::string::{StringId, StringTable};
 use crate::write::util;
-use crate::write::{Error, Result, WritableBuffer};
+use crate::write::{CountingBuffer, Error, Result, WritableBuffer, WritableBufferExt};
 
 /// A helper for writing COFF files.
 ///
@@ -26,7 +26,7 @@ use crate::write::{Error, Result, WritableBuffer};
 /// with checking this.
 #[allow(missing_debug_implementations)]
 pub struct Writer<'a> {
-    buffer: &'a mut dyn WritableBuffer,
+    buffer: CountingBuffer<&'a mut dyn WritableBuffer>,
     len: u64,
 
     section_num: u16,
@@ -44,7 +44,7 @@ impl<'a> Writer<'a> {
     /// Create a new `Writer`.
     pub fn new(buffer: &'a mut dyn WritableBuffer) -> Self {
         Writer {
-            buffer,
+            buffer: CountingBuffer::new(buffer),
             len: 0,
 
             section_num: 0,
@@ -67,7 +67,7 @@ impl<'a> Writer<'a> {
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
-        self.buffer.len()
+        self.buffer.count()
     }
 
     /// Reserve a file range with the given size and starting alignment.
@@ -87,7 +87,7 @@ impl<'a> Writer<'a> {
     /// Write alignment padding bytes.
     pub fn write_align(&mut self, align_start: u64) {
         if align_start > 1 {
-            util::write_align(self.buffer, align_start);
+            self.buffer.write_align(align_start);
         }
     }
 
@@ -104,7 +104,7 @@ impl<'a> Writer<'a> {
 
     /// Write padding up to the given file offset.
     pub fn pad_until(&mut self, offset: u64) {
-        debug_assert!(self.buffer.len() <= offset);
+        debug_assert!(self.buffer.count() <= offset);
         self.buffer.resize(offset);
     }
 
@@ -122,7 +122,7 @@ impl<'a> Writer<'a> {
     ///
     /// Fields that can be derived from known information are automatically set by this function.
     pub fn write_file_header(&mut self, header: FileHeader) -> Result<()> {
-        debug_assert_eq!(self.buffer.len(), 0);
+        debug_assert_eq!(self.buffer.count(), 0);
 
         // Start writing.
         self.buffer
@@ -139,7 +139,7 @@ impl<'a> Writer<'a> {
             size_of_optional_header: 0.into(),
             characteristics: header.characteristics.into(),
         };
-        self.buffer.write(&header);
+        self.buffer.write_pod(&header);
 
         Ok(())
     }
@@ -212,7 +212,7 @@ impl<'a> Writer<'a> {
                 }
             }
         }
-        self.buffer.write(&coff_section);
+        self.buffer.write_pod(&coff_section);
     }
 
     /// Reserve the range for the section data.
@@ -232,7 +232,7 @@ impl<'a> Writer<'a> {
     /// This is unneeded if you are using `write_section` or `write_section_zeroes`
     /// for the data.
     pub fn write_section_align(&mut self) {
-        util::write_align(self.buffer, 4);
+        self.buffer.write_align(4);
     }
 
     /// Write the section data.
@@ -256,7 +256,7 @@ impl<'a> Writer<'a> {
             return;
         }
         self.write_section_align();
-        self.buffer.resize(self.buffer.len() + len as u64);
+        self.buffer.write_zeros(len as u64);
     }
 
     /// Reserve a file range for the given number of relocations.
@@ -288,7 +288,7 @@ impl<'a> Writer<'a> {
                 symbol_table_index: 0.into(),
                 typ: 0.into(),
             };
-            self.buffer.write(&coff_relocation);
+            self.buffer.write_pod(&coff_relocation);
         }
     }
 
@@ -299,7 +299,7 @@ impl<'a> Writer<'a> {
             symbol_table_index: reloc.symbol.into(),
             typ: reloc.typ.into(),
         };
-        self.buffer.write(&coff_relocation);
+        self.buffer.write_pod(&coff_relocation);
     }
 
     /// Reserve a symbol table entry.
@@ -335,7 +335,7 @@ impl<'a> Writer<'a> {
                 coff_symbol.name[4..8].copy_from_slice(&u32::to_le_bytes(str_offset));
             }
         }
-        self.buffer.write(&coff_symbol);
+        self.buffer.write_pod(&coff_symbol);
     }
 
     /// Reserve auxiliary symbols for a file name.
@@ -354,7 +354,7 @@ impl<'a> Writer<'a> {
     pub fn write_aux_file_name(&mut self, name: &[u8], aux_count: u8) {
         let aux_len = aux_count as usize * pe::IMAGE_SIZEOF_SYMBOL;
         debug_assert!(aux_len >= name.len());
-        let old_len = self.buffer.len();
+        let old_len = self.buffer.count();
         self.buffer.write_bytes(name);
         self.buffer.resize(old_len + aux_len as u64);
     }
@@ -386,7 +386,7 @@ impl<'a> Writer<'a> {
             reserved: 0,
             high_number: ((section.number >> 16) as u16).into(),
         };
-        self.buffer.write(&aux);
+        self.buffer.write_pod(&aux);
     }
 
     /// Reserve an auxiliary symbol for a weak external.
@@ -406,7 +406,7 @@ impl<'a> Writer<'a> {
             weak_default_sym_index: weak.weak_default_sym_index.into(),
             weak_search_type: weak.weak_search_type.into(),
         };
-        self.buffer.write(&aux);
+        self.buffer.write_pod(&aux);
         // write padding for the unused field
         const PAD_LEN: usize = pe::IMAGE_SIZEOF_SYMBOL - mem::size_of::<pe::ImageAuxSymbolWeak>();
         self.buffer.write_bytes(&[0u8; PAD_LEN]);
@@ -458,7 +458,7 @@ impl<'a> Writer<'a> {
 
     /// Write the string table.
     pub fn write_strtab(&mut self) {
-        debug_assert_eq!(self.strtab_offset as u64, self.buffer.len());
+        debug_assert_eq!(self.strtab_offset as u64, self.buffer.count());
         self.buffer.write_bytes(&u32::to_le_bytes(self.strtab_len));
         self.buffer.write_bytes(&self.strtab_data);
     }

--- a/src/write/elf/encoder.rs
+++ b/src/write/elf/encoder.rs
@@ -6,8 +6,7 @@ use crate::Wrap;
 use crate::elf;
 use crate::endian::*;
 use crate::pod;
-use crate::write::util::{write_pod, write_pod_slice};
-use crate::write::{self, Error, Result, StringTable, WritableBuffer};
+use crate::write::{self, Error, Result, StringTable, WritableBuffer, WritableBufferExt};
 
 /// Alignment for .symtab_shndx.
 pub const ALIGN_SYMTAB_SHNDX: u64 = 4;
@@ -309,7 +308,7 @@ impl<E: Endian> Encoder<E> {
                 e_shnum: U16::new(endian, e_shnum),
                 e_shstrndx: U16::new(endian, e_shstrndx),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &elf::FileHeader32 {
                 e_ident,
@@ -327,7 +326,7 @@ impl<E: Endian> Encoder<E> {
                 e_shnum: U16::new(endian, e_shnum),
                 e_shstrndx: U16::new(endian, e_shstrndx),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
 
         Ok(())
@@ -365,7 +364,7 @@ impl<E: Endian> Encoder<E> {
                 p_memsz: U64::new(endian, header.p_memsz),
                 p_align: U64::new(endian, header.p_align),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &elf::ProgramHeader32 {
                 p_type: U32::new(endian, header.p_type),
@@ -377,7 +376,7 @@ impl<E: Endian> Encoder<E> {
                 p_flags: U32::new(endian, header.p_flags),
                 p_align: U32::new(endian, header.p_align as u32),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -429,7 +428,7 @@ impl<E: Endian> Encoder<E> {
                 sh_addralign: U64::new(endian, 0),
                 sh_entsize: U64::new(endian, 0),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &elf::SectionHeader32 {
                 sh_name: U32::new(endian, 0),
@@ -443,7 +442,7 @@ impl<E: Endian> Encoder<E> {
                 sh_addralign: U32::new(endian, 0),
                 sh_entsize: U32::new(endian, 0),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -472,7 +471,7 @@ impl<E: Endian> Encoder<E> {
                 sh_addralign: U64::new(endian, section.sh_addralign),
                 sh_entsize: U64::new(endian, section.sh_entsize),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &elf::SectionHeader32 {
                 sh_name: U32::new(endian, section.sh_name),
@@ -486,7 +485,7 @@ impl<E: Endian> Encoder<E> {
                 sh_addralign: U32::new(endian, section.sh_addralign as u32),
                 sh_entsize: U32::new(endian, section.sh_entsize as u32),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -727,9 +726,9 @@ impl<E: Endian> Encoder<E> {
     /// The buffer should already be aligned to `address_size`.
     pub fn null_symbol<W: WritableBuffer + ?Sized>(self, buffer: &mut W) {
         if self.is_64 {
-            write_pod(buffer, &elf::Sym64::<Endianness>::default());
+            buffer.write_pod(&elf::Sym64::<Endianness>::default());
         } else {
-            write_pod(buffer, &elf::Sym32::<Endianness>::default());
+            buffer.write_pod(&elf::Sym32::<Endianness>::default());
         }
     }
 
@@ -758,7 +757,7 @@ impl<E: Endian> Encoder<E> {
                 st_value: U64::new(endian, sym.st_value),
                 st_size: U64::new(endian, sym.st_size),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &elf::Sym32 {
                 st_name: U32::new(endian, sym.st_name),
@@ -768,7 +767,7 @@ impl<E: Endian> Encoder<E> {
                 st_value: U32::new(endian, sym.st_value as u32),
                 st_size: U32::new(endian, sym.st_size as u32),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
 
         if st_shndx == elf::SHN_XINDEX {
@@ -786,7 +785,7 @@ impl<E: Endian> Encoder<E> {
         buffer: &mut W,
         value: T,
     ) {
-        write_pod(buffer, &U32::new(self.endian, value));
+        buffer.write_u32(self.endian, value);
     }
 
     /// Return the size of a relocation entry.
@@ -830,13 +829,13 @@ impl<E: Endian> Encoder<E> {
                     r_info: elf::Rela64::r_info(endian, self.is_mips64el, rel.r_sym, rel.r_type),
                     r_addend: I64::new(endian, rel.r_addend),
                 };
-                write_pod(buffer, data);
+                buffer.write_pod(data);
             } else {
                 let data = &elf::Rel64 {
                     r_offset: U64::new(endian, rel.r_offset),
                     r_info: elf::Rel64::r_info(endian, rel.r_sym, rel.r_type),
                 };
-                write_pod(buffer, data);
+                buffer.write_pod(data);
             }
         } else {
             if is_rela {
@@ -845,13 +844,13 @@ impl<E: Endian> Encoder<E> {
                     r_info: elf::Rel32::r_info(endian, rel.r_sym, rel.r_type as u8),
                     r_addend: I32::new(endian, rel.r_addend as i32),
                 };
-                write_pod(buffer, data);
+                buffer.write_pod(data);
             } else {
                 let data = &elf::Rel32 {
                     r_offset: U32::new(endian, rel.r_offset as u32),
                     r_info: elf::Rel32::r_info(endian, rel.r_sym, rel.r_type as u8),
                 };
-                write_pod(buffer, data);
+                buffer.write_pod(data);
             }
         }
     }
@@ -882,7 +881,7 @@ impl<E: Endian> Encoder<E> {
                 d_tag: I64::new(endian, d_tag),
                 d_val: U64::new(endian, d_val),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let d_tag = I32::new_i64(endian, d_tag)
                 .map_err(|_| Error(format!("d_tag overflow: 0x{:x}", d_tag)))?;
@@ -893,7 +892,7 @@ impl<E: Endian> Encoder<E> {
                 d_tag,
                 d_val: U32::new(endian, d_val),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
         Ok(())
     }
@@ -930,9 +929,9 @@ impl<E: Endian> Encoder<E> {
             bucket_count: U32::new(self.endian, bucket_count),
             chain_count: U32::new(self.endian, chain_count),
         };
-        write_pod(buffer, data);
-        write_pod_slice(buffer, &buckets);
-        write_pod_slice(buffer, &chains);
+        buffer.write_pod(data);
+        buffer.write_pod_slice(&buckets);
+        buffer.write_pod_slice(&chains);
     }
 
     /// Return the size of a GNU hash table.
@@ -969,7 +968,7 @@ impl<E: Endian> Encoder<E> {
             bloom_count: U32::new(self.endian, bloom_count),
             bloom_shift: U32::new(self.endian, bloom_shift),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
 
         // Calculate and write bloom filter.
         if self.is_64 {
@@ -980,7 +979,7 @@ impl<E: Endian> Encoder<E> {
                     1 << (h % 64) | 1 << ((h >> bloom_shift) % 64);
             }
             for bloom_filter in bloom_filters {
-                write_pod(buffer, &U64::new(self.endian, bloom_filter));
+                buffer.write_u64(self.endian, bloom_filter);
             }
         } else {
             let mut bloom_filters = vec![0u32; bloom_count as usize];
@@ -990,7 +989,7 @@ impl<E: Endian> Encoder<E> {
                     1 << (h % 32) | 1 << ((h >> bloom_shift) % 32);
             }
             for bloom_filter in bloom_filters {
-                write_pod(buffer, &U32::new(self.endian, bloom_filter));
+                buffer.write_u32(self.endian, bloom_filter);
             }
         }
 
@@ -1001,16 +1000,16 @@ impl<E: Endian> Encoder<E> {
         for i in 0..symbol_count {
             let symbol_bucket = hash(i) % bucket_count;
             while bucket < symbol_bucket {
-                write_pod(buffer, &U32::new(self.endian, 0u32));
+                buffer.write_u32(self.endian, 0u32);
                 bucket += 1;
             }
             if bucket == symbol_bucket {
-                write_pod(buffer, &U32::new(self.endian, symbol_base + i));
+                buffer.write_u32(self.endian, symbol_base + i);
                 bucket += 1;
             }
         }
         while bucket < bucket_count {
-            write_pod(buffer, &U32::new(self.endian, 0u32));
+            buffer.write_u32(self.endian, 0u32);
             bucket += 1;
         }
 
@@ -1022,7 +1021,7 @@ impl<E: Endian> Encoder<E> {
             } else {
                 h &= !1;
             }
-            write_pod(buffer, &U32::new(self.endian, h));
+            buffer.write_u32(self.endian, h);
         }
     }
 
@@ -1033,7 +1032,7 @@ impl<E: Endian> Encoder<E> {
 
     /// Write a symbol version entry.
     pub fn gnu_versym<W: WritableBuffer + ?Sized>(self, buffer: &mut W, versym: elf::VersymIndex) {
-        write_pod(buffer, &U16::new(self.endian, versym));
+        buffer.write_u16(self.endian, versym);
     }
 
     /// Return the size of a GNU version definition section.
@@ -1065,7 +1064,7 @@ impl<E: Endian> Encoder<E> {
             vd_aux: U32::new(self.endian, vd_aux),
             vd_next: U32::new(self.endian, vd_next),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
         self.gnu_verdaux(buffer, verdef.aux_count > 1, verdef.name);
     }
 
@@ -1085,7 +1084,7 @@ impl<E: Endian> Encoder<E> {
             vd_aux: U32::new(self.endian, vd_aux),
             vd_next: U32::new(self.endian, vd_next),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Write a version definition auxiliary entry.
@@ -1101,7 +1100,7 @@ impl<E: Endian> Encoder<E> {
             vda_name: U32::new(self.endian, name),
             vda_next: U32::new(self.endian, vda_next),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Return the size of a GNU version dependency section.
@@ -1135,7 +1134,7 @@ impl<E: Endian> Encoder<E> {
             vn_aux: U32::new(self.endian, vn_aux),
             vn_next: U32::new(self.endian, vn_next),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Write a version needed auxiliary entry.
@@ -1157,7 +1156,7 @@ impl<E: Endian> Encoder<E> {
             vna_name: U32::new(self.endian, vernaux.name),
             vna_next: U32::new(self.endian, vna_next),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 }
 

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -46,18 +46,18 @@ impl<'a> Object<'a> {
             n_descsz: U32::new(self.endian, align_u32(3 * 4, address_size)),
             n_type: U32::new(self.endian, elf::NT_GNU_PROPERTY_TYPE_0),
         };
-        write_pod(&mut data, header);
+        data.write_pod(header);
         data.extend_from_slice(n_name);
         // This happens to already be aligned correctly.
         debug_assert_eq!(
             align(data.len() as u64, address_size.into()),
             data.len() as u64
         );
-        write_pod(&mut data, &U32::new(self.endian, property));
+        data.write_u32(self.endian, property);
         // Value size
-        write_pod(&mut data, &U32::new(self.endian, 4u32));
-        write_pod(&mut data, &U32::new(self.endian, value));
-        write_align(&mut data, address_size.into());
+        data.write_u32(self.endian, 4u32);
+        data.write_u32(self.endian, value);
+        data.resize(align(data.len() as u64, address_size.into()) as usize, 0);
 
         let section = self.section_id(StandardSection::GnuProperty);
         self.append_section_data(section, &data, address_size.into());

--- a/src/write/elf/writer.rs
+++ b/src/write/elf/writer.rs
@@ -7,7 +7,7 @@ use crate::endian::*;
 use crate::write::elf::encoder::*;
 use crate::write::string::{StringId, StringTable};
 use crate::write::util;
-use crate::write::{Error, GrowableBuffer, Result, WritableBuffer};
+use crate::write::{CountingBuffer, Error, GrowableBuffer, Result, WritableBuffer};
 
 /// The index of an ELF section.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -63,7 +63,7 @@ mod private {
 pub struct Writer<'a, M: Mode = TwoPhase> {
     mode: M,
     encoder: Encoder<Endianness>,
-    buffer: &'a mut dyn WritableBuffer,
+    buffer: CountingBuffer<&'a mut dyn WritableBuffer>,
 
     header: FileHeader,
     layout: FileHeaderLayout,
@@ -156,7 +156,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         Writer {
             mode,
             encoder: Encoder::new(endian, is_64, elf::EM_NONE),
-            buffer,
+            buffer: CountingBuffer::new(buffer),
 
             header: FileHeader::default(),
             layout: FileHeaderLayout::default(),
@@ -242,12 +242,12 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
-        self.buffer.len()
+        self.buffer.count()
     }
 
     /// Return the file offset of the next write.
     pub fn offset(&self) -> u64 {
-        self.buffer.len()
+        self.buffer.count()
     }
 
     /// Write alignment padding bytes.
@@ -255,7 +255,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// Returns the file offset after the padding.
     pub fn write_align(&mut self, align_start: u64) -> u64 {
         if align_start > 1 {
-            util::write_align(self.buffer, align_start);
+            self.buffer.write_align(align_start);
         }
         self.offset()
     }
@@ -279,13 +279,13 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Fields that can be derived from known information are automatically set by this function.
     pub fn write_file_header(&mut self, header: &FileHeader) -> Result<()> {
-        debug_assert_eq!(self.buffer.len(), 0);
+        debug_assert_eq!(self.buffer.count(), 0);
 
-        self.mode.reserve(self.buffer, self.encoder)?;
+        self.mode.reserve(&mut self.buffer, self.encoder)?;
         self.header = header.clone();
         self.encoder.set_machine(header.e_machine);
         self.encoder
-            .file_header(self.buffer, &self.header, &self.layout)
+            .file_header(&mut self.buffer, &self.header, &self.layout)
     }
 
     /// Write alignment padding bytes prior to the program headers.
@@ -305,7 +305,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Must be called after [`Self::write_align_program_headers`].
     pub fn write_program_header(&mut self, header: &ProgramHeader) {
-        self.encoder.program_header(self.buffer, header);
+        self.encoder.program_header(&mut self.buffer, header);
         self.written_segment_num += 1;
         M::set_count(&mut self.layout.segment_num, self.written_segment_num);
     }
@@ -322,7 +322,8 @@ impl<'a, M: Mode> Writer<'a, M> {
         }
         let offset = self.write_align(self.encoder.address_size());
         M::set_offset(&mut self.layout.e_shoff, offset);
-        self.encoder.null_section_header(self.buffer, &self.layout);
+        self.encoder
+            .null_section_header(&mut self.buffer, &self.layout);
         self.written_section_num = 1;
         M::set_count(&mut self.layout.section_num, self.written_section_num);
         offset
@@ -332,7 +333,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Must be called after [`Self::write_null_section_header`].
     pub fn write_section_header(&mut self, section: &SectionHeader) -> SectionIndex {
-        self.encoder.section_header(self.buffer, section);
+        self.encoder.section_header(&mut self.buffer, section);
         let index = SectionIndex(self.written_section_num);
         self.written_section_num += 1;
         M::set_count(&mut self.layout.section_num, self.written_section_num);
@@ -428,7 +429,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_offset(&mut self.symtab_offset, offset);
         M::set_section_name(&mut self.symtab_str_id, &mut self.shstrtab, b".symtab");
 
-        self.encoder.null_symbol(self.buffer);
+        self.encoder.null_symbol(&mut self.buffer);
         if M::need_offset(self.symtab_shndx_offset) {
             self.encoder.u32(&mut self.symtab_shndx_data, 0u32);
         }
@@ -444,7 +445,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Must be called after [`Self::write_null_symbol`].
     pub fn write_symbol(&mut self, sym: &Sym) -> SymbolIndex {
-        let section = self.encoder.symbol(self.buffer, sym);
+        let section = self.encoder.symbol(&mut self.buffer, sym);
         if M::need_offset(self.symtab_shndx_offset) {
             let section_index = if let Some(section) = section {
                 self.need_symtab_shndx = true;
@@ -583,7 +584,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_offset(&mut self.dynsym_offset, offset);
         M::set_section_name(&mut self.dynsym_str_id, &mut self.shstrtab, b".dynsym");
 
-        self.encoder.null_symbol(self.buffer);
+        self.encoder.null_symbol(&mut self.buffer);
 
         self.written_dynsym_num = 1;
         M::set_count(&mut self.dynsym_num, self.written_dynsym_num);
@@ -598,7 +599,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     pub fn write_dynamic_symbol(&mut self, sym: &Sym) -> SymbolIndex {
         // TODO: we don't write out .dynsym_shndx yet.
         // This is unlikely to be needed though.
-        let _ = self.encoder.symbol(self.buffer, sym);
+        let _ = self.encoder.symbol(&mut self.buffer, sym);
 
         let index = SymbolIndex(self.written_dynsym_num);
         self.written_dynsym_num += 1;
@@ -651,7 +652,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Must be called after [`Self::write_align_dynamic`].
     pub fn write_dynamic(&mut self, d_tag: elf::DynamicTag, d_val: u64) -> Result<()> {
-        self.encoder.dynamic(self.buffer, d_tag, d_val)?;
+        self.encoder.dynamic(&mut self.buffer, d_tag, d_val)?;
         self.written_dynamic_num += 1;
         M::set_count(&mut self.dynamic_num, self.written_dynamic_num);
         Ok(())
@@ -690,7 +691,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_offset(&mut self.hash_offset, offset);
         M::set_section_name(&mut self.hash_str_id, &mut self.shstrtab, b".hash");
         self.encoder
-            .hash_table(self.buffer, bucket_count, symbol_count, hash);
+            .hash_table(&mut self.buffer, bucket_count, symbol_count, hash);
         let size = self.offset() - self.hash_offset;
         M::set_size(&mut self.hash_size, size);
         offset
@@ -740,7 +741,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_section_name(&mut self.gnu_hash_str_id, &mut self.shstrtab, b".gnu.hash");
 
         self.encoder.gnu_hash_table(
-            self.buffer,
+            &mut self.buffer,
             &GnuHashTable {
                 bloom_shift,
                 bloom_count,
@@ -798,7 +799,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     ///
     /// Must be called after [`Self::write_null_gnu_versym`].
     pub fn write_gnu_versym(&mut self, versym: elf::VersymIndex) {
-        self.encoder.gnu_versym(self.buffer, versym);
+        self.encoder.gnu_versym(&mut self.buffer, versym);
         self.written_versym_num += 1;
         M::set_count(&mut self.gnu_versym_num, self.written_versym_num);
     }
@@ -851,7 +852,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         M::set_count(&mut self.gnu_verdaux_count, self.written_verdaux_count);
 
         self.encoder
-            .gnu_verdef(self.buffer, self.gnu_verdef_remaining != 0, verdef);
+            .gnu_verdef(&mut self.buffer, self.gnu_verdef_remaining != 0, verdef);
     }
 
     /// Write a version definition entry that shares the names of the next definition.
@@ -868,7 +869,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         debug_assert_ne!(verdef.aux_count, 0);
         self.gnu_verdaux_remaining = 0;
 
-        self.encoder.gnu_verdef_shared(self.buffer, verdef);
+        self.encoder.gnu_verdef_shared(&mut self.buffer, verdef);
     }
 
     /// Write a version definition auxiliary entry.
@@ -878,7 +879,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         debug_assert_ne!(self.gnu_verdaux_remaining, 0);
         self.gnu_verdaux_remaining -= 1;
         self.encoder.gnu_verdaux(
-            self.buffer,
+            &mut self.buffer,
             self.gnu_verdaux_remaining != 0,
             self.dynstr.get_offset(name),
         );
@@ -938,7 +939,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         };
 
         self.encoder
-            .gnu_verneed(self.buffer, self.gnu_verneed_remaining != 0, verneed);
+            .gnu_verneed(&mut self.buffer, self.gnu_verneed_remaining != 0, verneed);
     }
 
     /// Write a version needed auxiliary entry.
@@ -948,7 +949,7 @@ impl<'a, M: Mode> Writer<'a, M> {
         debug_assert_ne!(self.gnu_vernaux_remaining, 0);
         self.gnu_vernaux_remaining -= 1;
         self.encoder
-            .gnu_vernaux(self.buffer, self.gnu_vernaux_remaining != 0, vernaux);
+            .gnu_vernaux(&mut self.buffer, self.gnu_vernaux_remaining != 0, vernaux);
     }
 
     /// Write the section header for the `.gnu.version_r` section.
@@ -1024,7 +1025,7 @@ impl<'a, M: Mode> Writer<'a, M> {
     /// of a section. In two-phase mode, the file range must have been reserved with
     /// [`Self::reserve_relocations`].
     pub fn write_relocation(&mut self, is_rela: bool, rel: &Rel) {
-        self.encoder.relocation(self.buffer, is_rela, rel);
+        self.encoder.relocation(&mut self.buffer, is_rela, rel);
     }
 
     /// Write the section header for a relocation section.
@@ -1075,13 +1076,13 @@ impl<'a, M: Mode> Writer<'a, M> {
 
     /// Write `GRP_COMDAT` at the start of the COMDAT section.
     pub fn write_comdat_header(&mut self) {
-        util::write_align(self.buffer, 4);
-        self.encoder.u32(self.buffer, elf::GRP_COMDAT);
+        self.buffer.write_align(4);
+        self.encoder.u32(&mut self.buffer, elf::GRP_COMDAT);
     }
 
     /// Write an entry in a COMDAT section.
     pub fn write_comdat_entry(&mut self, entry: SectionIndex) {
-        self.encoder.u32(self.buffer, entry.0);
+        self.encoder.u32(&mut self.buffer, entry.0);
     }
 
     /// Write the section header for a COMDAT section.
@@ -1244,7 +1245,7 @@ impl<'a> Writer<'a, SinglePhase> {
         SinglePhase::set_count(&mut self.layout.segment_num, count);
         self.written_segment_num = count;
         let size = u64::from(count) * self.encoder.program_header_size();
-        self.buffer.resize(self.buffer.len() + size);
+        self.buffer.write_zeros(size);
         (offset, size)
     }
 
@@ -1294,7 +1295,7 @@ impl<'a> Writer<'a, SinglePhase> {
         debug_assert_eq!(self.shstrtab_offset, 0);
         self.shstrtab_str_id = Some(self.add_section_name(b".shstrtab"));
         self.shstrtab_offset = self.offset();
-        self.shstrtab_size = self.encoder.strtab(self.buffer, &mut self.shstrtab)?;
+        self.shstrtab_size = self.encoder.strtab(&mut self.buffer, &mut self.shstrtab)?;
         Ok((self.shstrtab_offset, self.shstrtab_size))
     }
 
@@ -1310,7 +1311,7 @@ impl<'a> Writer<'a, SinglePhase> {
         debug_assert_eq!(self.strtab_offset, 0);
         self.strtab_str_id = Some(self.add_section_name(b".strtab"));
         self.strtab_offset = self.offset();
-        self.strtab_size = self.encoder.strtab(self.buffer, &mut self.strtab)?;
+        self.strtab_size = self.encoder.strtab(&mut self.buffer, &mut self.strtab)?;
         Ok((self.strtab_offset, self.strtab_size))
     }
 
@@ -1326,7 +1327,7 @@ impl<'a> Writer<'a, SinglePhase> {
         debug_assert_eq!(self.dynstr_offset, 0);
         self.dynstr_str_id = Some(self.add_section_name(b".dynstr"));
         self.dynstr_offset = self.offset();
-        self.dynstr_size = self.encoder.strtab(self.buffer, &mut self.dynstr)?;
+        self.dynstr_size = self.encoder.strtab(&mut self.buffer, &mut self.dynstr)?;
         Ok((self.dynstr_offset, self.dynstr_size))
     }
 

--- a/src/write/macho/encoder.rs
+++ b/src/write/macho/encoder.rs
@@ -2,8 +2,8 @@ use core::mem;
 
 use crate::endian::*;
 use crate::macho;
-use crate::write::util::{align, write_pod};
-use crate::write::{Error, Result, StringTable, WritableBuffer};
+use crate::write::util::align;
+use crate::write::{Error, Result, StringTable, WritableBuffer, WritableBufferExt};
 
 /// Native endian version of [`macho::MachHeader64`].
 #[allow(missing_docs)]
@@ -197,7 +197,7 @@ impl<E: Endian> Encoder<E> {
                 flags: U32::new(endian, header.flags),
                 reserved: U32::default(),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let magic = if endian.is_big_endian() {
                 macho::MH_MAGIC
@@ -213,7 +213,7 @@ impl<E: Endian> Encoder<E> {
                 sizeofcmds: U32::new(endian, header.sizeofcmds),
                 flags: U32::new(endian, header.flags),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -241,7 +241,7 @@ impl<E: Endian> Encoder<E> {
             cmd: U32::new(endian, cmd),
             cmdsize: U32::new(endian, cmdsize),
         };
-        write_pod(buffer, command);
+        buffer.write_pod(command);
         buffer.write_bytes(data);
     }
 
@@ -279,7 +279,7 @@ impl<E: Endian> Encoder<E> {
                 nsects: U32::new(endian, segment.nsects),
                 flags: U32::new(endian, segment.flags),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &macho::SegmentCommand32 {
                 cmd: U32::new(endian, macho::LC_SEGMENT),
@@ -294,7 +294,7 @@ impl<E: Endian> Encoder<E> {
                 nsects: U32::new(endian, segment.nsects),
                 flags: U32::new(endian, segment.flags),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -332,7 +332,7 @@ impl<E: Endian> Encoder<E> {
                 reserved2: U32::new(endian, section.reserved2),
                 reserved3: U32::new(endian, section.reserved3),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &macho::Section32 {
                 sectname: section.sectname,
@@ -347,7 +347,7 @@ impl<E: Endian> Encoder<E> {
                 reserved1: U32::new(endian, section.reserved1),
                 reserved2: U32::new(endian, section.reserved2),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -364,7 +364,7 @@ impl<E: Endian> Encoder<E> {
         buffer: &mut W,
         rel: &macho::RelocationInfo,
     ) {
-        write_pod(buffer, &rel.relocation(self.endian));
+        buffer.write_pod(&rel.relocation(self.endian));
     }
 
     /// Return the size of a symtab load command.
@@ -387,7 +387,7 @@ impl<E: Endian> Encoder<E> {
             stroff: U32::new(endian, symtab.stroff),
             strsize: U32::new(endian, symtab.strsize),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Return the size of a symbol.
@@ -412,7 +412,7 @@ impl<E: Endian> Encoder<E> {
                 n_desc: U16::new(endian, nlist.n_desc),
                 n_value: U64::new(endian, nlist.n_value),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         } else {
             let data = &macho::Nlist32 {
                 n_strx: U32::new(endian, nlist.n_strx),
@@ -421,7 +421,7 @@ impl<E: Endian> Encoder<E> {
                 n_desc: U16::new(endian, nlist.n_desc),
                 n_value: U32::new(endian, nlist.n_value as u32),
             };
-            write_pod(buffer, data);
+            buffer.write_pod(data);
         }
     }
 
@@ -438,7 +438,7 @@ impl<E: Endian> Encoder<E> {
         buffer.write_bytes(&[0]);
         let len = strtab.write(buffer, 1)? as u64;
         let aligned_len = align(len, self.address_size());
-        buffer.resize(buffer.len() + (aligned_len - len));
+        buffer.write_zeros(aligned_len - len);
         u32::try_from(aligned_len).map_err(|_| Error("string table size overflow".into()))
     }
 
@@ -476,7 +476,7 @@ impl<E: Endian> Encoder<E> {
             locreloff: U32::new(endian, dysymtab.locreloff),
             nlocrel: U32::new(endian, dysymtab.nlocrel),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Return the size of an indirect symbol for a dynamic symtab load command.
@@ -490,7 +490,7 @@ impl<E: Endian> Encoder<E> {
         buffer: &mut W,
         symbol: macho::IndirectSymbol,
     ) {
-        write_pod(buffer, &U32::new(self.endian, symbol));
+        buffer.write_u32(self.endian, symbol);
     }
 
     /// Return the size of a dylib command.
@@ -509,7 +509,6 @@ impl<E: Endian> Encoder<E> {
         buffer: &mut W,
         dylib: &DylibCommand<'_>,
     ) {
-        let offset = buffer.len();
         let cmdsize = self.dylib_command_size(dylib.name.len());
         let name_offset = mem::size_of::<macho::DylibCommand<Endianness>>() as u32;
         let endian = self.endian;
@@ -525,9 +524,10 @@ impl<E: Endian> Encoder<E> {
                 compatibility_version: U32::new(endian, dylib.compatibility_version),
             },
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
         buffer.write_bytes(dylib.name);
-        buffer.resize(offset + cmdsize);
+        let written = name_offset as u64 + dylib.name.len() as u64;
+        buffer.write_zeros(cmdsize - written);
     }
 
     /// Return the size of a build version load command.
@@ -554,7 +554,7 @@ impl<E: Endian> Encoder<E> {
             sdk: U32::new(endian, version.sdk),
             ntools: U32::new(endian, version.ntools),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Write a build tool version.
@@ -571,7 +571,7 @@ impl<E: Endian> Encoder<E> {
             tool: U32::new(endian, tool),
             version: U32::new(endian, version),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Return the size of a load command referencing linkedit data.
@@ -594,7 +594,7 @@ impl<E: Endian> Encoder<E> {
             dataoff: U32::new(endian, dataoff),
             datasize: U32::new(endian, datasize),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 
     /// Return the size of a load command referencing dyld information.
@@ -624,6 +624,6 @@ impl<E: Endian> Encoder<E> {
             export_off: U32::new(endian, info.export_off),
             export_size: U32::new(endian, info.export_size),
         };
-        write_pod(buffer, data);
+        buffer.write_pod(data);
     }
 }

--- a/src/write/macho/object.rs
+++ b/src/write/macho/object.rs
@@ -599,6 +599,7 @@ impl<'a> Object<'a> {
         buffer
             .reserve(reserved_len)
             .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+        let buffer = &mut CountingBuffer::new(buffer);
 
         // Write file header.
         let (cputype, cpusubtype_id) = match (self.architecture, self.sub_architecture) {
@@ -649,7 +650,7 @@ impl<'a> Object<'a> {
         encoder.mach_header(buffer, mach_header);
 
         // Write segment command.
-        debug_assert_eq!(segment_command_offset, buffer.len());
+        debug_assert_eq!(segment_command_offset, buffer.count());
         let segment_command = &SegmentCommand {
             segname: [0; 16],
             vmaddr: 0,
@@ -711,7 +712,7 @@ impl<'a> Object<'a> {
 
         // Write build version.
         if let Some(version) = &self.macho_build_version {
-            debug_assert_eq!(build_version_offset, buffer.len());
+            debug_assert_eq!(build_version_offset, buffer.count());
             let build_version_command = &BuildVersionCommand {
                 platform: version.platform,
                 minos: version.minos,
@@ -722,7 +723,7 @@ impl<'a> Object<'a> {
         }
 
         // Write symtab command.
-        debug_assert_eq!(symtab_command_offset, buffer.len());
+        debug_assert_eq!(symtab_command_offset, buffer.count());
         let symtab_command = &SymtabCommand {
             symoff: symtab_offset as u32,
             nsyms,
@@ -732,7 +733,7 @@ impl<'a> Object<'a> {
         encoder.symtab_command(buffer, symtab_command);
 
         // Write dysymtab command.
-        debug_assert_eq!(dysymtab_command_offset, buffer.len());
+        debug_assert_eq!(dysymtab_command_offset, buffer.count());
         let dysymtab_command = &DysymtabCommand {
             ilocalsym: 0,
             nlocalsym: local_symbols.len() as u32,
@@ -745,14 +746,14 @@ impl<'a> Object<'a> {
         encoder.dysymtab_command(buffer, dysymtab_command);
 
         // Write section data.
-        debug_assert_eq!(segment_file_offset, buffer.len());
+        debug_assert_eq!(segment_file_offset, buffer.count());
         for (index, section) in self.sections.iter().enumerate() {
             if !section.is_bss() {
                 buffer.resize(section_offsets[index].offset);
                 buffer.write_bytes(&section.data);
             }
         }
-        debug_assert_eq!(segment_file_offset + segment_file_size, buffer.len());
+        debug_assert_eq!(segment_file_offset + segment_file_size, buffer.count());
 
         // Write relocations.
         for (index, section) in self.sections.iter().enumerate() {
@@ -904,10 +905,10 @@ impl<'a> Object<'a> {
         }
 
         // Write strtab.
-        debug_assert_eq!(strtab_offset, buffer.len());
+        debug_assert_eq!(strtab_offset, buffer.count());
         buffer.write_bytes(&strtab_data);
 
-        debug_assert_eq!(reserved_len, buffer.len());
+        debug_assert_eq!(reserved_len, buffer.count());
 
         Ok(())
     }

--- a/src/write/pe.rs
+++ b/src/write/pe.rs
@@ -6,7 +6,7 @@ use core::mem;
 use crate::endian::{LittleEndian as LE, *};
 use crate::pe;
 use crate::write::util;
-use crate::write::{Error, Result, WritableBuffer};
+use crate::write::{CountingBuffer, Error, Result, WritableBuffer, WritableBufferExt};
 
 /// A helper for writing PE files.
 ///
@@ -21,7 +21,7 @@ pub struct Writer<'a> {
     section_alignment: u32,
     file_alignment: u32,
 
-    buffer: &'a mut dyn WritableBuffer,
+    buffer: CountingBuffer<&'a mut dyn WritableBuffer>,
     len: u64,
     virtual_len: u32,
     headers_len: u32,
@@ -60,7 +60,7 @@ impl<'a> Writer<'a> {
             section_alignment,
             file_alignment,
 
-            buffer,
+            buffer: CountingBuffer::new(buffer),
             len: 0,
             virtual_len: 0,
             headers_len: 0,
@@ -120,7 +120,7 @@ impl<'a> Writer<'a> {
     /// Return the current file length that has been written.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
-        self.buffer.len()
+        self.buffer.count()
     }
 
     /// Reserve a file range with the given size and starting alignment.
@@ -155,7 +155,7 @@ impl<'a> Writer<'a> {
 
     /// Write alignment padding bytes.
     pub fn write_align(&mut self, align_start: u32) {
-        util::write_align(self.buffer, align_start as u64);
+        self.buffer.write_align(align_start as u64);
     }
 
     /// Write padding up to the next multiple of file alignment.
@@ -171,7 +171,7 @@ impl<'a> Writer<'a> {
 
     /// Write padding up to the given file offset.
     pub fn pad_until(&mut self, offset: u32) {
-        debug_assert!(self.buffer.len() <= offset as u64);
+        debug_assert!(self.buffer.count() <= offset as u64);
         self.buffer.resize(offset as u64);
     }
 
@@ -189,14 +189,14 @@ impl<'a> Writer<'a> {
     ///
     /// This must be at the start of the file.
     pub fn write_custom_dos_header(&mut self, dos_header: &pe::ImageDosHeader) -> Result<()> {
-        debug_assert_eq!(self.buffer.len(), 0);
+        debug_assert_eq!(self.buffer.count(), 0);
 
         // Start writing.
         self.buffer
             .reserve(self.len)
             .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
 
-        self.buffer.write(dos_header);
+        self.buffer.write_pod(dos_header);
         Ok(())
     }
 
@@ -322,7 +322,7 @@ impl<'a> Writer<'a> {
     /// Write the NT headers.
     pub fn write_nt_headers(&mut self, nt_headers: NtHeaders) {
         self.pad_until(self.nt_headers_offset);
-        self.buffer.write(&U32::new(LE, pe::IMAGE_NT_SIGNATURE));
+        self.buffer.write_u32(LE, pe::IMAGE_NT_SIGNATURE);
         let file_header = pe::ImageFileHeader {
             machine: nt_headers.machine.into(),
             number_of_sections: self.section_header_num.into(),
@@ -332,7 +332,7 @@ impl<'a> Writer<'a> {
             size_of_optional_header: (self.optional_header_size() as u16).into(),
             characteristics: nt_headers.characteristics.into(),
         };
-        self.buffer.write(&file_header);
+        self.buffer.write_pod(&file_header);
         if self.is_64 {
             let optional_header = pe::ImageOptionalHeader64 {
                 magic: pe::IMAGE_NT_OPTIONAL_HDR64_MAGIC.into(),
@@ -371,7 +371,7 @@ impl<'a> Writer<'a> {
                 loader_flags: 0.into(),
                 number_of_rva_and_sizes: (self.data_directories.len() as u32).into(),
             };
-            self.buffer.write(&optional_header);
+            self.buffer.write_pod(&optional_header);
         } else {
             let optional_header = pe::ImageOptionalHeader32 {
                 magic: pe::IMAGE_NT_OPTIONAL_HDR32_MAGIC.into(),
@@ -411,11 +411,11 @@ impl<'a> Writer<'a> {
                 loader_flags: 0.into(),
                 number_of_rva_and_sizes: (self.data_directories.len() as u32).into(),
             };
-            self.buffer.write(&optional_header);
+            self.buffer.write_pod(&optional_header);
         }
 
         for dir in &self.data_directories {
-            self.buffer.write(&pe::ImageDataDirectory {
+            self.buffer.write_pod(&pe::ImageDataDirectory {
                 virtual_address: dir.virtual_address.into(),
                 size: dir.size.into(),
             })
@@ -458,7 +458,7 @@ impl<'a> Writer<'a> {
                 number_of_linenumbers: 0.into(),
                 characteristics: section.characteristics.into(),
             };
-            self.buffer.write(&section_header);
+            self.buffer.write_pod(&section_header);
         }
     }
 
@@ -747,12 +747,12 @@ impl<'a> Writer<'a> {
 
         let mut total = 0;
         for block in &self.reloc_blocks {
-            self.buffer.write(&pe::ImageBaseRelocation {
+            self.buffer.write_pod(&pe::ImageBaseRelocation {
                 virtual_address: block.virtual_address.into(),
                 size_of_block: block.size().into(),
             });
             self.buffer
-                .write_slice(&self.relocs[total..][..block.count as usize]);
+                .write_pod_slice(&self.relocs[total..][..block.count as usize]);
             total += block.count as usize;
         }
         debug_assert_eq!(total, self.relocs.len());

--- a/src/write/util.rs
+++ b/src/write/util.rs
@@ -2,17 +2,16 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::{io, mem};
 
+use crate::constants::Wrap;
+use crate::endian::{Endian, U16, U32, U64};
 use crate::pod::{Pod, bytes_of, bytes_of_slice};
 
 /// Trait for writable buffer.
-#[allow(clippy::len_without_is_empty)]
+///
+/// This is a low-level, append-only sink. Callers that need to know the current
+/// write offset should wrap the buffer in a [`CountingBuffer`], which counts the
+/// number of bytes written.
 pub trait WritableBuffer {
-    /// Returns the next offset that data will be written at.
-    ///
-    /// This is called often, so implementors should track this value
-    /// themselves if determining the length is an expensive operation.
-    fn len(&self) -> u64;
-
     /// Reserves specified number of bytes in the buffer.
     ///
     /// If called, this will be called exactly once before any writes, and the given size
@@ -20,42 +19,77 @@ pub trait WritableBuffer {
     /// [`GrowableBuffer`] may skip this call, but it is required for other writers.
     fn reserve(&mut self, size: u64) -> Result<(), ()>;
 
-    /// Writes zero bytes at the end of the buffer until the buffer
-    /// has the specified length.
-    fn resize(&mut self, new_len: u64);
-
     /// Writes the specified slice of bytes at the end of the buffer.
     fn write_bytes(&mut self, val: &[u8]);
 
-    /// Writes the specified `Pod` type at the end of the buffer.
-    fn write_pod<T: Pod>(&mut self, val: &T)
-    where
-        Self: Sized,
-    {
-        self.write_bytes(bytes_of(val))
-    }
-
-    /// Writes the specified `Pod` slice at the end of the buffer.
-    fn write_pod_slice<T: Pod>(&mut self, val: &[T])
-    where
-        Self: Sized,
-    {
-        self.write_bytes(bytes_of_slice(val))
+    /// Writes `additional` zero bytes at the end of the buffer.
+    fn write_zeros(&mut self, mut additional: u64) {
+        while additional > 0 {
+            let write_amt = additional.min(1024) as usize;
+            self.write_bytes(&[0; 1024][..write_amt]);
+            additional -= write_amt as u64;
+        }
     }
 }
 
-// `write_pod`/`write_pod_slice` are generic, so they require `Self: Sized`
-// to keep the trait object-safe. That bound also excludes them from
-// `&mut dyn WritableBuffer` call sites, so provide them again here.
-impl<'a> dyn WritableBuffer + 'a {
+/// Extension methods for [`WritableBuffer`].
+///
+/// These are provided as a separate trait so that they can be used with `?Sized`.
+pub trait WritableBufferExt: WritableBuffer {
     /// Writes the specified `Pod` type at the end of the buffer.
-    pub fn write<T: Pod>(&mut self, val: &T) {
+    fn write_pod<T: Pod>(&mut self, val: &T) {
         self.write_bytes(bytes_of(val))
     }
 
     /// Writes the specified `Pod` slice at the end of the buffer.
-    pub fn write_slice<T: Pod>(&mut self, val: &[T]) {
+    fn write_pod_slice<T: Pod>(&mut self, val: &[T]) {
         self.write_bytes(bytes_of_slice(val))
+    }
+
+    /// Write a `u16` with the specified endianness at the end of the buffer.
+    fn write_u16<E, T>(&mut self, endian: E, val: T)
+    where
+        E: Endian,
+        T: Wrap<Inner = u16> + Copy + 'static,
+    {
+        self.write_bytes(bytes_of(&U16::new(endian, val)))
+    }
+
+    /// Write a `u32` with the specified endianness at the end of the buffer.
+    fn write_u32<E, T>(&mut self, endian: E, val: T)
+    where
+        E: Endian,
+        T: Wrap<Inner = u32> + Copy + 'static,
+    {
+        self.write_bytes(bytes_of(&U32::new(endian, val)))
+    }
+
+    /// Write a `u64` with the specified endianness at the end of the buffer.
+    fn write_u64<E, T>(&mut self, endian: E, val: T)
+    where
+        E: Endian,
+        T: Wrap<Inner = u64> + Copy + 'static,
+    {
+        self.write_bytes(bytes_of(&U64::new(endian, val)))
+    }
+}
+
+impl<W: WritableBuffer + ?Sized> WritableBufferExt for W {}
+
+impl<W: WritableBuffer + ?Sized> WritableBuffer for &mut W {
+    #[inline]
+    fn reserve(&mut self, size: u64) -> Result<(), ()> {
+        (**self).reserve(size)
+    }
+
+    #[inline]
+    fn write_bytes(&mut self, val: &[u8]) {
+        (**self).write_bytes(val)
+    }
+
+    #[inline]
+    fn write_zeros(&mut self, additional: u64) {
+        (**self).write_zeros(additional)
     }
 }
 
@@ -70,15 +104,69 @@ pub trait GrowableBuffer: WritableBuffer {
     fn as_writable(&mut self) -> &mut dyn WritableBuffer;
 }
 
-impl<'a> dyn GrowableBuffer + 'a {
-    /// Writes the specified `Pod` type at the end of the buffer.
-    pub fn write<T: Pod>(&mut self, val: &T) {
-        self.write_bytes(bytes_of(val))
+/// Wraps a [`WritableBuffer`] and counts the number of bytes written.
+///
+/// The user is responsible for calling [`WritableBuffer::reserve`] if required (either
+/// before creating the `CountingBuffer`, or via `CountingBuffer`'s implementation).
+pub struct CountingBuffer<W> {
+    buffer: W,
+    count: u64,
+}
+
+impl<W> core::fmt::Debug for CountingBuffer<W> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CountingBuffer")
+            .field("count", &self.count)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<W> CountingBuffer<W> {
+    /// Create a new `CountingBuffer` wrapping the given buffer, starting at count 0.
+    pub fn new(buffer: W) -> Self {
+        CountingBuffer { buffer, count: 0 }
     }
 
-    /// Writes the specified `Pod` slice at the end of the buffer.
-    pub fn write_slice<T: Pod>(&mut self, val: &[T]) {
-        self.write_bytes(bytes_of_slice(val))
+    /// Unwraps this `CountingBuffer` giving back the original buffer.
+    pub fn into_inner(self) -> W {
+        self.buffer
+    }
+
+    /// Returns the number of bytes that have been written.
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+}
+
+impl<W: WritableBuffer> CountingBuffer<W> {
+    /// Writes zero bytes until the total count written reaches `new_len`.
+    pub fn resize(&mut self, new_len: u64) {
+        debug_assert!(new_len >= self.count);
+        self.write_zeros(new_len.saturating_sub(self.count));
+    }
+
+    /// Writes zero bytes until the total count written is aligned to `size`.
+    pub fn write_align(&mut self, size: u64) {
+        self.resize(align(self.count, size));
+    }
+}
+
+impl<W: WritableBuffer> WritableBuffer for CountingBuffer<W> {
+    #[inline]
+    fn reserve(&mut self, size: u64) -> Result<(), ()> {
+        self.buffer.reserve(size)
+    }
+
+    #[inline]
+    fn write_bytes(&mut self, val: &[u8]) {
+        self.buffer.write_bytes(val);
+        self.count += val.len() as u64;
+    }
+
+    #[inline]
+    fn write_zeros(&mut self, additional: u64) {
+        self.buffer.write_zeros(additional);
+        self.count += additional;
     }
 }
 
@@ -90,11 +178,6 @@ impl GrowableBuffer for Vec<u8> {
 
 impl WritableBuffer for Vec<u8> {
     #[inline]
-    fn len(&self) -> u64 {
-        self.len() as u64
-    }
-
-    #[inline]
     fn reserve(&mut self, size: u64) -> Result<(), ()> {
         debug_assert!(self.is_empty());
         let size = usize::try_from(size).map_err(|_| ())?;
@@ -103,14 +186,43 @@ impl WritableBuffer for Vec<u8> {
     }
 
     #[inline]
-    fn resize(&mut self, new_len: u64) {
-        debug_assert!(new_len as usize >= self.len());
-        self.resize(new_len as usize, 0);
+    fn write_bytes(&mut self, val: &[u8]) {
+        self.extend_from_slice(val)
+    }
+
+    #[inline]
+    fn write_zeros(&mut self, additional: u64) {
+        let new_len = self.len() + additional as usize;
+        self.resize(new_len, 0);
+    }
+}
+
+/// A fixed-size buffer.
+///
+/// `reserve` returns an error if the slice is too small. The slice is allowed to be
+/// larger than needed, but trailing bytes are left untouched. Writing more bytes than
+/// the slice can hold will panic.
+impl WritableBuffer for &mut [u8] {
+    #[inline]
+    fn reserve(&mut self, size: u64) -> Result<(), ()> {
+        if size > self.len() as u64 {
+            return Err(());
+        }
+        Ok(())
     }
 
     #[inline]
     fn write_bytes(&mut self, val: &[u8]) {
-        self.extend_from_slice(val)
+        let (head, tail) = core::mem::take(self).split_at_mut(val.len());
+        head.copy_from_slice(val);
+        *self = tail;
+    }
+
+    #[inline]
+    fn write_zeros(&mut self, additional: u64) {
+        let (head, tail) = core::mem::take(self).split_at_mut(additional as usize);
+        head.fill(0);
+        *self = tail;
     }
 }
 
@@ -125,7 +237,6 @@ impl WritableBuffer for Vec<u8> {
 #[derive(Debug)]
 pub struct StreamingBuffer<W> {
     writer: W,
-    len: u64,
     result: Result<(), io::Error>,
 }
 
@@ -135,7 +246,6 @@ impl<W> StreamingBuffer<W> {
     pub fn new(writer: W) -> Self {
         StreamingBuffer {
             writer,
-            len: 0,
             result: Ok(()),
         }
     }
@@ -170,22 +280,8 @@ impl<W: io::Write> GrowableBuffer for StreamingBuffer<W> {
 #[cfg(feature = "std")]
 impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {
     #[inline]
-    fn len(&self) -> u64 {
-        self.len
-    }
-
-    #[inline]
     fn reserve(&mut self, _size: u64) -> Result<(), ()> {
         Ok(())
-    }
-
-    #[inline]
-    fn resize(&mut self, new_len: u64) {
-        debug_assert!(self.len <= new_len);
-        while self.len < new_len {
-            let write_amt = (new_len - self.len).min(1024) as usize;
-            self.write_bytes(&[0; 1024][..write_amt]);
-        }
     }
 
     #[inline]
@@ -193,9 +289,6 @@ impl<W: io::Write> WritableBuffer for StreamingBuffer<W> {
         if self.result.is_ok() {
             self.result = self.writer.write_all(val);
         }
-        // Callers depend on `len` being equal to the total requested writes,
-        // even if those writes failed.
-        self.len += val.len() as u64;
     }
 }
 
@@ -260,18 +353,26 @@ pub(crate) fn align(offset: u64, size: u64) -> u64 {
     (offset + (size - 1)) & !(size - 1)
 }
 
-#[allow(dead_code)]
-pub(crate) fn write_align<W: WritableBuffer + ?Sized>(buffer: &mut W, size: u64) {
-    let new_len = align(buffer.len(), size);
-    buffer.resize(new_len);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[allow(dead_code)]
-pub(crate) fn write_pod<T: Pod, W: WritableBuffer + ?Sized>(buffer: &mut W, val: &T) {
-    buffer.write_bytes(bytes_of(val))
-}
+    #[test]
+    fn slice_buffer() {
+        let mut data = [0u8; 4];
+        assert_eq!((&mut data[..]).reserve(5), Err(()));
+        assert_eq!((&mut data[..]).reserve(4), Ok(()));
+        assert_eq!((&mut data[..]).reserve(3), Ok(()));
 
-#[allow(dead_code)]
-pub(crate) fn write_pod_slice<T: Pod, W: WritableBuffer + ?Sized>(buffer: &mut W, val: &[T]) {
-    buffer.write_bytes(bytes_of_slice(val))
+        let mut data = [0xffu8; 9];
+        let mut slice = &mut data[..];
+        let mut buffer = CountingBuffer::new(&mut slice);
+        buffer.write_bytes(&[1, 2, 3]);
+        assert_eq!(buffer.count(), 3);
+        buffer.write_zeros(2);
+        assert_eq!(buffer.count(), 5);
+        buffer.write_align(4);
+        assert_eq!(buffer.count(), 8);
+        assert_eq!(data, [1, 2, 3, 0, 0, 0, 0, 0, 0xff]);
+    }
 }

--- a/src/write/xcoff.rs
+++ b/src/write/xcoff.rs
@@ -356,6 +356,7 @@ impl<'a> Object<'a> {
         buffer
             .reserve(offset)
             .map_err(|_| Error(String::from("Cannot allocate buffer")))?;
+        let buffer = &mut CountingBuffer::new(buffer);
 
         // Write file header.
         let f_flags = match self.flags {
@@ -372,7 +373,7 @@ impl<'a> Object<'a> {
                 f_opthdr: 0.into(),
                 f_flags: f_flags.into(),
             };
-            buffer.write(&header);
+            buffer.write_pod(&header);
         } else {
             let header = xcoff::FileHeader32 {
                 f_magic: xcoff::MAGIC_32.into(),
@@ -383,7 +384,7 @@ impl<'a> Object<'a> {
                 f_opthdr: 0.into(),
                 f_flags: f_flags.into(),
             };
-            buffer.write(&header);
+            buffer.write_pod(&header);
         }
 
         // Write section headers.
@@ -420,7 +421,7 @@ impl<'a> Object<'a> {
                     s_flags: s_flags.into(),
                     s_reserve: 0.into(),
                 };
-                buffer.write(&section_header);
+                buffer.write_pod(&section_header);
             } else {
                 let section_header = xcoff::SectionHeader32 {
                     s_name: sectname,
@@ -438,7 +439,7 @@ impl<'a> Object<'a> {
                     s_nlnno: 0.into(),
                     s_flags: s_flags.into(),
                 };
-                buffer.write(&section_header);
+                buffer.write_pod(&section_header);
             }
         }
 
@@ -446,8 +447,8 @@ impl<'a> Object<'a> {
         for (index, section) in self.sections.iter().enumerate() {
             let len = section.data.len();
             if len != 0 {
-                write_align(buffer, 4);
-                debug_assert_eq!(section_offsets[index].data_offset, buffer.len());
+                buffer.write_align(4);
+                debug_assert_eq!(section_offsets[index].data_offset, buffer.count());
                 buffer.write_bytes(&section.data);
             }
         }
@@ -455,7 +456,7 @@ impl<'a> Object<'a> {
         // Write relocations.
         for (index, section) in self.sections.iter().enumerate() {
             if !section.relocations.is_empty() {
-                debug_assert_eq!(section_offsets[index].reloc_offset, buffer.len());
+                debug_assert_eq!(section_offsets[index].reloc_offset, buffer.count());
                 for reloc in &section.relocations {
                     let (r_rtype, r_rsize) =
                         if let RelocationFlags::Xcoff { r_rtype, r_rsize } = reloc.flags {
@@ -470,7 +471,7 @@ impl<'a> Object<'a> {
                             r_rsize,
                             r_rtype,
                         };
-                        buffer.write(&xcoff_rel);
+                        buffer.write_pod(&xcoff_rel);
                     } else {
                         let xcoff_rel = xcoff::Rel32 {
                             r_vaddr: (reloc.offset as u32).into(),
@@ -478,14 +479,14 @@ impl<'a> Object<'a> {
                             r_rsize,
                             r_rtype,
                         };
-                        buffer.write(&xcoff_rel);
+                        buffer.write_pod(&xcoff_rel);
                     }
                 }
             }
         }
 
         // Write symbols.
-        debug_assert_eq!(symtab_offset, buffer.len());
+        debug_assert_eq!(symtab_offset, buffer.count());
         for (index, symbol) in self.symbols.iter().enumerate() {
             let n_value = if let SymbolSection::Section(id) = symbol.section {
                 section_offsets[id.0].address + symbol.value
@@ -518,7 +519,7 @@ impl<'a> Object<'a> {
                     n_sclass,
                     n_numaux,
                 };
-                buffer.write(&xcoff_sym);
+                buffer.write_pod(&xcoff_sym);
             } else {
                 let mut sym_name = [0; 8];
                 if n_sclass == xcoff::C_FILE {
@@ -537,7 +538,7 @@ impl<'a> Object<'a> {
                     n_sclass,
                     n_numaux,
                 };
-                buffer.write(&xcoff_sym);
+                buffer.write_pod(&xcoff_sym);
             }
             // Generate auxiliary entries.
             if n_sclass == xcoff::C_FILE {
@@ -557,7 +558,7 @@ impl<'a> Object<'a> {
                         x_freserve: Default::default(),
                         x_auxtype: xcoff::AUX_FILE,
                     };
-                    buffer.write(&file_aux);
+                    buffer.write_pod(&file_aux);
                 } else {
                     let file_aux = xcoff::FileAux32 {
                         x_fname,
@@ -565,7 +566,7 @@ impl<'a> Object<'a> {
                         x_ftype: xcoff::XFT_FN,
                         x_freserve: Default::default(),
                     };
-                    buffer.write(&file_aux);
+                    buffer.write_pod(&file_aux);
                 }
             } else if n_sclass == xcoff::C_EXT
                 || n_sclass == xcoff::C_WEAKEXT
@@ -591,7 +592,7 @@ impl<'a> Object<'a> {
                         pad: 0,
                         x_auxtype: xcoff::AUX_CSECT,
                     };
-                    buffer.write(&csect_aux);
+                    buffer.write_pod(&csect_aux);
                 } else {
                     let csect_aux = xcoff::CsectAux32 {
                         x_scnlen: (scnlen as u32).into(),
@@ -602,17 +603,17 @@ impl<'a> Object<'a> {
                         x_stab: 0.into(),
                         x_snstab: 0.into(),
                     };
-                    buffer.write(&csect_aux);
+                    buffer.write_pod(&csect_aux);
                 }
             }
         }
 
         // Write string table.
-        debug_assert_eq!(strtab_offset, buffer.len());
+        debug_assert_eq!(strtab_offset, buffer.count());
         buffer.write_bytes(&u32::to_be_bytes(strtab_len));
         buffer.write_bytes(&strtab_data);
 
-        debug_assert_eq!(offset, buffer.len());
+        debug_assert_eq!(offset, buffer.count());
         Ok(())
     }
 }


### PR DESCRIPTION
Move all position tracking from WritableBuffer into CountingBuffer.
This allows WritableBuffer to be implemented for &mut [u8], which can
then be used for elf::Encoder and macho::Encoder. This may also make it
possible to support appending to a non-empty Vec, but I haven't allowed
that yet.

This removes WritableBuffer::len and WritableBuffer::resize.

Also move WritableBuffer::write_pod and write_pod_slice to a new
WritableBufferExt trait. This also replaces the write/write_slice
methods that were implemented for dyn WritableBuffer, as well as
some internal freestanding functions.