### PR TITLE
read: seal low-level traits

### DIFF
--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -290,7 +290,7 @@ pub fn anon_object_class_id<'data, R: ReadRef<'data>>(data: R) -> Result<pe::Cls
 
 /// A trait for generic access to [`pe::ImageFileHeader`] and [`pe::AnonObjectHeaderBigobj`].
 #[allow(missing_docs)]
-pub trait CoffHeader: Debug + Pod {
+pub trait CoffHeader: Debug + Pod + read::private::Sealed {
     type ImageSymbol: ImageSymbol;
     type ImageSymbolBytes: Debug + Pod;
 
@@ -337,6 +337,8 @@ pub trait CoffHeader: Debug + Pod {
     }
 }
 
+impl read::private::Sealed for pe::ImageFileHeader {}
+
 impl CoffHeader for pe::ImageFileHeader {
     type ImageSymbol = pe::ImageSymbol;
     type ImageSymbolBytes = pe::ImageSymbolBytes;
@@ -379,6 +381,8 @@ impl CoffHeader for pe::ImageFileHeader {
         Ok(header)
     }
 }
+
+impl read::private::Sealed for pe::AnonObjectHeaderBigobj {}
 
 impl CoffHeader for pe::AnonObjectHeaderBigobj {
     type ImageSymbol = pe::ImageSymbolEx;

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -535,7 +535,7 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> ObjectSymbol<'data>
 
 /// A trait for generic access to [`pe::ImageSymbol`] and [`pe::ImageSymbolEx`].
 #[allow(missing_docs)]
-pub trait ImageSymbol: Debug + Pod {
+pub trait ImageSymbol: Debug + Pod + read::private::Sealed {
     fn raw_name(&self) -> &[u8; 8];
     fn value(&self) -> u32;
     fn section_number(&self) -> pe::SymbolSection;
@@ -644,6 +644,8 @@ pub trait ImageSymbol: Debug + Pod {
     }
 }
 
+impl read::private::Sealed for pe::ImageSymbol {}
+
 impl ImageSymbol for pe::ImageSymbol {
     fn raw_name(&self) -> &[u8; 8] {
         &self.name
@@ -669,6 +671,8 @@ impl ImageSymbol for pe::ImageSymbol {
         self.number_of_aux_symbols
     }
 }
+
+impl read::private::Sealed for pe::ImageSymbolEx {}
 
 impl ImageSymbol for pe::ImageSymbolEx {
     fn raw_name(&self) -> &[u8; 8] {

--- a/src/read/elf/compression.rs
+++ b/src/read/elf/compression.rs
@@ -3,10 +3,11 @@ use core::fmt::Debug;
 use crate::elf;
 use crate::endian;
 use crate::pod::Pod;
+use crate::read;
 
 /// A trait for generic access to [`elf::CompressionHeader32`] and [`elf::CompressionHeader64`].
 #[allow(missing_docs)]
-pub trait CompressionHeader: Debug + Pod {
+pub trait CompressionHeader: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -14,6 +15,8 @@ pub trait CompressionHeader: Debug + Pod {
     fn ch_size(&self, endian: Self::Endian) -> Self::Word;
     fn ch_addralign(&self, endian: Self::Endian) -> Self::Word;
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::CompressionHeader32<Endian> {}
 
 impl<Endian: endian::Endian> CompressionHeader for elf::CompressionHeader32<Endian> {
     type Word = u32;
@@ -34,6 +37,8 @@ impl<Endian: endian::Endian> CompressionHeader for elf::CompressionHeader32<Endi
         self.ch_addralign.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::CompressionHeader64<Endian> {}
 
 impl<Endian: endian::Endian> CompressionHeader for elf::CompressionHeader64<Endian> {
     type Word = u64;

--- a/src/read/elf/dynamic.rs
+++ b/src/read/elf/dynamic.rs
@@ -5,7 +5,7 @@ use core::slice;
 use crate::elf;
 use crate::endian;
 use crate::pod::Pod;
-use crate::read::{ReadError, ReadRef, Result, SectionIndex, StringTable};
+use crate::read::{self, ReadError, ReadRef, Result, SectionIndex, StringTable};
 
 use super::{FileHeader, SectionHeader, SectionTable};
 
@@ -190,7 +190,7 @@ impl Dynamic {
 
 /// A trait for generic access to [`elf::Dyn32`] and [`elf::Dyn64`].
 #[allow(missing_docs)]
-pub trait Dyn: Debug + Pod {
+pub trait Dyn: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -245,6 +245,8 @@ pub trait Dyn: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for elf::Dyn32<Endian> {}
+
 impl<Endian: endian::Endian> Dyn for elf::Dyn32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -259,6 +261,8 @@ impl<Endian: endian::Endian> Dyn for elf::Dyn32<Endian> {
         self.d_val.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Dyn64<Endian> {}
 
 impl<Endian: endian::Endian> Dyn for elf::Dyn64<Endian> {
     type Word = u64;

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -544,7 +544,7 @@ where
 
 /// A trait for generic access to [`elf::FileHeader32`] and [`elf::FileHeader64`].
 #[allow(missing_docs)]
-pub trait FileHeader: Debug + Pod {
+pub trait FileHeader: Debug + Pod + read::private::Sealed {
     // Ideally this would be a `u64: From<Word>`, but can't express that.
     type Word: Into<u64> + Default + Copy;
     type Sword: Into<i64>;
@@ -837,6 +837,8 @@ pub trait FileHeader: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for elf::FileHeader32<Endian> {}
+
 impl<Endian: endian::Endian> FileHeader for elf::FileHeader32<Endian> {
     type Word = u32;
     type Sword = i32;
@@ -934,6 +936,8 @@ impl<Endian: endian::Endian> FileHeader for elf::FileHeader32<Endian> {
         self.e_shstrndx.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::FileHeader64<Endian> {}
 
 impl<Endian: endian::Endian> FileHeader for elf::FileHeader64<Endian> {
     type Word = u64;

--- a/src/read/elf/note.rs
+++ b/src/read/elf/note.rs
@@ -182,13 +182,15 @@ impl<'data, Elf: FileHeader> Note<'data, Elf> {
 
 /// A trait for generic access to [`elf::NoteHeader32`] and [`elf::NoteHeader64`].
 #[allow(missing_docs)]
-pub trait NoteHeader: Debug + Pod {
+pub trait NoteHeader: Debug + Pod + read::private::Sealed {
     type Endian: endian::Endian;
 
     fn n_namesz(&self, endian: Self::Endian) -> u32;
     fn n_descsz(&self, endian: Self::Endian) -> u32;
     fn n_type(&self, endian: Self::Endian) -> elf::NoteType;
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::NoteHeader32<Endian> {}
 
 impl<Endian: endian::Endian> NoteHeader for elf::NoteHeader32<Endian> {
     type Endian = Endian;
@@ -208,6 +210,8 @@ impl<Endian: endian::Endian> NoteHeader for elf::NoteHeader32<Endian> {
         self.n_type.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::NoteHeader64<Endian> {}
 
 impl<Endian: endian::Endian> NoteHeader for elf::NoteHeader64<Endian> {
     type Endian = Endian;

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -556,7 +556,7 @@ fn parse_relocation<Elf: FileHeader>(
 
 /// A trait for generic access to [`elf::Rel32`] and [`elf::Rel64`].
 #[allow(missing_docs)]
-pub trait Rel: Debug + Pod + Clone {
+pub trait Rel: Debug + Pod + Clone + read::private::Sealed {
     type Word: Into<u64>;
     type Sword: Into<i64>;
     type Endian: endian::Endian;
@@ -578,6 +578,8 @@ pub trait Rel: Debug + Pod + Clone {
         }
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Rel32<Endian> {}
 
 impl<Endian: endian::Endian> Rel for elf::Rel32<Endian> {
     type Word = u32;
@@ -604,6 +606,8 @@ impl<Endian: endian::Endian> Rel for elf::Rel32<Endian> {
         self.r_type(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Rel64<Endian> {}
 
 impl<Endian: endian::Endian> Rel for elf::Rel64<Endian> {
     type Word = u64;
@@ -633,7 +637,7 @@ impl<Endian: endian::Endian> Rel for elf::Rel64<Endian> {
 
 /// A trait for generic access to [`elf::Rela32`] and [`elf::Rela64`].
 #[allow(missing_docs)]
-pub trait Rela: Debug + Pod + Clone {
+pub trait Rela: Debug + Pod + Clone + read::private::Sealed {
     type Word: Into<u64>;
     type Sword: Into<i64>;
     type Endian: endian::Endian;
@@ -656,6 +660,8 @@ pub trait Rela: Debug + Pod + Clone {
         }
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Rela32<Endian> {}
 
 impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
     type Word = u32;
@@ -687,6 +693,8 @@ impl<Endian: endian::Endian> Rela for elf::Rela32<Endian> {
         self.r_type(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Rela64<Endian> {}
 
 impl<Endian: endian::Endian> Rela for elf::Rela64<Endian> {
     type Word = u64;
@@ -769,7 +777,7 @@ impl<'data, Elf: FileHeader> Iterator for RelrIterator<'data, Elf> {
 
 /// A trait for generic access to [`elf::Relr32`] and [`elf::Relr64`].
 #[allow(missing_docs)]
-pub trait Relr: Debug + Pod + Clone {
+pub trait Relr: Debug + Pod + Clone + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -790,6 +798,8 @@ pub trait Relr: Debug + Pod + Clone {
     fn next(offset: &mut Self::Word, bits: &mut Self::Word) -> Option<Self::Word>;
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for elf::Relr32<Endian> {}
+
 impl<Endian: endian::Endian> Relr for elf::Relr32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -805,6 +815,8 @@ impl<Endian: endian::Endian> Relr for elf::Relr32<Endian> {
         if *bits & 1 != 0 { Some(*offset) } else { None }
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Relr64<Endian> {}
 
 impl<Endian: endian::Endian> Relr for elf::Relr64<Endian> {
     type Word = u64;

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -697,7 +697,7 @@ where
 
 /// A trait for generic access to [`elf::SectionHeader32`] and [`elf::SectionHeader64`].
 #[allow(missing_docs)]
-pub trait SectionHeader: Debug + Pod {
+pub trait SectionHeader: Debug + Pod + read::private::Sealed {
     type Elf: FileHeader<SectionHeader = Self, Endian = Self::Endian, Word = Self::Word>;
     type Word: Into<u64>;
     type Endian: endian::Endian;
@@ -1201,6 +1201,8 @@ pub trait SectionHeader: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for elf::SectionHeader32<Endian> {}
+
 impl<Endian: endian::Endian> SectionHeader for elf::SectionHeader32<Endian> {
     type Elf = elf::FileHeader32<Endian>;
     type Word = u32;
@@ -1256,6 +1258,8 @@ impl<Endian: endian::Endian> SectionHeader for elf::SectionHeader32<Endian> {
         self.sh_entsize.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::SectionHeader64<Endian> {}
 
 impl<Endian: endian::Endian> SectionHeader for elf::SectionHeader64<Endian> {
     type Word = u64;

--- a/src/read/elf/segment.rs
+++ b/src/read/elf/segment.rs
@@ -160,7 +160,7 @@ where
 
 /// A trait for generic access to [`elf::ProgramHeader32`] and [`elf::ProgramHeader64`].
 #[allow(missing_docs)]
-pub trait ProgramHeader: Debug + Pod {
+pub trait ProgramHeader: Debug + Pod + read::private::Sealed {
     type Elf: FileHeader<ProgramHeader = Self, Endian = Self::Endian, Word = Self::Word>;
     type Word: Into<u64>;
     type Endian: endian::Endian;
@@ -283,6 +283,8 @@ pub trait ProgramHeader: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for elf::ProgramHeader32<Endian> {}
+
 impl<Endian: endian::Endian> ProgramHeader for elf::ProgramHeader32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -328,6 +330,8 @@ impl<Endian: endian::Endian> ProgramHeader for elf::ProgramHeader32<Endian> {
         self.p_align.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::ProgramHeader64<Endian> {}
 
 impl<Endian: endian::Endian> ProgramHeader for elf::ProgramHeader64<Endian> {
     type Word = u64;

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -494,7 +494,7 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
 
 /// A trait for generic access to [`elf::Sym32`] and [`elf::Sym64`].
 #[allow(missing_docs)]
-pub trait Sym: Debug + Pod {
+pub trait Sym: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -571,6 +571,8 @@ pub trait Sym: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for elf::Sym32<Endian> {}
+
 impl<Endian: endian::Endian> Sym for elf::Sym32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -620,6 +622,8 @@ impl<Endian: endian::Endian> Sym for elf::Sym32<Endian> {
         self.st_size.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for elf::Sym64<Endian> {}
 
 impl<Endian: endian::Endian> Sym for elf::Sym64<Endian> {
     type Word = u64;

--- a/src/read/macho/fat.rs
+++ b/src/read/macho/fat.rs
@@ -1,7 +1,7 @@
 use crate::endian::BigEndian;
 use crate::macho;
 use crate::pod::Pod;
-use crate::read::{Architecture, Error, ReadError, ReadRef, Result};
+use crate::read::{self, Architecture, Error, ReadError, ReadRef, Result};
 
 pub use macho::{FatArch32, FatArch64, FatHeader};
 
@@ -56,7 +56,7 @@ impl<'data, Fat: FatArch> MachOFatFile<'data, Fat> {
 
 /// A trait for generic access to [`macho::FatArch32`] and [`macho::FatArch64`].
 #[allow(missing_docs)]
-pub trait FatArch: Pod {
+pub trait FatArch: Pod + read::private::Sealed {
     type Word: Into<u64>;
     const MAGIC: u32;
 
@@ -89,6 +89,8 @@ pub trait FatArch: Pod {
     }
 }
 
+impl read::private::Sealed for FatArch32 {}
+
 impl FatArch for FatArch32 {
     type Word = u32;
     const MAGIC: u32 = macho::FAT_MAGIC;
@@ -113,6 +115,8 @@ impl FatArch for FatArch32 {
         self.align.get(BigEndian)
     }
 }
+
+impl read::private::Sealed for FatArch64 {}
 
 impl FatArch for FatArch64 {
     type Word = u64;

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -725,7 +725,7 @@ where
 
 /// A trait for generic access to [`macho::MachHeader32`] and [`macho::MachHeader64`].
 #[allow(missing_docs)]
-pub trait MachHeader: Debug + Pod {
+pub trait MachHeader: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
     type Segment: Segment<Endian = Self::Endian, Section = Self::Section>;
@@ -814,6 +814,8 @@ pub trait MachHeader: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for macho::MachHeader32<Endian> {}
+
 impl<Endian: endian::Endian> MachHeader for macho::MachHeader32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -861,6 +863,8 @@ impl<Endian: endian::Endian> MachHeader for macho::MachHeader32<Endian> {
         self.flags.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for macho::MachHeader64<Endian> {}
 
 impl<Endian: endian::Endian> MachHeader for macho::MachHeader64<Endian> {
     type Word = u64;

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -287,7 +287,7 @@ impl<'data, Mach: MachHeader, R: ReadRef<'data>> MachOSectionInternal<'data, Mac
 
 /// A trait for generic access to [`macho::Section32`] and [`macho::Section64`].
 #[allow(missing_docs)]
-pub trait Section: Debug + Pod {
+pub trait Section: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -419,6 +419,8 @@ pub trait Section: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for macho::Section32<Endian> {}
+
 impl<Endian: endian::Endian> Section for macho::Section32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -457,6 +459,8 @@ impl<Endian: endian::Endian> Section for macho::Section32<Endian> {
         self.reserved2.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for macho::Section64<Endian> {}
 
 impl<Endian: endian::Endian> Section for macho::Section64<Endian> {
     type Word = u64;

--- a/src/read/macho/segment.rs
+++ b/src/read/macho/segment.rs
@@ -179,7 +179,7 @@ pub(super) struct MachOSegmentInternal<'data, Mach: MachHeader, R: ReadRef<'data
 
 /// A trait for generic access to [`macho::SegmentCommand32`] and [`macho::SegmentCommand64`].
 #[allow(missing_docs)]
-pub trait Segment: Debug + Pod {
+pub trait Segment: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
     type Section: Section<Endian = Self::Endian>;
@@ -238,6 +238,8 @@ pub trait Segment: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for macho::SegmentCommand32<Endian> {}
+
 impl<Endian: endian::Endian> Segment for macho::SegmentCommand32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -281,6 +283,8 @@ impl<Endian: endian::Endian> Segment for macho::SegmentCommand32<Endian> {
         self.flags.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for macho::SegmentCommand64<Endian> {}
 
 impl<Endian: endian::Endian> Segment for macho::SegmentCommand64<Endian> {
     type Word = u64;

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -484,7 +484,7 @@ where
 
 /// A trait for generic access to [`macho::Nlist32`] and [`macho::Nlist64`].
 #[allow(missing_docs)]
-pub trait Nlist: Debug + Pod {
+pub trait Nlist: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type Endian: endian::Endian;
 
@@ -538,6 +538,8 @@ pub trait Nlist: Debug + Pod {
     }
 }
 
+impl<Endian: endian::Endian> read::private::Sealed for macho::Nlist32<Endian> {}
+
 impl<Endian: endian::Endian> Nlist for macho::Nlist32<Endian> {
     type Word = u32;
     type Endian = Endian;
@@ -558,6 +560,8 @@ impl<Endian: endian::Endian> Nlist for macho::Nlist32<Endian> {
         self.n_value.get(endian)
     }
 }
+
+impl<Endian: endian::Endian> read::private::Sealed for macho::Nlist64<Endian> {}
 
 impl<Endian: endian::Endian> Nlist for macho::Nlist64<Endian> {
     type Word = u64;

--- a/src/read/pe/file.rs
+++ b/src/read/pe/file.rs
@@ -595,7 +595,7 @@ pub fn optional_header_magic<'data, R: ReadRef<'data>>(data: R) -> Result<u16> {
 
 /// A trait for generic access to [`pe::ImageNtHeaders32`] and [`pe::ImageNtHeaders64`].
 #[allow(missing_docs)]
-pub trait ImageNtHeaders: Debug + Pod {
+pub trait ImageNtHeaders: Debug + Pod + read::private::Sealed {
     type ImageOptionalHeader: ImageOptionalHeader;
     type ImageThunkData: ImageThunkData;
 
@@ -681,7 +681,7 @@ pub trait ImageNtHeaders: Debug + Pod {
 
 /// A trait for generic access to [`pe::ImageOptionalHeader32`] and [`pe::ImageOptionalHeader64`].
 #[allow(missing_docs)]
-pub trait ImageOptionalHeader: Debug + Pod {
+pub trait ImageOptionalHeader: Debug + Pod + read::private::Sealed {
     // Standard fields.
     fn magic(&self) -> u16;
     fn major_linker_version(&self) -> u8;
@@ -717,6 +717,8 @@ pub trait ImageOptionalHeader: Debug + Pod {
     fn number_of_rva_and_sizes(&self) -> u32;
 }
 
+impl read::private::Sealed for pe::ImageNtHeaders32 {}
+
 impl ImageNtHeaders for pe::ImageNtHeaders32 {
     type ImageOptionalHeader = pe::ImageOptionalHeader32;
     type ImageThunkData = pe::ImageThunkData32;
@@ -746,6 +748,8 @@ impl ImageNtHeaders for pe::ImageNtHeaders32 {
         &self.optional_header
     }
 }
+
+impl read::private::Sealed for pe::ImageOptionalHeader32 {}
 
 impl ImageOptionalHeader for pe::ImageOptionalHeader32 {
     #[inline]
@@ -899,6 +903,8 @@ impl ImageOptionalHeader for pe::ImageOptionalHeader32 {
     }
 }
 
+impl read::private::Sealed for pe::ImageNtHeaders64 {}
+
 impl ImageNtHeaders for pe::ImageNtHeaders64 {
     type ImageOptionalHeader = pe::ImageOptionalHeader64;
     type ImageThunkData = pe::ImageThunkData64;
@@ -928,6 +934,8 @@ impl ImageNtHeaders for pe::ImageNtHeaders64 {
         &self.optional_header
     }
 }
+
+impl read::private::Sealed for pe::ImageOptionalHeader64 {}
 
 impl ImageOptionalHeader for pe::ImageOptionalHeader64 {
     #[inline]

--- a/src/read/pe/import.rs
+++ b/src/read/pe/import.rs
@@ -4,7 +4,7 @@ use core::mem;
 use crate::endian::{LittleEndian as LE, U16};
 use crate::pe;
 use crate::pod::Pod;
-use crate::read::{Bytes, ReadError, ReadRef, Result};
+use crate::read::{self, Bytes, ReadError, ReadRef, Result};
 
 use super::{ImageNtHeaders, SectionTable};
 
@@ -238,7 +238,7 @@ pub enum Import<'data> {
 
 /// A trait for generic access to [`pe::ImageThunkData32`] and [`pe::ImageThunkData64`].
 #[allow(missing_docs)]
-pub trait ImageThunkData: Debug + Pod {
+pub trait ImageThunkData: Debug + Pod + read::private::Sealed {
     /// Return the raw thunk value.
     fn raw(self) -> u64;
 
@@ -255,6 +255,8 @@ pub trait ImageThunkData: Debug + Pod {
     /// Does not check the ordinal flag.
     fn address(self) -> u32;
 }
+
+impl read::private::Sealed for pe::ImageThunkData64 {}
 
 impl ImageThunkData for pe::ImageThunkData64 {
     fn raw(self) -> u64 {
@@ -273,6 +275,8 @@ impl ImageThunkData for pe::ImageThunkData64 {
         self.0.get(LE) as u32 & 0x7fff_ffff
     }
 }
+
+impl read::private::Sealed for pe::ImageThunkData32 {}
 
 impl ImageThunkData for pe::ImageThunkData32 {
     fn raw(self) -> u64 {

--- a/src/read/xcoff/file.rs
+++ b/src/read/xcoff/file.rs
@@ -312,7 +312,7 @@ where
 
 /// A trait for generic access to [`xcoff::FileHeader32`] and [`xcoff::FileHeader64`].
 #[allow(missing_docs)]
-pub trait FileHeader: Debug + Pod {
+pub trait FileHeader: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type AuxHeader: AuxHeader<Word = Self::Word>;
     type SectionHeader: SectionHeader<Word = Self::Word, Rel = Self::Rel>;
@@ -395,6 +395,8 @@ pub trait FileHeader: Debug + Pod {
     }
 }
 
+impl read::private::Sealed for xcoff::FileHeader32 {}
+
 impl FileHeader for xcoff::FileHeader32 {
     type Word = u32;
     type AuxHeader = xcoff::AuxHeader32;
@@ -436,6 +438,8 @@ impl FileHeader for xcoff::FileHeader32 {
         self.f_flags.get(BE)
     }
 }
+
+impl read::private::Sealed for xcoff::FileHeader64 {}
 
 impl FileHeader for xcoff::FileHeader64 {
     type Word = u64;
@@ -481,7 +485,7 @@ impl FileHeader for xcoff::FileHeader64 {
 
 /// A trait for generic access to [`xcoff::AuxHeader32`] and [`xcoff::AuxHeader64`].
 #[allow(missing_docs)]
-pub trait AuxHeader: Debug + Pod {
+pub trait AuxHeader: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
 
     fn o_mflag(&self) -> u16;
@@ -515,6 +519,8 @@ pub trait AuxHeader: Debug + Pod {
     fn o_sntbss(&self) -> u16;
     fn o_x64flags(&self) -> Option<u16>;
 }
+
+impl read::private::Sealed for xcoff::AuxHeader32 {}
 
 impl AuxHeader for xcoff::AuxHeader32 {
     type Word = u32;
@@ -639,6 +645,8 @@ impl AuxHeader for xcoff::AuxHeader32 {
         None
     }
 }
+
+impl read::private::Sealed for xcoff::AuxHeader64 {}
 
 impl AuxHeader for xcoff::AuxHeader64 {
     type Word = u64;

--- a/src/read/xcoff/relocation.rs
+++ b/src/read/xcoff/relocation.rs
@@ -5,8 +5,8 @@ use core::slice;
 use crate::endian::BigEndian as BE;
 use crate::pod::Pod;
 use crate::read::{
-    ReadRef, Relocation, RelocationEncoding, RelocationFlags, RelocationKind, RelocationTarget,
-    SymbolIndex,
+    self, ReadRef, Relocation, RelocationEncoding, RelocationFlags, RelocationKind,
+    RelocationTarget, SymbolIndex,
 };
 use crate::xcoff;
 
@@ -86,7 +86,7 @@ where
 
 /// A trait for generic access to [`xcoff::Rel32`] and [`xcoff::Rel64`].
 #[allow(missing_docs)]
-pub trait Rel: Debug + Pod {
+pub trait Rel: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     fn r_vaddr(&self) -> Self::Word;
     fn r_symndx(&self) -> u32;
@@ -97,6 +97,8 @@ pub trait Rel: Debug + Pod {
         SymbolIndex(self.r_symndx() as usize)
     }
 }
+
+impl read::private::Sealed for xcoff::Rel32 {}
 
 impl Rel for xcoff::Rel32 {
     type Word = u32;
@@ -117,6 +119,8 @@ impl Rel for xcoff::Rel32 {
         self.r_rtype
     }
 }
+
+impl read::private::Sealed for xcoff::Rel64 {}
 
 impl Rel for xcoff::Rel64 {
     type Word = u64;

--- a/src/read/xcoff/section.rs
+++ b/src/read/xcoff/section.rs
@@ -286,7 +286,7 @@ where
 
 /// A trait for generic access to [`xcoff::SectionHeader32`] and [`xcoff::SectionHeader64`].
 #[allow(missing_docs)]
-pub trait SectionHeader: Debug + Pod {
+pub trait SectionHeader: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
     type HalfWord: Into<u32>;
     type Xcoff: FileHeader<SectionHeader = Self, Word = Self::Word>;
@@ -332,6 +332,8 @@ pub trait SectionHeader: Debug + Pod {
     /// Read the relocations.
     fn relocations<'data, R: ReadRef<'data>>(&self, data: R) -> read::Result<&'data [Self::Rel]>;
 }
+
+impl read::private::Sealed for xcoff::SectionHeader32 {}
 
 impl SectionHeader for xcoff::SectionHeader32 {
     type Word = u32;
@@ -394,6 +396,8 @@ impl SectionHeader for xcoff::SectionHeader32 {
             .read_error("Invalid XCOFF relocation offset or number")
     }
 }
+
+impl read::private::Sealed for xcoff::SectionHeader64 {}
 
 impl SectionHeader for xcoff::SectionHeader64 {
     type Word = u64;

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -542,7 +542,7 @@ impl<'data, 'file, Xcoff: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
 
 /// A trait for generic access to [`xcoff::Symbol32`] and [`xcoff::Symbol64`].
 #[allow(missing_docs)]
-pub trait Symbol: Debug + Pod {
+pub trait Symbol: Debug + Pod + read::private::Sealed {
     type Word: Into<u64>;
 
     fn n_value(&self) -> Self::Word;
@@ -594,6 +594,8 @@ pub trait Symbol: Debug + Pod {
     }
 }
 
+impl read::private::Sealed for xcoff::Symbol64 {}
+
 impl Symbol for xcoff::Symbol64 {
     type Word = u64;
 
@@ -631,6 +633,8 @@ impl Symbol for xcoff::Symbol64 {
             .read_error("Invalid XCOFF symbol name offset")
     }
 }
+
+impl read::private::Sealed for xcoff::Symbol32 {}
 
 impl Symbol for xcoff::Symbol32 {
     type Word = u32;
@@ -686,7 +690,7 @@ impl Symbol for xcoff::Symbol32 {
 
 /// A trait for generic access to [`xcoff::FileAux32`] and [`xcoff::FileAux64`].
 #[allow(missing_docs)]
-pub trait FileAux: Debug + Pod {
+pub trait FileAux: Debug + Pod + read::private::Sealed {
     fn x_fname(&self) -> &[u8; 8];
     fn x_ftype(&self) -> xcoff::FileAuxType;
     fn x_auxtype(&self) -> Option<xcoff::AuxType>;
@@ -721,6 +725,8 @@ pub trait FileAux: Debug + Pod {
     }
 }
 
+impl read::private::Sealed for xcoff::FileAux64 {}
+
 impl FileAux for xcoff::FileAux64 {
     fn x_fname(&self) -> &[u8; 8] {
         &self.x_fname
@@ -734,6 +740,8 @@ impl FileAux for xcoff::FileAux64 {
         Some(self.x_auxtype)
     }
 }
+
+impl read::private::Sealed for xcoff::FileAux32 {}
 
 impl FileAux for xcoff::FileAux32 {
     fn x_fname(&self) -> &[u8; 8] {
@@ -751,7 +759,7 @@ impl FileAux for xcoff::FileAux32 {
 
 /// A trait for generic access to [`xcoff::CsectAux32`] and [`xcoff::CsectAux64`].
 #[allow(missing_docs)]
-pub trait CsectAux: Debug + Pod {
+pub trait CsectAux: Debug + Pod + read::private::Sealed {
     fn x_scnlen(&self) -> u64;
     fn x_parmhash(&self) -> u32;
     fn x_snhash(&self) -> u16;
@@ -768,6 +776,8 @@ pub trait CsectAux: Debug + Pod {
         self.x_smtyp().typ()
     }
 }
+
+impl read::private::Sealed for xcoff::CsectAux64 {}
 
 impl CsectAux for xcoff::CsectAux64 {
     fn x_scnlen(&self) -> u64 {
@@ -802,6 +812,8 @@ impl CsectAux for xcoff::CsectAux64 {
         Some(self.x_auxtype)
     }
 }
+
+impl read::private::Sealed for xcoff::CsectAux32 {}
 
 impl CsectAux for xcoff::CsectAux32 {
     fn x_scnlen(&self) -> u64 {


### PR DESCRIPTION
These were never intended to be implemented for external types.