### PR TITLE
read/coff: rename trait ImageSymbol to Symbol

### DIFF
--- a/crates/examples/src/readobj/pe.rs
+++ b/crates/examples/src/readobj/pe.rs
@@ -1,7 +1,6 @@
 use super::*;
 use object::LittleEndian as LE;
 use object::pe::*;
-use object::read::coff::ImageSymbol as _;
 use object::read::coff::*;
 use object::read::pe::*;
 use object::{Bytes, U32, U64};

--- a/src/read/coff/comdat.rs
+++ b/src/read/coff/comdat.rs
@@ -6,7 +6,7 @@ use crate::read::{
     self, ComdatKind, ObjectComdat, ReadError, ReadRef, Result, SectionIndex, SymbolIndex,
 };
 
-use super::{CoffFile, CoffHeader, ImageSymbol};
+use super::{CoffFile, CoffHeader, Symbol};
 
 /// An iterator for the COMDAT section groups in a [`CoffBigFile`](super::CoffBigFile).
 pub type CoffBigComdatIterator<'data, 'file, R = &'data [u8]> =
@@ -68,7 +68,7 @@ pub struct CoffComdat<
 > {
     file: &'file CoffFile<'data, R, Coff>,
     symbol_index: SymbolIndex,
-    symbol: &'data Coff::ImageSymbol,
+    symbol: &'data Coff::Symbol,
     section_index: u32,
     selection: pe::ComdatSelection,
 }
@@ -76,7 +76,7 @@ pub struct CoffComdat<
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> CoffComdat<'data, 'file, R, Coff> {
     fn parse(
         file: &'file CoffFile<'data, R, Coff>,
-        section_symbol: &'data Coff::ImageSymbol,
+        section_symbol: &'data Coff::Symbol,
         index: SymbolIndex,
     ) -> Option<CoffComdat<'data, 'file, R, Coff>> {
         // Must be a section symbol.

--- a/src/read/coff/file.rs
+++ b/src/read/coff/file.rs
@@ -11,8 +11,8 @@ use crate::{SkipDebugList, pe};
 
 use super::{
     CoffComdat, CoffComdatIterator, CoffSection, CoffSectionIterator, CoffSegment,
-    CoffSegmentIterator, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, ImageSymbol,
-    SectionTable, SymbolTable,
+    CoffSegmentIterator, CoffSymbol, CoffSymbolIterator, CoffSymbolTable, SectionTable, Symbol,
+    SymbolTable,
 };
 
 /// The common parts of `PeFile` and `CoffFile`.
@@ -291,8 +291,8 @@ pub fn anon_object_class_id<'data, R: ReadRef<'data>>(data: R) -> Result<pe::Cls
 /// A trait for generic access to [`pe::ImageFileHeader`] and [`pe::AnonObjectHeaderBigobj`].
 #[allow(missing_docs)]
 pub trait CoffHeader: Debug + Pod + read::private::Sealed {
-    type ImageSymbol: ImageSymbol;
-    type ImageSymbolBytes: Debug + Pod;
+    type Symbol: Symbol;
+    type SymbolBytes: Debug + Pod;
 
     /// Return true if this type is [`pe::AnonObjectHeaderBigobj`].
     ///
@@ -340,8 +340,8 @@ pub trait CoffHeader: Debug + Pod + read::private::Sealed {
 impl read::private::Sealed for pe::ImageFileHeader {}
 
 impl CoffHeader for pe::ImageFileHeader {
-    type ImageSymbol = pe::ImageSymbol;
-    type ImageSymbolBytes = pe::ImageSymbolBytes;
+    type Symbol = pe::ImageSymbol;
+    type SymbolBytes = pe::ImageSymbolBytes;
 
     fn is_type_bigobj() -> bool {
         false
@@ -385,8 +385,8 @@ impl CoffHeader for pe::ImageFileHeader {
 impl read::private::Sealed for pe::AnonObjectHeaderBigobj {}
 
 impl CoffHeader for pe::AnonObjectHeaderBigobj {
-    type ImageSymbol = pe::ImageSymbolEx;
-    type ImageSymbolBytes = pe::ImageSymbolExBytes;
+    type Symbol = pe::ImageSymbolEx;
+    type SymbolBytes = pe::ImageSymbolExBytes;
 
     fn is_type_bigobj() -> bool {
         true

--- a/src/read/coff/mod.rs
+++ b/src/read/coff/mod.rs
@@ -22,7 +22,7 @@
 //! ### Example for low level API
 //!  ```no_run
 //! use object::pe;
-//! use object::read::coff::{CoffHeader, ImageSymbol as _};
+//! use object::read::coff::{CoffHeader, Symbol};
 //! use std::error::Error;
 //! use std::fs;
 //!

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -26,7 +26,7 @@ where
     R: ReadRef<'data>,
     Coff: CoffHeader,
 {
-    symbols: &'data [Coff::ImageSymbolBytes],
+    symbols: &'data [Coff::SymbolBytes],
     strings: StringTable<'data, R>,
 }
 
@@ -98,8 +98,8 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader> SymbolTable<'data, R, Coff> {
 
     /// Return the symbol table entry at the given index.
     #[inline]
-    pub fn symbol(&self, index: SymbolIndex) -> Result<&'data Coff::ImageSymbol> {
-        self.get::<Coff::ImageSymbol>(index, 0)
+    pub fn symbol(&self, index: SymbolIndex) -> Result<&'data Coff::Symbol> {
+        self.get::<Coff::Symbol>(index, 0)
     }
 
     /// Return the auxiliary function symbol for the symbol table entry at the given index.
@@ -157,7 +157,7 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader> SymbolTable<'data, R, Coff> {
     }
 
     /// Construct a map from addresses to a user-defined map entry.
-    pub fn map<Entry: SymbolMapEntry, F: Fn(&'data Coff::ImageSymbol) -> Option<Entry>>(
+    pub fn map<Entry: SymbolMapEntry, F: Fn(&'data Coff::Symbol) -> Option<Entry>>(
         &self,
         f: F,
     ) -> SymbolMap<Entry> {
@@ -190,7 +190,7 @@ where
 impl<'data, 'table, R: ReadRef<'data>, Coff: CoffHeader> Iterator
     for SymbolIterator<'data, 'table, R, Coff>
 {
-    type Item = (SymbolIndex, &'data Coff::ImageSymbol);
+    type Item = (SymbolIndex, &'data Coff::Symbol);
 
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.index;
@@ -317,19 +317,19 @@ where
 {
     pub(crate) file: &'file CoffCommon<'data, R, Coff>,
     pub(crate) index: SymbolIndex,
-    pub(crate) symbol: &'data Coff::ImageSymbol,
+    pub(crate) symbol: &'data Coff::Symbol,
 }
 
 impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> CoffSymbol<'data, 'file, R, Coff> {
     #[inline]
-    /// Get the raw `ImageSymbol` struct.
+    /// Get the raw symbol struct.
     #[deprecated(note = "Use `coff_symbol` instead")]
-    pub fn raw_symbol(&self) -> &'data Coff::ImageSymbol {
+    pub fn raw_symbol(&self) -> &'data Coff::Symbol {
         self.symbol
     }
 
-    /// Get the raw `ImageSymbol` struct.
-    pub fn coff_symbol(&self) -> &'data Coff::ImageSymbol {
+    /// Get the raw symbol struct.
+    pub fn coff_symbol(&self) -> &'data Coff::Symbol {
         self.symbol
     }
 }
@@ -535,7 +535,7 @@ impl<'data, 'file, R: ReadRef<'data>, Coff: CoffHeader> ObjectSymbol<'data>
 
 /// A trait for generic access to [`pe::ImageSymbol`] and [`pe::ImageSymbolEx`].
 #[allow(missing_docs)]
-pub trait ImageSymbol: Debug + Pod + read::private::Sealed {
+pub trait Symbol: Debug + Pod + read::private::Sealed {
     fn raw_name(&self) -> &[u8; 8];
     fn value(&self) -> u32;
     fn section_number(&self) -> pe::SymbolSection;
@@ -646,7 +646,7 @@ pub trait ImageSymbol: Debug + Pod + read::private::Sealed {
 
 impl read::private::Sealed for pe::ImageSymbol {}
 
-impl ImageSymbol for pe::ImageSymbol {
+impl Symbol for pe::ImageSymbol {
     fn raw_name(&self) -> &[u8; 8] {
         &self.name
     }
@@ -674,7 +674,7 @@ impl ImageSymbol for pe::ImageSymbol {
 
 impl read::private::Sealed for pe::ImageSymbolEx {}
 
-impl ImageSymbol for pe::ImageSymbolEx {
+impl Symbol for pe::ImageSymbolEx {
     fn raw_name(&self) -> &[u8; 8] {
         &self.name
     }


### PR DESCRIPTION
Also rename CoffHeader::ImageSymbol and CoffHeader::ImageSymbolBytes.

This avoids the name overlap with pe::ImageSymbol, which is commonly used at the same time.