### PR TITLE
read/macho: add LoadCommandData::offset

### DIFF
--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -788,13 +788,16 @@ pub trait MachHeader: Debug + Pod + read::private::Sealed {
         data: R,
         header_offset: u64,
     ) -> Result<LoadCommandIterator<'data, Self::Endian>> {
+        let header_size = mem::size_of::<Self>() as u64;
         let data = data
-            .read_bytes_at(
-                header_offset + mem::size_of::<Self>() as u64,
-                self.sizeofcmds(endian).into(),
-            )
+            .read_bytes_at(header_offset + header_size, self.sizeofcmds(endian).into())
             .read_error("Invalid Mach-O load command table size")?;
-        Ok(LoadCommandIterator::new(endian, data, self.ncmds(endian)))
+        Ok(LoadCommandIterator::new(
+            endian,
+            data,
+            self.ncmds(endian),
+            header_size,
+        ))
     }
 
     /// Return the UUID from the `LC_UUID` load command, if one is present.

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -13,14 +13,16 @@ pub struct LoadCommandIterator<'data, E: Endian> {
     endian: E,
     data: Bytes<'data>,
     ncmds: u32,
+    offset: u64,
 }
 
 impl<'data, E: Endian> LoadCommandIterator<'data, E> {
-    pub(super) fn new(endian: E, data: &'data [u8], ncmds: u32) -> Self {
+    pub(super) fn new(endian: E, data: &'data [u8], ncmds: u32, offset: u64) -> Self {
         LoadCommandIterator {
             endian,
             data: Bytes(data),
             ncmds,
+            offset,
         }
     }
 
@@ -53,8 +55,11 @@ impl<'data, E: Endian> LoadCommandIterator<'data, E> {
             .data
             .read_bytes(cmdsize)
             .read_error("Invalid Mach-O load command size")?;
+        let offset = self.offset;
+        self.offset += cmdsize as u64;
         Ok(LoadCommandData {
             cmd,
+            offset,
             data,
             marker: Default::default(),
         })
@@ -73,6 +78,7 @@ impl<'data, E: Endian> Iterator for LoadCommandIterator<'data, E> {
 #[derive(Debug, Clone, Copy)]
 pub struct LoadCommandData<'data, E: Endian> {
     cmd: macho::LoadCommandType,
+    offset: u64,
     // Includes the header.
     data: Bytes<'data>,
     marker: PhantomData<E>,
@@ -89,6 +95,11 @@ impl<'data, E: Endian> LoadCommandData<'data, E> {
     /// Return the `cmdsize` field of the [`macho::LoadCommand`].
     pub fn cmdsize(&self) -> u32 {
         self.data.len() as u32
+    }
+
+    /// Return the file offset of the command, relative to the start of the Mach-O header.
+    pub fn offset(&self) -> u64 {
+        self.offset
     }
 
     /// Parse the data as the given type.
@@ -533,13 +544,13 @@ mod tests {
     fn cmd_size_invalid() {
         #[repr(align(16))]
         struct Align<const N: usize>([u8; N]);
-        let mut commands = LoadCommandIterator::new(LittleEndian, &Align([0; 8]).0, 10);
+        let mut commands = LoadCommandIterator::new(LittleEndian, &Align([0; 8]).0, 10, 0);
         assert!(commands.next().is_err());
         let mut commands =
-            LoadCommandIterator::new(LittleEndian, &Align([0, 0, 0, 0, 7, 0, 0, 0, 0]).0, 10);
+            LoadCommandIterator::new(LittleEndian, &Align([0, 0, 0, 0, 7, 0, 0, 0, 0]).0, 10, 0);
         assert!(commands.next().is_err());
         let mut commands =
-            LoadCommandIterator::new(LittleEndian, &Align([0, 0, 0, 0, 8, 0, 0, 0, 0]).0, 10);
+            LoadCommandIterator::new(LittleEndian, &Align([0, 0, 0, 0, 8, 0, 0, 0, 0]).0, 10, 0);
         assert!(commands.next().is_ok());
     }
 

--- a/tests/read/macho.rs
+++ b/tests/read/macho.rs
@@ -109,3 +109,37 @@ fn test_go_macho() {
         }
     }
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn test_macho_load_command_offset() {
+    use object::LittleEndian;
+    use object::read::macho::MachOFile64;
+
+    let path = std::path::Path::new("testfiles/macho").join("base-x86_64");
+    let data = std::fs::read(&path).unwrap();
+    let object = MachOFile64::<LittleEndian>::parse(&*data).unwrap();
+
+    let mut commands = object.macho_load_commands().unwrap();
+
+    let command = commands.next().unwrap().unwrap();
+    let offset = command.offset();
+    let cmdsize = command.cmdsize();
+    assert_eq!(offset, 32);
+    assert_eq!(
+        &data[offset as usize..][..cmdsize as usize],
+        command.raw_data()
+    );
+
+    let command = commands.last().unwrap().unwrap();
+    let offset = command.offset();
+    let cmdsize = command.cmdsize();
+    assert_eq!(
+        offset,
+        (32 + object.macho_header().sizeofcmds.get(LittleEndian) - cmdsize) as u64
+    );
+    assert_eq!(
+        &data[offset as usize..][..cmdsize as usize],
+        command.raw_data()
+    );
+}


### PR DESCRIPTION
This is useful when patching load commands.