### PR TITLE
read: malformed data handling improvements

### DIFF
--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -585,7 +585,8 @@ pub trait Symbol: Debug + Pod + read::private::Sealed {
         let section = sections.section(section_index)?;
         let virtual_address = u64::from(section.virtual_address.get(LE));
         let value = u64::from(self.value());
-        Ok(Some(image_base + virtual_address + value))
+        let address = image_base.wrapping_add(virtual_address).wrapping_add(value);
+        Ok(Some(address))
     }
 
     /// Return the section index for the symbol.

--- a/src/read/elf/hash.rs
+++ b/src/read/elf/hash.rs
@@ -41,12 +41,18 @@ impl<'data, Elf: FileHeader> HashTable<'data, Elf> {
         self.chains.len() as u32
     }
 
-    fn bucket(&self, endian: Elf::Endian, hash: u32) -> SymbolIndex {
-        SymbolIndex(self.buckets[(hash as usize) % self.buckets.len()].get(endian) as usize)
+    fn bucket(&self, endian: Elf::Endian, hash: u32) -> Option<SymbolIndex> {
+        let bucket_count = self.buckets.len();
+        if bucket_count == 0 {
+            return None;
+        }
+        Some(SymbolIndex(
+            self.buckets[(hash as usize) % bucket_count].get(endian) as usize,
+        ))
     }
 
-    fn chain(&self, endian: Elf::Endian, index: SymbolIndex) -> SymbolIndex {
-        SymbolIndex(self.chains[index.0].get(endian) as usize)
+    fn chain(&self, endian: Elf::Endian, index: SymbolIndex) -> Option<SymbolIndex> {
+        Some(SymbolIndex(self.chains.get(index.0)?.get(endian) as usize))
     }
 
     /// Use the hash table to find the symbol table entry with the given name, hash and version.
@@ -60,7 +66,7 @@ impl<'data, Elf: FileHeader> HashTable<'data, Elf> {
         versions: &VersionTable<'data, Elf>,
     ) -> Option<(SymbolIndex, &'data Elf::Sym)> {
         // Get the chain start from the bucket for this hash.
-        let mut index = self.bucket(endian, hash);
+        let mut index = self.bucket(endian, hash)?;
         // Avoid infinite loop.
         let mut i = 0;
         let strings = symbols.strings();
@@ -72,7 +78,7 @@ impl<'data, Elf: FileHeader> HashTable<'data, Elf> {
                     return Some((index, symbol));
                 }
             }
-            index = self.chain(endian, index);
+            index = self.chain(endian, index)?;
             i += 1;
         }
         None
@@ -144,30 +150,31 @@ impl<'data, Elf: FileHeader> GnuHashTable<'data, Elf> {
         }
 
         // Find the highest chain index in a bucket.
-        let mut max_symbol = 0;
-        for bucket in self.buckets {
-            let bucket = bucket.get(endian);
-            if max_symbol < bucket {
-                max_symbol = bucket;
-            }
-        }
+        let max_bucket = self.buckets.iter().map(|b| b.get(endian)).max()?;
 
         // Find the end of the chain.
+        let mut chain_length = 0;
         for value in self
             .values
-            .get(max_symbol.checked_sub(self.symbol_base)? as usize..)?
+            .get(max_bucket.checked_sub(self.symbol_base)? as usize..)?
         {
-            max_symbol += 1;
+            chain_length += 1;
             if value.get(endian) & 1 != 0 {
-                return Some(max_symbol);
+                return max_bucket.checked_add(chain_length);
             }
         }
 
         None
     }
 
-    fn bucket(&self, endian: Elf::Endian, hash: u32) -> SymbolIndex {
-        SymbolIndex(self.buckets[(hash as usize) % self.buckets.len()].get(endian) as usize)
+    fn bucket(&self, endian: Elf::Endian, hash: u32) -> Option<SymbolIndex> {
+        let bucket_count = self.buckets.len();
+        if bucket_count == 0 {
+            return None;
+        }
+        Some(SymbolIndex(
+            self.buckets[(hash as usize) % bucket_count].get(endian) as usize,
+        ))
     }
 
     /// Use the hash table to find the symbol table entry with the given name, hash, and version.
@@ -184,6 +191,9 @@ impl<'data, Elf: FileHeader> GnuHashTable<'data, Elf> {
 
         // Test against bloom filter.
         let bloom_count = self.bloom_filters.len() / mem::size_of::<Elf::Word>();
+        if bloom_count == 0 {
+            return None;
+        }
         let offset =
             ((hash / word_bits) & (bloom_count as u32 - 1)) * mem::size_of::<Elf::Word>() as u32;
         let filter = if word_bits == 64 {
@@ -206,7 +216,7 @@ impl<'data, Elf: FileHeader> GnuHashTable<'data, Elf> {
         }
 
         // Get the chain start from the bucket for this hash.
-        let mut index = self.bucket(endian, hash);
+        let mut index = self.bucket(endian, hash)?;
         if index == SymbolIndex(0) {
             return None;
         }
@@ -232,5 +242,104 @@ impl<'data, Elf: FileHeader> GnuHashTable<'data, Elf> {
             index.0 += 1;
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::elf;
+    use crate::endian::LittleEndian;
+
+    type FileHeader = elf::FileHeader64<LittleEndian>;
+
+    #[test]
+    fn hash_table_zero_buckets() {
+        // bucket_count = 0, chain_count = 0.
+        let data = [0u8; 8];
+        let table = HashTable::<FileHeader>::parse(LittleEndian, &data).unwrap();
+        let symbols = SymbolTable::<FileHeader, &[u8]>::default();
+        let versions = VersionTable::default();
+        assert!(
+            table
+                .find(LittleEndian, b"foo", 0, None, &symbols, &versions)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn hash_table_chain_out_of_bounds() {
+        let data = [
+            1, 0, 0, 0, // bucket_count = 1
+            1, 0, 0, 0, // chain_count = 1
+            1, 0, 0, 0, // buckets[0] = 1 (invalid)
+            0, 0, 0, 0, // chains[0] = 0
+        ];
+        let table = HashTable::<FileHeader>::parse(LittleEndian, &data).unwrap();
+        let symbols = SymbolTable::<FileHeader, &[u8]>::default();
+        let versions = VersionTable::default();
+        // hash 0 selects buckets[0] = 1, which is out of range for the chains.
+        assert!(
+            table
+                .find(LittleEndian, b"foo", 0, None, &symbols, &versions)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn gnu_hash_table_zero_bloom() {
+        let data = [
+            1, 0, 0, 0, // bucket_count = 1
+            1, 0, 0, 0, // symbol_base = 1
+            0, 0, 0, 0, // bloom_count = 0
+            0, 0, 0, 0, // bloom_shift = 0
+            0, 0, 0, 0, // buckets[0] = 0
+            1, 0, 0, 0, // values[0] (chain end bit set)
+        ];
+        let table = GnuHashTable::<FileHeader>::parse(LittleEndian, &data).unwrap();
+        let symbols = SymbolTable::<FileHeader, &[u8]>::default();
+        let versions = VersionTable::default();
+        assert!(
+            table
+                .find(LittleEndian, b"foo", 0, None, &symbols, &versions)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn gnu_hash_table_zero_buckets() {
+        let data = [
+            0, 0, 0, 0, // bucket_count = 0
+            1, 0, 0, 0, // symbol_base = 1
+            1, 0, 0, 0, // bloom_count = 1
+            0, 0, 0, 0, // bloom_shift = 0
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // bloom_filters[0]
+            1, 0, 0, 0, // values[0] (chain end bit set)
+        ];
+        let table = GnuHashTable::<FileHeader>::parse(LittleEndian, &data).unwrap();
+        let symbols = SymbolTable::<FileHeader, &[u8]>::default();
+        let versions = VersionTable::default();
+        // The bloom filter passes so that the empty bucket lookup is reached.
+        assert!(
+            table
+                .find(LittleEndian, b"foo", 0, None, &symbols, &versions)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn gnu_hash_table_symbol_length_overflow() {
+        let data = [
+            1, 0, 0, 0, // bucket_count = 1
+            0xff, 0xff, 0xff, 0xff, // symbol_base = u32::MAX
+            1, 0, 0, 0, // bloom_count = 1
+            0, 0, 0, 0, // bloom_shift = 0
+            0, 0, 0, 0, 0, 0, 0, 0, // bloom_filters[0]
+            0xff, 0xff, 0xff, 0xff, // buckets[0] = u32::MAX
+            1, 0, 0, 0, // values[0] (chain end bit set)
+        ];
+        let table = GnuHashTable::<FileHeader>::parse(LittleEndian, &data).unwrap();
+        // max_bucket (u32::MAX) + 1 overflows, so this returns None
+        assert_eq!(table.symbol_table_length(LittleEndian), None);
     }
 }

--- a/src/read/elf/relocation.rs
+++ b/src/read/elf/relocation.rs
@@ -810,7 +810,7 @@ impl<Endian: endian::Endian> Relr for elf::Relr32<Endian> {
     }
 
     fn next(offset: &mut Self::Word, bits: &mut Self::Word) -> Option<Self::Word> {
-        *offset += 4;
+        *offset = offset.wrapping_add(4);
         *bits >>= 1;
         if *bits & 1 != 0 { Some(*offset) } else { None }
     }
@@ -828,7 +828,7 @@ impl<Endian: endian::Endian> Relr for elf::Relr64<Endian> {
     }
 
     fn next(offset: &mut Self::Word, bits: &mut Self::Word) -> Option<Self::Word> {
-        *offset += 8;
+        *offset = offset.wrapping_add(8);
         *bits >>= 1;
         if *bits & 1 != 0 { Some(*offset) } else { None }
     }
@@ -1020,5 +1020,31 @@ impl<'data> Iterator for CrelIterator<'data> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::endian::LittleEndian;
+
+    // Pedantic overflow tests; in practice the offset is already invalid before it gets this far.
+    #[test]
+    fn relr32_next_offset_overflow() {
+        let data = [elf::Relr32(0xffff_fffc.into()), elf::Relr32(0b111.into())];
+        let offsets =
+            RelrIterator::<elf::FileHeader32<_>>::new(LittleEndian, &data).collect::<Vec<_>>();
+        assert_eq!(offsets, [0xffff_fffc, 0, 4]);
+    }
+
+    #[test]
+    fn relr64_next_offset_overflow() {
+        let data = [
+            elf::Relr64(0xffff_ffff_ffff_fff8.into()),
+            elf::Relr64(0b111.into()),
+        ];
+        let offsets =
+            RelrIterator::<elf::FileHeader64<_>>::new(LittleEndian, &data).collect::<Vec<_>>();
+        assert_eq!(offsets, [0xffff_ffff_ffff_fff8, 0, 8]);
     }
 }

--- a/src/read/macho/dyld_cache.rs
+++ b/src/read/macho/dyld_cache.rs
@@ -248,10 +248,10 @@ where
     /// Find the file offset an address in the mappings.
     fn address_to_file_offset(&self, endian: E, address: u64) -> Option<u64> {
         for mapping in self.mappings(endian) {
-            let mapping_address = mapping.address();
-            if address >= mapping_address && address < mapping_address.wrapping_add(mapping.size())
-            {
-                return Some(address - mapping_address + mapping.file_offset());
+            if let Some(mapping_offset) = address.checked_sub(mapping.address()) {
+                if mapping_offset < mapping.size() {
+                    return mapping.file_offset().checked_add(mapping_offset);
+                }
             }
         }
         None
@@ -680,8 +680,10 @@ where
                 RelocationStateV2::Page | RelocationStateV2::PageExtra => {
                     let offset = self.offset;
                     let pointer = self
-                        .data
-                        .read_at::<U64<E>>(self.mapping_file_offset + self.page_offset + offset)
+                        .mapping_file_offset
+                        .checked_add(self.page_offset)
+                        .and_then(|x| x.checked_add(offset))
+                        .and_then(|x| self.data.read_at::<U64<E>>(x).ok())
                         .read_error("Invalid dyld cache slide pointer offset")?
                         .get(self.endian);
 
@@ -693,14 +695,17 @@ where
                             self.state = RelocationStateV2::Start
                         };
                     } else {
-                        self.offset = offset + next * 4;
+                        self.offset = next
+                            .checked_mul(4)
+                            .and_then(|delta| offset.checked_add(delta))
+                            .read_error("Invalid dyld cache slide pointer offset")?;
                     };
 
                     let value = pointer & !self.delta_mask;
                     if value != 0 {
                         return Ok(Some(DyldRelocation {
                             offset,
-                            value: value + self.value_add,
+                            value: value.wrapping_add(self.value_add),
                             auth: None,
                         }));
                     }
@@ -762,8 +767,9 @@ where
                 RelocationStateV3::Page => {
                     let offset = self.offset;
                     let pointer = self
-                        .data
-                        .read_at::<U64<E>>(self.mapping_file_offset + offset)
+                        .mapping_file_offset
+                        .checked_add(offset)
+                        .and_then(|x| self.data.read_at::<U64<E>>(x).ok())
                         .read_error("Invalid dyld cache slide pointer offset")?
                         .get(self.endian);
                     let pointer = macho::DyldCacheSlidePointer3(pointer);
@@ -772,11 +778,13 @@ where
                     if next == 0 {
                         self.state = RelocationStateV3::Start;
                     } else {
-                        self.offset = offset + next * 8;
+                        self.offset = offset
+                            .checked_add(next * 8)
+                            .read_error("Invalid dyld cache slide pointer offset")?;
                     }
 
                     if pointer.is_auth() {
-                        let value = pointer.runtime_offset() + self.auth_value_add;
+                        let value = pointer.runtime_offset().wrapping_add(self.auth_value_add);
                         let key = match pointer.key() {
                             1 => macho::PtrauthKey::IB,
                             2 => macho::PtrauthKey::DA,
@@ -859,8 +867,9 @@ where
                 RelocationStateV5::Page => {
                     let offset = self.offset;
                     let pointer = self
-                        .data
-                        .read_at::<U64<E>>(self.mapping_file_offset + offset)
+                        .mapping_file_offset
+                        .checked_add(offset)
+                        .and_then(|x| self.data.read_at::<U64<E>>(x).ok())
                         .read_error("Invalid dyld cache slide pointer offset")?
                         .get(self.endian);
                     let pointer = macho::DyldCacheSlidePointer5(pointer);
@@ -869,10 +878,12 @@ where
                     if next == 0 {
                         self.state = RelocationStateV5::Start;
                     } else {
-                        self.offset = offset + next * 8;
+                        self.offset = offset
+                            .checked_add(next * 8)
+                            .read_error("Invalid dyld cache slide pointer offset")?;
                     }
 
-                    let mut value = pointer.runtime_offset() + self.value_add;
+                    let mut value = pointer.runtime_offset().wrapping_add(self.value_add);
                     let auth = if pointer.is_auth() {
                         let key = if pointer.key_is_data() {
                             macho::PtrauthKey::DA

--- a/src/read/pe/import.rs
+++ b/src/read/pe/import.rs
@@ -202,9 +202,9 @@ pub struct ImportThunkList<'data> {
 impl<'data> ImportThunkList<'data> {
     /// Get the thunk at the given index.
     pub fn get<Pe: ImageNtHeaders>(&self, index: usize) -> Result<Pe::ImageThunkData> {
-        let thunk = self
-            .data
-            .read_at(index * mem::size_of::<Pe::ImageThunkData>())
+        let thunk = index
+            .checked_mul(mem::size_of::<Pe::ImageThunkData>())
+            .and_then(|offset| self.data.read_at(offset).ok())
             .read_error("Invalid PE import thunk index")?;
         Ok(*thunk)
     }


### PR DESCRIPTION
Fix the following to return None:
- elf::HashTable::find divide by zero for zero buckets
- elf::HashTable::find out of bounds index for invalid chains
- elf::GnuHashTable::find divide by zero for zero buckets
- elf::GnuHashTable::find underflow for zero bloom filters
- elf::GnuHashTable::symbol_table_length overflow for invalid chains
- macho::DyldCache::data_and_offset_for_address overflow for invalid file offset

Fix the following to return an error:
- macho::DyldCacheRelocationIterator::next overflows for invalid pointer offsets
- pe::ImportThunkList::get overflow for invalid index

Fix the following to use wrapping_add:
- coff::Symbol::address overflow for large image_base
- elf::RelrIterator::next overflow for invalid offset
- macho::DyldCacheRelocationIterator::next overflows for invalid relocation value

Closes #928