### PR TITLE
read/macho: avoid infinite loops in exports trie

### DIFF
--- a/src/read/macho/exports_trie.rs
+++ b/src/read/macho/exports_trie.rs
@@ -100,6 +100,7 @@ impl<'data> ExportSymbol<'data> {
 #[derive(Debug)]
 struct Frame<'data> {
     data: Bytes<'data>,
+    offset: u64,
     children_remaining: u8,
     name_buf_len: usize,
 }
@@ -107,7 +108,7 @@ struct Frame<'data> {
 #[derive(Debug)]
 struct NodeIterator<'data> {
     data: &'data [u8],
-    offset: usize,
+    first: bool,
     stack: Vec<Frame<'data>>,
     // Accumulates the prefix edge strings as we traverse the trie.
     name_buf: Vec<u8>,
@@ -118,16 +119,16 @@ impl<'data> NodeIterator<'data> {
     pub(super) fn new(data: &'data [u8]) -> Self {
         NodeIterator {
             data,
-            offset: 0,
+            first: true,
             stack: Vec::new(),
             name_buf: Vec::new(),
         }
     }
 
-    fn push_node(&mut self) -> Result<Option<ExportSymbol<'data>>> {
+    fn push_node(&mut self, offset: u64) -> Result<Option<ExportSymbol<'data>>> {
         let mut data = Bytes(
             self.data
-                .get(self.offset..)
+                .get(offset as usize..)
                 .read_error("Invalid exports trie offset")?,
         );
         let terminal_size = data
@@ -151,6 +152,7 @@ impl<'data> NodeIterator<'data> {
             .read_error("Invalid exports trie children count")?;
         self.stack.push(Frame {
             data,
+            offset,
             children_remaining: children_count,
             name_buf_len: self.name_buf.len(),
         });
@@ -162,31 +164,37 @@ impl<'data> NodeIterator<'data> {
     // - `Ok(Some(None))` if we don't have terminal data at the current node.
     // - `Ok(None)` if we've reached the end of the trie.
     fn next(&mut self) -> Result<Option<Option<ExportSymbol<'data>>>> {
-        let Some(frame) = self.stack.last_mut() else {
-            // The stack is empty at the beginning and end of our traversal. We
-            // use self.offset to distinguish the two cases.
-            if self.offset == 0 {
-                return Ok(Some(self.push_node()?));
-            }
-            return Ok(None);
-        };
-        self.name_buf.truncate(frame.name_buf_len);
-        if frame.children_remaining == 0 {
-            self.stack.pop();
-            return self.next();
+        if self.first {
+            self.first = false;
+            // The root node is at offset 0.
+            return Ok(Some(self.push_node(0)?));
         }
-        let edge_str = frame
-            .data
-            .read_string()
-            .read_error("Invalid exports trie edge string")?;
-        let child_offset = frame
-            .data
-            .read_uleb128()
-            .read_error("Invalid exports trie child offset")?;
-        frame.children_remaining -= 1;
-        self.name_buf.extend(edge_str);
-        self.offset = child_offset as usize;
-        Ok(Some(self.push_node()?))
+        loop {
+            let Some(frame) = self.stack.last_mut() else {
+                // The stack only drains once the root node's subtree is fully
+                // traversed, so an empty stack here means we are done.
+                return Ok(None);
+            };
+            self.name_buf.truncate(frame.name_buf_len);
+            if frame.children_remaining == 0 {
+                self.stack.pop();
+                continue;
+            }
+            let edge_str = frame
+                .data
+                .read_string()
+                .read_error("Invalid exports trie edge string")?;
+            let child_offset = frame
+                .data
+                .read_uleb128()
+                .read_error("Invalid exports trie child offset")?;
+            frame.children_remaining -= 1;
+            self.name_buf.extend(edge_str);
+            if self.stack.iter().any(|frame| frame.offset == child_offset) {
+                return Err(Error("Invalid exports trie child offset"));
+            }
+            return Ok(Some(self.push_node(child_offset)?));
+        }
     }
 }
 
@@ -265,5 +273,58 @@ impl<'data> ExportData<'data> {
             .read_uleb128()
             .read_error("Invalid exports trie address")?;
         Ok((flags, ExportData::Regular { address }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_export() {
+        let data = [
+            // Root node at offset 0.
+            0x00, // terminal_size
+            0x01, // children_count
+            b'a', 0x00, // edge_str
+            0x05, // child_offset
+            // Terminal node at offset 5.
+            0x02, // terminal_size
+            0x00, // flags
+            0x10, // address
+            0x00, // children_count
+        ];
+        let mut exports = ExportsTrieIterator::new(&data);
+        let symbol = exports.next().unwrap().unwrap();
+        assert_eq!(symbol.name(), b"a");
+        assert_eq!(symbol.flags(), macho::ExportSymbolFlags(0));
+        let ExportData::Regular { address: 0x10 } = symbol.data() else {
+            panic!();
+        };
+
+        assert!(exports.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn root_with_no_children() {
+        let data = [
+            0x00, // terminal_size
+            0x00, // children_count
+        ];
+        let mut exports = ExportsTrieIterator::new(&data);
+        assert!(exports.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn cycle_to_root() {
+        // The root's only child points back at offset 0.
+        let data = [
+            0x00, // terminal_size
+            0x01, // children_count
+            b'a', 0x00, // edge_str
+            0x00, // child_offset (points at the root)
+        ];
+        let mut exports = ExportsTrieIterator::new(&data);
+        assert!(exports.next().is_err());
     }
 }


### PR DESCRIPTION
If the first node has no children, our offset==0 sentinel handling resulted in an infinite loop. Replace with a boolean and stop using recursion.

Also check for cycles (child offset equals an ancestor offset). Note that this still does not check for shared subtrees.