### PR TITLE
read/pe: handle period in forwarded dll name

### DIFF
--- a/crates/examples/testfiles/pe/export.dll.readobj
+++ b/crates/examples/testfiles/pe/export.dll.readobj
@@ -231,7 +231,7 @@ ImageExportDirectory {
         Ordinal: 8
         Name: "forward_with_dot" (0x20C7)
         Address: 0x20F5
-        ForwardLibrary: "kernel32"
-        ForwardName: "dll.Sleep"
+        ForwardLibrary: "kernel32.dll"
+        ForwardName: "Sleep"
     }
 }

--- a/src/read/pe/export.rs
+++ b/src/read/pe/export.rs
@@ -324,7 +324,7 @@ impl<'data> ExportTable<'data> {
         Ok(if let Some(forward) = self.forward_string(address)? {
             let i = forward
                 .iter()
-                .position(|x| *x == b'.')
+                .rposition(|x| *x == b'.')
                 .read_error("Missing PE forwarded export separator")?;
             let library = &forward[..i];
             match &forward[i + 1..] {


### PR DESCRIPTION
This matches how wine's find_forwarded_export() handles it. I didn't test whether the Windows loader supports this, or find any documentation for it.