### PR TITLE
Fix skipping the COFF `/<ECSYMBOLS>/` member when no names table is present

### DIFF
--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -152,12 +152,18 @@ impl<'data, R: ReadRef<'data>> ArchiveFile<'data, R> {
                                 // COFF names table.
                                 file.names = member.data(data)?;
                                 members_offset = tail;
-                            }
-                        }
-                        if tail < len {
-                            let member = ArchiveMember::parse(data, &mut tail, file.names, thin)?;
-                            if member.name == b"/<ECSYMBOLS>/" {
-                                // COFF EC Symbol Table.
+
+                                // The EC symbol table may follow the names table.
+                                if tail < len {
+                                    let member =
+                                        ArchiveMember::parse(data, &mut tail, file.names, thin)?;
+                                    if member.name == b"/<ECSYMBOLS>/" {
+                                        // COFF EC symbol table.
+                                        members_offset = tail;
+                                    }
+                                }
+                            } else if member.name == b"/<ECSYMBOLS>/" {
+                                // COFF EC symbol table with no names table.
                                 members_offset = tail;
                             }
                         }
@@ -1188,6 +1194,63 @@ mod tests {
         let archive = ArchiveFile::parse(&data[..]).unwrap();
         assert_eq!(archive.kind(), ArchiveKind::Gnu);
         assert!(archive.is_thin());
+    }
+
+    #[test]
+    fn coff_ec_symbols() {
+        use alloc::vec::Vec;
+
+        // Append a COFF archive member (header followed by data) to `archive`.
+        fn add_member(archive: &mut Vec<u8>, name: &str, data: &[u8]) {
+            let mut header = [b' '; 60];
+            header[..name.len()].copy_from_slice(name.as_bytes());
+            let size = format!("{}", data.len());
+            header[48..48 + size.len()].copy_from_slice(size.as_bytes());
+            header[58] = b'`';
+            header[59] = b'\n';
+            archive.extend_from_slice(&header);
+            archive.extend_from_slice(data);
+            // Members are padded to an even number of bytes.
+            if data.len() % 2 != 0 {
+                archive.push(b'\n');
+            }
+        }
+
+        // A COFF archive with an EC symbol table but no `//` names table, which
+        // `llvm-ar` omits when all member names fit in the header. The
+        // `/<ECSYMBOLS>/` member must be skipped when iterating members.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"!<arch>\n");
+        add_member(&mut data, "/", &[0, 0, 0, 0]);
+        add_member(&mut data, "/", &[0, 0, 0, 0]);
+        add_member(&mut data, "/<ECSYMBOLS>/", &[1, 0, 1, 0]);
+        add_member(&mut data, "foo.obj/", b"data");
+
+        let archive = ArchiveFile::parse(&data[..]).unwrap();
+        assert_eq!(archive.kind(), ArchiveKind::Coff);
+        let mut members = archive.members();
+        let member = members.next().unwrap().unwrap();
+        assert_eq!(member.name(), b"foo.obj");
+        assert_eq!(member.data(&data[..]).unwrap(), &b"data"[..]);
+        assert!(members.next().is_none());
+
+        // The same archive, but with a `//` names table before the EC symbol
+        // table. The `/<ECSYMBOLS>/` member must still be skipped.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"!<arch>\n");
+        add_member(&mut data, "/", &[0, 0, 0, 0]);
+        add_member(&mut data, "/", &[0, 0, 0, 0]);
+        add_member(&mut data, "//", b"foo.obj/\n");
+        add_member(&mut data, "/<ECSYMBOLS>/", &[1, 0, 1, 0]);
+        add_member(&mut data, "foo.obj/", b"data");
+
+        let archive = ArchiveFile::parse(&data[..]).unwrap();
+        assert_eq!(archive.kind(), ArchiveKind::Coff);
+        let mut members = archive.members();
+        let member = members.next().unwrap().unwrap();
+        assert_eq!(member.name(), b"foo.obj");
+        assert_eq!(member.data(&data[..]).unwrap(), &b"data"[..]);
+        assert!(members.next().is_none());
     }
 
     #[test]

--- a/src/read/archive.rs
+++ b/src/read/archive.rs
@@ -1242,7 +1242,7 @@ mod tests {
         add_member(&mut data, "/", &[0, 0, 0, 0]);
         add_member(&mut data, "//", b"foo.obj/\n");
         add_member(&mut data, "/<ECSYMBOLS>/", &[1, 0, 1, 0]);
-        add_member(&mut data, "foo.obj/", b"data");
+        add_member(&mut data, "/0", b"data");
 
         let archive = ArchiveFile::parse(&data[..]).unwrap();
         assert_eq!(archive.kind(), ArchiveKind::Coff);


### PR DESCRIPTION
The Arm64EC EC symbol table member is only skipped by `ArchiveFile::parse` when a `//` long-names member immediately precedes it. When the archive has no `//` member (which `llvm-ar` omits when all member names fit in the header), the two sequential checks parse the wrong members: the `//` check consumes `/<ECSYMBOLS>/`, and the ECSYMBOLS check consumes the first real object. As a result `members_offset` is left pointing at `/<ECSYMBOLS>/`, so `members()` yields it and callers (e.g. rustc) fail to parse it as an object file.

Nest the ECSYMBOLS check inside the `//` branch and add a separate check for the case where `/<ECSYMBOLS>/` directly follows the second linker member, so it is skipped regardless of whether a names table is present.