### PR TITLE
read: handle PE export by ordinal in Object::exports

### DIFF
--- a/crates/examples/testfiles/macho/libexports.dylib.objdump
+++ b/crates/examples/testfiles/macho/libexports.dylib.objdump
@@ -4,7 +4,7 @@ Architecture: Aarch64
 Flags: MachO { flags: MH_NOUNDEFS | MH_DYLDLINK | MH_TWOLEVEL | MH_WEAK_DEFINES | MH_BINDS_TO_WEAK | MH_NO_REEXPORTED_DYLIBS | MH_HAS_TLV_DESCRIPTORS }
 Relative Address Base: 0
 Entry Address: 0
-Mach UUID: [50, a7, 77, 38, b1, 36, 32, 92, 8d, 7c, 4d, a2, 99, 9c, e1, a]
+Mach UUID: [9c, 74, 2d, 58, db, b2, 33, 1, bd, 99, 78, 30, 93, d2, ef, 76]
 Segment { name: "__TEXT", address: 0, size: 4000, permissions: R-X }
 Segment { name: "__DATA", address: 4000, size: 4000, permissions: RW- }
 Segment { name: "__LINKEDIT", address: 8000, size: 4000, permissions: R-- }
@@ -22,9 +22,10 @@ Symbols
 3: Symbol { name: "_foo_resolver", address: 464, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Dynamic, weak: false, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0 } }
 4: Symbol { name: "_tls", address: 4008, size: 0, kind: Tls, section: Section(SectionIndex(5)), scope: Dynamic, weak: false, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0 } }
 5: Symbol { name: "_weak", address: 468, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Dynamic, weak: true, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0x80 } }
-6: Symbol { name: "my_stub_binder", address: 34, size: 0, kind: Unknown, section: Unknown, scope: Dynamic, weak: false, flags: MachO { n_type: N_INDR | N_EXT, n_desc: 0 } }
-7: Symbol { name: "__tlv_bootstrap", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: false, flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
-8: Symbol { name: "dyld_stub_binder", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: false, flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
+6: Symbol { name: "dyld_stub_binder", address: 25, size: 0, kind: Unknown, section: Unknown, scope: Dynamic, weak: false, flags: MachO { n_type: N_INDR | N_EXT, n_desc: 0 } }
+7: Symbol { name: "my_stub_binder", address: 45, size: 0, kind: Unknown, section: Unknown, scope: Dynamic, weak: false, flags: MachO { n_type: N_INDR | N_EXT, n_desc: 0 } }
+8: Symbol { name: "__tlv_bootstrap", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: false, flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
+9: Symbol { name: "dyld_stub_binder", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Unknown, weak: false, flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
 
 Dynamic symbols
 
@@ -36,6 +37,7 @@ Export { name: "_foo", target: Resolver { resolver: 460, stub: Some(46c) }, flag
 Export { name: "_foo_resolver", target: Address { address: 464 }, flags: None }
 Export { name: "_tls", target: TlvDescriptor { address: 4008 }, flags: None }
 Export { name: "_weak", target: Address { address: 468 }, weak: true, flags: None }
+Export { name: "dyld_stub_binder", target: Reexport { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder" }, flags: None }
 Export { name: "my_stub_binder", target: Reexport { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder" }, flags: None }
 
 Symbol map

--- a/crates/examples/testfiles/macho/libexports.dylib.readobj
+++ b/crates/examples/testfiles/macho/libexports.dylib.readobj
@@ -157,7 +157,7 @@ SegmentCommand {
     VmAddress: 0x8000
     VmSize: 0x4000
     FileOffset: 0x8000
-    FileSize: 0x390
+    FileSize: 0x3D0
     MaxProt: VM_PROT_READ (0x1)
     InitProt: VM_PROT_READ (0x1)
     NumberOfSections: 0
@@ -215,7 +215,7 @@ LinkeditDataCommand {
     Cmd: LC_DYLD_EXPORTS_TRIE (0x80000033)
     CmdSize: 0x10
     DataOffset: 0x8060
-    DataSize: 0x78
+    DataSize: 0x90
     ExportSymbol {
         Name: "_abs"
         Flags: EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE (0x2)
@@ -247,6 +247,14 @@ LinkeditDataCommand {
         Address: 0x468
     }
     ExportSymbol {
+        Name: "dyld_stub_binder"
+        Flags: 0x8
+            EXPORT_SYMBOL_FLAGS_KIND_REGULAR (0x0)
+            EXPORT_SYMBOL_FLAGS_REEXPORT (0x8)
+        DylibOrdinal: 0x1
+        ImportName: ""
+    }
+    ExportSymbol {
         Name: "my_stub_binder"
         Flags: 0x8
             EXPORT_SYMBOL_FLAGS_KIND_REGULAR (0x0)
@@ -258,13 +266,13 @@ LinkeditDataCommand {
 SymtabCommand {
     Cmd: LC_SYMTAB (0x2)
     CmdSize: 0x18
-    SymbolOffset: 0x80E0
-    NumberOfSymbols: 0x9
-    StringOffset: 0x8178
-    StringSize: 0x78
+    SymbolOffset: 0x80F8
+    NumberOfSymbols: 0xA
+    StringOffset: 0x81A0
+    StringSize: 0x88
     Nlist {
         Index: 0
-        String: "_tls$tlv$init" (0x66)
+        String: "_tls$tlv$init" (0x77)
         Type: N_SECT (0xE)
         Section: "__DATA,__thread_data" (0x6)
         Desc: 0x0
@@ -322,17 +330,27 @@ SymtabCommand {
     }
     Nlist {
         Index: 6
-        String: "my_stub_binder" (0x25)
+        String: "dyld_stub_binder" (0x25)
         Type: 0xB
             N_INDR (0xA)
             N_EXT (0x1)
         Section: "" (0x0)
         Desc: 0x0
-        Value: 0x34
+        Value: 0x25
     }
     Nlist {
         Index: 7
-        String: "__tlv_bootstrap" (0x45)
+        String: "my_stub_binder" (0x36)
+        Type: 0xB
+            N_INDR (0xA)
+            N_EXT (0x1)
+        Section: "" (0x0)
+        Desc: 0x0
+        Value: 0x45
+    }
+    Nlist {
+        Index: 8
+        String: "__tlv_bootstrap" (0x56)
         Type: 0x1
             N_UNDF (0x0)
             N_EXT (0x1)
@@ -343,8 +361,8 @@ SymtabCommand {
         Value: 0x0
     }
     Nlist {
-        Index: 8
-        String: "dyld_stub_binder" (0x55)
+        Index: 9
+        String: "dyld_stub_binder" (0x66)
         Type: 0x1
             N_UNDF (0x0)
             N_EXT (0x1)
@@ -361,8 +379,8 @@ DysymtabCommand {
     IndexOfLocalSymbols: 0
     NumberOfLocalSymbols: 1
     IndexOfExternallyDefinedSymbols: 1
-    NumberOfExternallyDefinedSymbols: 6
-    IndexOfUndefinedSymbols: 7
+    NumberOfExternallyDefinedSymbols: 7
+    IndexOfUndefinedSymbols: 8
     NumberOfUndefinedSymbols: 2
     TocOffset: 0x0
     NumberOfTocEntries: 0
@@ -370,7 +388,7 @@ DysymtabCommand {
     NumberOfModuleTableEntries: 0
     ExternalRefSymbolOffset: 0x0
     NumberOfExternalRefSymbols: 0
-    IndirectSymbolOffset: 0x8170
+    IndirectSymbolOffset: 0x8198
     NumberOfIndirectSymbols: 2
     ExternalRelocationOffset: 0x0
     NumberOfExternalRelocations: 0
@@ -380,7 +398,7 @@ DysymtabCommand {
 UuidCommand {
     Cmd: LC_UUID (0x1B)
     CmdSize: 0x18
-    Uuid: [50, A7, 77, 38, B1, 36, 32, 92, 8D, 7C, 4D, A2, 99, 9C, E1, A]
+    Uuid: [9C, 74, 2D, 58, DB, B2, 33, 1, BD, 99, 78, 30, 93, D2, EF, 76]
 }
 BuildVersionCommand {
     Cmd: LC_BUILD_VERSION (0x32)
@@ -412,7 +430,7 @@ DylibCommand {
 LinkeditDataCommand {
     Cmd: LC_FUNCTION_STARTS (0x26)
     CmdSize: 0x10
-    DataOffset: 0x80D8
+    DataOffset: 0x80F0
     DataSize: 0x8
     FunctionStarts {
         Address: 0x460
@@ -423,13 +441,13 @@ LinkeditDataCommand {
 LinkeditDataCommand {
     Cmd: LC_DATA_IN_CODE (0x29)
     CmdSize: 0x10
-    DataOffset: 0x80E0
+    DataOffset: 0x80F8
     DataSize: 0x0
 }
 LinkeditDataCommand {
     Cmd: LC_CODE_SIGNATURE (0x1D)
     CmdSize: 0x10
-    DataOffset: 0x81F0
+    DataOffset: 0x8230
     DataSize: 0x1A0
     CodeSignature {
         Magic: 0xFADE0CC0
@@ -449,7 +467,7 @@ LinkeditDataCommand {
                 IdentOffset: "libexports.dylib" (0x58)
                 NSpecialSlots: 0
                 NCodeSlots: 9
-                CodeLimit: 0x81F0
+                CodeLimit: 0x8230
                 HashSize: 32
                 HashType: CS_HASHTYPE_SHA256 (0x2)
                 Platform: 0
@@ -460,7 +478,7 @@ LinkeditDataCommand {
                 ExecSegBase: 0x0
                 ExecSegLimit: 0xC
                 ExecSegFlags: 0x0
-                CodeHash: f18a4b95f38c14a17241083d859f763158fb8a71e334e899bf72f1f9ff2f487f
+                CodeHash: b80bdddbc6f6af75067a39b67b082c9ac630249b22648cd211c9da0667363f86
                 CodeHash: ad7facb2586fc6e966c004d7d1d16b024f5805ff7cb47c7a85dabd8b48892ca7
                 CodeHash: ad7facb2586fc6e966c004d7d1d16b024f5805ff7cb47c7a85dabd8b48892ca7
                 CodeHash: ad7facb2586fc6e966c004d7d1d16b024f5805ff7cb47c7a85dabd8b48892ca7
@@ -468,7 +486,7 @@ LinkeditDataCommand {
                 CodeHash: ad7facb2586fc6e966c004d7d1d16b024f5805ff7cb47c7a85dabd8b48892ca7
                 CodeHash: ad7facb2586fc6e966c004d7d1d16b024f5805ff7cb47c7a85dabd8b48892ca7
                 CodeHash: ad7facb2586fc6e966c004d7d1d16b024f5805ff7cb47c7a85dabd8b48892ca7
-                CodeHash: 3e9cc5d8eb574c67b0968ddb6ccf0f908505001b2b6e9c43a7d6d318dda05511
+                CodeHash: 5d9af29c60b7babbecd538510e6b5000fc13f9607fe170f736b5c12e814f6abb
             }
         }
     }

--- a/crates/examples/testfiles/pe/export.dll.objdump
+++ b/crates/examples/testfiles/pe/export.dll.objdump
@@ -17,7 +17,8 @@ Export { name: "exported_alias", target: Address { address: 180001020 }, flags: 
 Export { name: "exported_multi", target: Address { address: 180001020 }, flags: Pe { ordinal: 3 } }
 Export { name: "exported_named", target: Address { address: 180001000 }, flags: Pe { ordinal: 1 } }
 Export { name: "forward_by_name", target: Reexport { library: "kernel32", name: "Sleep" }, flags: Pe { ordinal: 6 } }
-Export { name: "forward_by_ordinal", target: ReexportOrdinal { library: "kernel32", ordinal: 7b }, flags: Pe { ordinal: 7 } }
+Export { name: "forward_by_ordinal", target: Reexport { library: "kernel32", ordinal: 7b }, flags: Pe { ordinal: 7 } }
 Export { name: "forward_with_dot", target: Reexport { library: "kernel32.dll", name: "Sleep" }, flags: Pe { ordinal: 8 } }
+Export { ordinal: 2, target: Address { address: 180001010 }, flags: Pe { ordinal: 2 } }
 
 Symbol map

--- a/src/read/elf/export.rs
+++ b/src/read/elf/export.rs
@@ -3,7 +3,7 @@ use alloc::fmt;
 
 use crate::elf;
 use crate::endian::Endianness;
-use crate::read::{self, Export, ExportFlags, ExportTarget, ReadRef, SymbolIndex};
+use crate::read::{self, Export, ExportFlags, ExportTarget, NameOrOrdinal, ReadRef, SymbolIndex};
 
 use super::{FileHeader, Sym, SymbolTable, VersionTable};
 
@@ -89,7 +89,7 @@ where
                 (None, false)
             };
             return Ok(Some(Export {
-                name: Cow::Borrowed(name),
+                name: NameOrOrdinal::Name(Cow::Borrowed(name)),
                 target,
                 weak: symbol.st_bind() == elf::STB_WEAK,
                 flags: ExportFlags::Elf {

--- a/src/read/macho/export.rs
+++ b/src/read/macho/export.rs
@@ -6,7 +6,8 @@ use core::slice;
 use crate::Endianness;
 use crate::macho;
 use crate::read::{
-    Error, Export, ExportFlags, ExportTarget, ReadError, ReadRef, Result, SectionIndex,
+    Error, Export, ExportFlags, ExportTarget, NameOrOrdinal, ReadError, ReadRef, Result,
+    SectionIndex,
 };
 
 use super::{ExportData, ExportsTrieIterator, MachHeader, MachOFile, Nlist, Section, Segment};
@@ -159,12 +160,12 @@ where
                             .read_error("Invalid Mach-O export dylib ordinal")?;
                         ExportTarget::Reexport {
                             library,
-                            name: import_name,
+                            name: NameOrOrdinal::Name(import_name),
                         }
                     }
                 };
                 Ok(Some(Export {
-                    name: Cow::Owned(symbol.into_name()),
+                    name: NameOrOrdinal::Name(Cow::Owned(symbol.into_name())),
                     target,
                     weak: flags.contains(macho::EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION),
                     flags: ExportFlags::None,
@@ -195,7 +196,7 @@ where
                                 .read_error("Invalid Mach-O indirect symbol value")?;
                             ExportTarget::Reexport {
                                 library: &[],
-                                name: import_name,
+                                name: NameOrOrdinal::Name(import_name),
                             }
                         }
                         macho::N_SECT => {
@@ -219,7 +220,7 @@ where
                         _ => continue,
                     };
                     break Ok(Some(Export {
-                        name: Cow::Borrowed(name),
+                        name: NameOrOrdinal::Name(Cow::Borrowed(name)),
                         target,
                         weak: symbol.n_desc(endian).contains(macho::N_WEAK_DEF),
                         flags: ExportFlags::MachO {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -449,7 +449,7 @@ impl<'data> Import<'data> {
 /// Returned by [`Object::exports`].
 #[derive(Clone, PartialEq, Eq)]
 pub struct Export<'data> {
-    name: Cow<'data, [u8]>,
+    name: NameOrOrdinal<Cow<'data, [u8]>>,
     target: ExportTarget<'data>,
     weak: bool,
     flags: ExportFlags<'data>,
@@ -458,8 +458,11 @@ pub struct Export<'data> {
 impl<'data> fmt::Debug for Export<'data> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("Export");
-        s.field("name", &ByteString(&self.name));
-        s.field("target", &self.target);
+        match &self.name {
+            NameOrOrdinal::Name(name) => s.field("name", &ByteString(name)),
+            NameOrOrdinal::Ordinal(ordinal) => s.field("ordinal", ordinal),
+        };
+        s.field("target", &self.target());
         if self.weak {
             s.field("weak", &self.weak);
         }
@@ -469,22 +472,34 @@ impl<'data> fmt::Debug for Export<'data> {
 }
 
 impl<'data> Export<'data> {
-    /// The symbol name.
+    /// The name or ordinal that the symbol is exported as.
     #[inline]
-    pub fn name(&self) -> &[u8] {
-        &self.name
+    pub fn name(&self) -> NameOrOrdinal<&[u8]> {
+        self.name.as_ref()
     }
 
-    /// Consume the export and return the name buffer.
+    /// Consume the export and return the name.
+    ///
+    /// Use this to avoid copying the name when it is owned.
     #[inline]
-    pub fn into_name(self) -> Cow<'data, [u8]> {
+    pub fn into_name(self) -> NameOrOrdinal<Cow<'data, [u8]>> {
         self.name
     }
 
     /// The target of the export.
     #[inline]
-    pub fn target(&self) -> ExportTarget<'data> {
-        self.target
+    pub fn target(&self) -> ExportTarget<'_> {
+        match self.target {
+            // Handle empty name for EXPORT_SYMBOL_FLAGS_REEXPORT in Mach-O exports trie.
+            ExportTarget::Reexport {
+                library,
+                name: NameOrOrdinal::Name(b""),
+            } => ExportTarget::Reexport {
+                library,
+                name: self.name.as_ref(),
+            },
+            target => target,
+        }
     }
 
     /// Return true if the export is a weak definition.
@@ -546,7 +561,7 @@ pub enum ExportTarget<'data> {
         /// ELF may have a corresponding PLT entry, but we don't attempt to determine it.
         stub: Option<u64>,
     },
-    /// A symbol from an external library which is reexported by name.
+    /// A symbol from an external library which is reexported.
     ///
     /// This is used for PE and Mach-O.
     Reexport {
@@ -555,19 +570,8 @@ pub enum ExportTarget<'data> {
         /// This is empty if the library is not specified.
         // TODO: Mach-O special library ordinals
         library: &'data [u8],
-        /// The symbol name in the external library.
-        ///
-        /// An empty name means the imported symbol has the same name as this export.
-        name: &'data [u8],
-    },
-    /// A symbol from an external library which is reexported by ordinal.
-    ///
-    /// This is only used for PE.
-    ReexportOrdinal {
-        /// The name of the library.
-        library: &'data [u8],
-        /// The ordinal of the symbol in the external library.
-        ordinal: u16,
+        /// The name or ordinal of the symbol in the external library.
+        name: NameOrOrdinal<&'data [u8]>,
     },
 }
 
@@ -590,16 +594,15 @@ impl<'data> fmt::Debug for ExportTarget<'data> {
                 .field("resolver", resolver)
                 .field("stub", stub)
                 .finish(),
-            ExportTarget::Reexport { library, name } => f
-                .debug_struct("Reexport")
-                .field("library", &ByteString(library))
-                .field("name", &ByteString(name))
-                .finish(),
-            ExportTarget::ReexportOrdinal { library, ordinal } => f
-                .debug_struct("ReexportOrdinal")
-                .field("library", &ByteString(library))
-                .field("ordinal", ordinal)
-                .finish(),
+            ExportTarget::Reexport { library, name } => {
+                let mut s = f.debug_struct("Reexport");
+                s.field("library", &ByteString(library));
+                match name {
+                    NameOrOrdinal::Name(name) => s.field("name", &ByteString(name)),
+                    NameOrOrdinal::Ordinal(ordinal) => s.field("ordinal", ordinal),
+                };
+                s.finish()
+            }
         }
     }
 }
@@ -678,6 +681,61 @@ impl<'data> fmt::Debug for ExportFlags<'data> {
             ExportFlags::Pe { ordinal } => f.debug_struct("Pe").field("ordinal", ordinal).finish(),
             #[cfg(not(feature = "elf"))]
             ExportFlags::_Phantom(_, i) => match *i {},
+        }
+    }
+}
+
+/// The name or ordinal of an exported symbol in a library.
+///
+/// Only PE supports identifying a symbol by ordinal instead of by name.
+///
+/// `T` is the storage for the name. This is normally `&[u8]`, but it is
+/// `Cow<[u8]>` where the name may need to be owned (see [`Export::into_name`]).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum NameOrOrdinal<T> {
+    /// The name of the symbol.
+    Name(T),
+    /// The ordinal of the symbol in the library.
+    Ordinal(u16),
+}
+
+impl<T: AsRef<[u8]>> fmt::Debug for NameOrOrdinal<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NameOrOrdinal::Name(name) => f
+                .debug_tuple("Name")
+                .field(&ByteString(name.as_ref()))
+                .finish(),
+            NameOrOrdinal::Ordinal(ordinal) => f.debug_tuple("Ordinal").field(ordinal).finish(),
+        }
+    }
+}
+
+impl<T: AsRef<[u8]>> NameOrOrdinal<T> {
+    /// The name of the symbol, or `None` if it is identified by ordinal.
+    #[inline]
+    pub fn name(&self) -> Option<&[u8]> {
+        match self {
+            NameOrOrdinal::Name(name) => Some(name.as_ref()),
+            NameOrOrdinal::Ordinal(_) => None,
+        }
+    }
+
+    /// The ordinal of the symbol, or `None` if it is identified by name.
+    #[inline]
+    pub fn ordinal(&self) -> Option<u16> {
+        match self {
+            NameOrOrdinal::Name(_) => None,
+            NameOrOrdinal::Ordinal(ordinal) => Some(*ordinal),
+        }
+    }
+
+    /// Borrow the name.
+    #[inline]
+    pub fn as_ref(&self) -> NameOrOrdinal<&[u8]> {
+        match self {
+            NameOrOrdinal::Name(name) => NameOrOrdinal::Name(name.as_ref()),
+            NameOrOrdinal::Ordinal(ordinal) => NameOrOrdinal::Ordinal(*ordinal),
         }
     }
 }

--- a/src/read/pe/export.rs
+++ b/src/read/pe/export.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 
 use crate::endian::{LittleEndian as LE, U16, U32};
 use crate::pe;
-use crate::read::{self, ByteString, Bytes, Error, ReadError, ReadRef, Result};
+use crate::read::{self, ByteString, Bytes, Error, NameOrOrdinal, ReadError, ReadRef, Result};
 
 use super::{ImageNtHeaders, PeFile};
 
@@ -426,6 +426,9 @@ where
     image_base: u64,
     table: Option<ExportTable<'data>>,
     index: usize,
+    // false: iterating names, true: iterating addresses
+    addresses: bool,
+    seen: Vec<bool>,
     marker: PhantomData<(&'file (), R)>,
 }
 
@@ -435,10 +438,16 @@ where
 {
     pub(super) fn new<Pe: ImageNtHeaders>(file: &'file PeFile<'data, Pe, R>) -> Result<Self> {
         let table = file.export_table()?;
+        let seen = match &table {
+            Some(table) => vec![false; table.addresses().len()],
+            None => Vec::new(),
+        };
         Ok(PeExportIterator {
             image_base: file.common.image_base,
             table,
             index: 0,
+            addresses: false,
+            seen,
             marker: PhantomData,
         })
     }
@@ -447,36 +456,69 @@ where
         let Some(table) = &self.table else {
             return Ok(None);
         };
-        let index = self.index;
-        let Some(name_pointer) = table.name_pointers().get(index) else {
-            return Ok(None);
-        };
-        let Some(address_index) = table.name_ordinals().get(index) else {
-            return Ok(None);
-        };
-        // Ensure progress is made, so errors after here don't need to terminate iteration.
-        self.index += 1;
+        if !self.addresses {
+            let index = self.index;
+            if let (Some(name_pointer), Some(address_index)) = (
+                table.name_pointers().get(index),
+                table.name_ordinals().get(index),
+            ) {
+                // Ensure progress is made, so errors after here don't need to terminate iteration.
+                self.index += 1;
 
-        let name = table.name_from_pointer(name_pointer.get(LE))?;
-        let address_index = address_index.get(LE);
-        let address = table.address_by_index(address_index)?;
-        let ordinal = table.ordinal_from_index(address_index)?;
+                let address_index = address_index.get(LE);
+                if let Some(seen) = self.seen.get_mut(usize::from(address_index.0)) {
+                    *seen = true;
+                }
+
+                let address = table.address_by_index(address_index)?;
+                let ordinal = table.ordinal_from_index(address_index)?;
+                let name = table.name_from_pointer(name_pointer.get(LE))?;
+                let name = NameOrOrdinal::Name(Cow::Borrowed(name));
+                return self.export(table, address, ordinal, name);
+            } else {
+                self.index = 0;
+                self.addresses = true;
+            }
+        }
+        loop {
+            let index = self.index;
+            let Some(address) = table.addresses().get(index).map(|x| x.get(LE)) else {
+                return Ok(None);
+            };
+            // Ensure progress is made, so errors after here don't need to terminate iteration.
+            self.index += 1;
+
+            if self.seen[index] || address == 0 {
+                continue;
+            }
+
+            let ordinal = table.ordinal_from_index(ExportAddressIndex(index as u16))?;
+            return self.export(table, address, ordinal, NameOrOrdinal::Ordinal(ordinal.0));
+        }
+    }
+
+    fn export(
+        &self,
+        table: &ExportTable<'data>,
+        address: u32,
+        ordinal: ExportOrdinal,
+        name: NameOrOrdinal<Cow<'data, [u8]>>,
+    ) -> read::Result<Option<read::Export<'data>>> {
         let target = match table.target_from_address(address)? {
             ExportTarget::Address(address) => read::ExportTarget::Address {
                 address: self.image_base.wrapping_add(address.into()),
             },
-            ExportTarget::ForwardByName(library, name) => {
-                read::ExportTarget::Reexport { library, name }
-            }
-            ExportTarget::ForwardByOrdinal(library, ordinal) => {
-                read::ExportTarget::ReexportOrdinal {
-                    library,
-                    ordinal: ordinal.0,
-                }
-            }
+            ExportTarget::ForwardByName(library, name) => read::ExportTarget::Reexport {
+                library,
+                name: NameOrOrdinal::Name(name),
+            },
+            ExportTarget::ForwardByOrdinal(library, ordinal) => read::ExportTarget::Reexport {
+                library,
+                name: NameOrOrdinal::Ordinal(ordinal.0),
+            },
         };
         Ok(Some(read::Export {
-            name: Cow::Borrowed(name),
+            name,
             target,
             weak: false,
             flags: read::ExportFlags::Pe { ordinal },


### PR DESCRIPTION
Also improve handling for Mach-O re-export with same name.