### PR TITLE
read: bound zstd-decompressed size to the declared size

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1062,10 +1062,21 @@ impl<'data> CompressedData<'data> {
                                 }
                                 x => x.ok().read_error("Invalid zstd compressed data")?,
                             };
-                            decoder
+                            // Bound the decoded output to the reserved `size` so a crafted
+                            // stream cannot grow `decompressed` past the reservation (the Zlib
+                            // branch is already bounded by its reserved capacity). One extra byte
+                            // lets the `size != decompressed.len()` check below reject.
+                            let limit = (size as u64)
+                                .saturating_sub(decompressed.len() as u64)
+                                .saturating_add(1);
+                            (&mut decoder)
+                                .take(limit)
                                 .read_to_end(&mut decompressed)
                                 .ok()
                                 .read_error("Invalid zstd compressed data")?;
+                            if decompressed.len() > size {
+                                break;
+                            }
                         }
                     }
                     _ => unreachable!(),


### PR DESCRIPTION
Fixes #950.

The Zstandard branch of `CompressedData::decompress` grows `decompressed` past the `try_reserve_exact(size)` reservation that the Zlib branch respects (`decompress_vec` stays within its reserved capacity, `read_to_end` does not). So a section declaring a small `ch_size` can allocate the full decoded size of a large-expanding zstd stream before the trailing `size != decompressed.len()` check rejects it.

This bounds the zstd read to `size` (plus one byte, so the existing size check still rejects an over-long stream), so the allocation can no longer exceed the declared uncompressed size.

Verified against `main`:
- the PoC from #950 (6.7 KB ELF) previously peaked at ~386 MB RSS; with this change it stays ~3 MB and returns the existing "size does not match" error;
- `cargo test` passes (25 lib + 7 integration);
- normal binaries still decode.

Discovered by the [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace/) security pipeline.
