### PR TITLE
read/macho: bound exports trie traversal to avoid exponential blowup

### DIFF
--- a/src/read/macho/exports_trie.rs
+++ b/src/read/macho/exports_trie.rs
@@ -117,6 +117,12 @@ struct NodeIterator<'data> {
     stack: Vec<Frame<'data>>,
     // Accumulates the prefix edge strings as we traverse the trie.
     name_buf: Vec<u8>,
+    // Bounds the traversal. A well-formed exports trie is a prefix tree with at
+    // most `data.len()` nodes, so a DFS needs at most ~2 * data.len() steps. The
+    // ancestor check below rejects cycles, but not shared subtrees, which can
+    // cause exponential re-traversal; this budget stops such (and any other
+    // pathological) input cleanly instead of hanging.
+    budget: usize,
 }
 
 // Implements a DFS pre-order traversal of the exports trie.
@@ -127,6 +133,7 @@ impl<'data> NodeIterator<'data> {
             first: true,
             stack: Vec::new(),
             name_buf: Vec::new(),
+            budget: data.len().saturating_mul(2).saturating_add(2),
         }
     }
 
@@ -169,6 +176,15 @@ impl<'data> NodeIterator<'data> {
     // - `Ok(Some(None))` if we don't have terminal data at the current node.
     // - `Ok(None)` if we've reached the end of the trie.
     fn next(&mut self) -> Result<Option<Option<ExportSymbol<'data>>>> {
+        match self.budget.checked_sub(1) {
+            Some(remaining) => self.budget = remaining,
+            None => {
+                // Cyclic or shared-subtree (exponential) trie: stop cleanly.
+                self.stack.clear();
+                self.first = false;
+                return Ok(None);
+            }
+        }
         if self.first {
             self.first = false;
             // The root node is at offset 0.


### PR DESCRIPTION
Fixes #952.

The cycle check added in #940 rejects a child offset equal to an ancestor, but not shared subtrees: a node reached by multiple non-ancestor paths is re-traversed each time. A trie whose every node has two edges to the same next node therefore has `2^depth` root-to-leaf paths and the DFS runs in exponential time (a ~330-byte Mach-O hangs the `exports_trie()` iterator).

A well-formed exports trie is a prefix tree with at most `data.len()` nodes, so a valid DFS needs at most ~`2 * data.len()` steps. This bounds the traversal to that and stops cleanly when exceeded, covering shared-subtree (and any residual cyclic) inputs.

Verified against `main`: `cargo test` passes (25 lib incl the `exports_trie` tests, integration, and `--features all`), valid tries still traverse, and the crafted exponential trie (#952) now terminates instead of hanging.

Discovered by the [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace) security pipeline.
