### PR TITLE
read/macho: use LC_DYLD_CHAINED_FIXUPS and LC_DYLD_INFO_ONLY for imports

### DIFF
--- a/crates/examples/testfiles/macho/base-aarch64.objdump
+++ b/crates/examples/testfiles/macho/base-aarch64.objdump
@@ -22,7 +22,7 @@ Symbols
 
 Dynamic symbols
 
-Import { library: "/usr/lib/libSystem.B.dylib", name: "_printf", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "_printf", flags: MachOBind { dylib: 1, flags: 0 } }
 
 Export { name: "__mh_execute_header", target: Address { address: 100000000 }, flags: None }
 Export { name: "_main", target: Address { address: 100003f68 }, flags: None }

--- a/crates/examples/testfiles/macho/base-x86_64.objdump
+++ b/crates/examples/testfiles/macho/base-x86_64.objdump
@@ -28,8 +28,8 @@ Symbols
 
 Dynamic symbols
 
-Import { library: "/usr/lib/libSystem.B.dylib", name: "_printf", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
-Import { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder", flags: MachOBind { dylib: 1, flags: 0 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "_printf", flags: MachOBind { dylib: 1, flags: 0 } }
 
 Export { name: "__mh_execute_header", target: Address { address: 100000000 }, flags: None }
 Export { name: "_main", target: Address { address: 100003f60 }, flags: None }

--- a/crates/examples/testfiles/macho/imports-dyldinfo.bundle.objdump
+++ b/crates/examples/testfiles/macho/imports-dyldinfo.bundle.objdump
@@ -29,11 +29,12 @@ Symbols
 
 Dynamic symbols
 
-Import { library: "/usr/lib/libSystem.B.dylib", name: "_close", weak: true, flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x140 } }
-Import { library: "/usr/lib/libSystem.B.dylib", name: "_dup", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
-Import { library: "", name: "_flat_lookup", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0xfe00 } }
-Import { library: "", name: "_main_executable", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0xff00 } }
-Import { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder", flags: MachOBind { dylib: 1, flags: 0 } }
+Import { library: "", name: "_weak_lookup", flags: MachOBind { dylib: BIND_SPECIAL_DYLIB_WEAK_LOOKUP, flags: 0 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "_close", weak: true, flags: MachOBind { dylib: 1, flags: BIND_SYMBOL_FLAGS_WEAK_IMPORT } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "_dup", flags: MachOBind { dylib: 1, flags: 0 } }
+Import { library: "", name: "_flat_lookup", flags: MachOBind { dylib: BIND_SPECIAL_DYLIB_FLAT_LOOKUP, flags: 0 } }
+Import { library: "", name: "_main_executable", flags: MachOBind { dylib: BIND_SPECIAL_DYLIB_MAIN_EXECUTABLE, flags: 0 } }
 
 Export { name: "_interposable", target: Address { address: 480 }, flags: None }
 Export { name: "_use_imports", target: Address { address: 4a0 }, flags: None }

--- a/crates/examples/testfiles/macho/imports.bundle.objdump
+++ b/crates/examples/testfiles/macho/imports.bundle.objdump
@@ -24,10 +24,11 @@ Symbols
 
 Dynamic symbols
 
-Import { library: "/usr/lib/libSystem.B.dylib", name: "_close", weak: true, flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x140 } }
-Import { library: "/usr/lib/libSystem.B.dylib", name: "_dup", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
-Import { library: "", name: "_flat_lookup", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0xfe00 } }
-Import { library: "", name: "_main_executable", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0xff00 } }
+Import { library: "", name: "_main_executable", flags: MachOBind { dylib: BIND_SPECIAL_DYLIB_MAIN_EXECUTABLE, flags: 0 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "_close", weak: true, flags: MachOBind { dylib: 1, flags: BIND_SYMBOL_FLAGS_WEAK_IMPORT } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "_dup", flags: MachOBind { dylib: 1, flags: 0 } }
+Import { library: "", name: "_flat_lookup", flags: MachOBind { dylib: BIND_SPECIAL_DYLIB_FLAT_LOOKUP, flags: 0 } }
+Import { library: "", name: "_weak_lookup", flags: MachOBind { dylib: BIND_SPECIAL_DYLIB_WEAK_LOOKUP, flags: 0 } }
 
 Export { name: "_interposable", target: Address { address: 390 }, flags: None }
 Export { name: "_use_imports", target: Address { address: 3a0 }, flags: None }

--- a/crates/examples/testfiles/macho/libexports.dylib.objdump
+++ b/crates/examples/testfiles/macho/libexports.dylib.objdump
@@ -29,8 +29,7 @@ Symbols
 
 Dynamic symbols
 
-Import { library: "/usr/lib/libSystem.B.dylib", name: "__tlv_bootstrap", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
-Import { library: "/usr/lib/libSystem.B.dylib", name: "dyld_stub_binder", flags: MachO { n_type: N_UNDF | N_EXT, n_desc: 0x100 } }
+Import { library: "/usr/lib/libSystem.B.dylib", name: "__tlv_bootstrap", flags: MachOBind { dylib: 1, flags: 0 } }
 
 Export { name: "_abs", target: Absolute { value: fffff }, flags: None }
 Export { name: "_foo", target: Resolver { resolver: 460, stub: Some(46c) }, flags: None }

--- a/src/read/macho/export.rs
+++ b/src/read/macho/export.rs
@@ -156,6 +156,8 @@ where
                         }
                         let library = usize::try_from(*dylib_ordinal)
                             .ok()
+                            // No special ordinals.
+                            .filter(|index| *index != 0)
                             .and_then(|index| libraries.as_deref()?.get(index).copied())
                             .read_error("Invalid Mach-O export dylib ordinal")?;
                         ExportTarget::Reexport {

--- a/src/read/macho/import.rs
+++ b/src/read/macho/import.rs
@@ -6,7 +6,10 @@ use crate::Endianness;
 use crate::macho;
 use crate::read::{Import, ImportFlags, NameOrOrdinal, ReadError, ReadRef, Result};
 
-use super::{MachHeader, MachOFile, Nlist, SymbolTable};
+use super::{
+    BindOperation, BindOperationIterator, DyldChainedImportIterator, MachHeader, MachOFile, Nlist,
+    SymbolTable,
+};
 
 /// An iterator for the imports in a [`MachOFile32`](super::MachOFile32).
 pub type MachOImportIterator32<'data, 'file, Endian = Endianness, R = &'data [u8]> =
@@ -21,11 +24,17 @@ where
     Mach: MachHeader,
     R: ReadRef<'data>,
 {
-    endian: Mach::Endian,
-    libraries: Vec<&'data [u8]>,
-    twolevel: bool,
-    symbols: &'file SymbolTable<'data, Mach, R>,
-    iter: slice::Iter<'data, Mach::Nlist>,
+    internal: MachOImportIteratorInternal<'data, 'file, Mach, R>,
+}
+
+enum MachOImportIteratorInternal<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    ChainedFixups(MachOImportChainedFixups<'data, Mach>),
+    DyldInfo(MachOImportDyldInfo<'data>),
+    Symbols(MachOImportSymbols<'data, 'file, Mach, R>),
 }
 
 impl<'data, 'file, Mach, R> fmt::Debug for MachOImportIterator<'data, 'file, Mach, R>
@@ -44,6 +53,66 @@ where
     R: ReadRef<'data>,
 {
     pub(super) fn new(file: &'file MachOFile<'data, Mach, R>) -> Result<Self> {
+        let mut chained_fixups = None;
+        let mut dyld_info = None;
+        let mut commands = file.macho_load_commands()?;
+        while let Some(command) = commands.next()? {
+            if let Some(command) = command.dyld_chained_fixups()? {
+                chained_fixups = Some(command);
+            } else if let Some(command) = command.dyld_info()? {
+                dyld_info = Some(command);
+            }
+        }
+        let internal = if let Some(chained_fixups) = chained_fixups {
+            MachOImportChainedFixups::new(file, chained_fixups)
+                .map(MachOImportIteratorInternal::ChainedFixups)?
+        } else if let Some(dyld_info) = dyld_info {
+            MachOImportDyldInfo::new(file, dyld_info).map(MachOImportIteratorInternal::DyldInfo)?
+        } else {
+            MachOImportSymbols::new(file).map(MachOImportIteratorInternal::Symbols)?
+        };
+        Ok(MachOImportIterator { internal })
+    }
+
+    fn next(&mut self) -> Result<Option<Import<'data>>> {
+        match &mut self.internal {
+            MachOImportIteratorInternal::ChainedFixups(iter) => iter.next(),
+            MachOImportIteratorInternal::DyldInfo(iter) => iter.next(),
+            MachOImportIteratorInternal::Symbols(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'data, 'file, Mach, R> Iterator for MachOImportIterator<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    type Item = Result<Import<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next().transpose()
+    }
+}
+
+struct MachOImportSymbols<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    endian: Mach::Endian,
+    libraries: Vec<&'data [u8]>,
+    twolevel: bool,
+    symbols: &'file SymbolTable<'data, Mach, R>,
+    iter: slice::Iter<'data, Mach::Nlist>,
+}
+
+impl<'data, 'file, Mach, R> MachOImportSymbols<'data, 'file, Mach, R>
+where
+    Mach: MachHeader,
+    R: ReadRef<'data>,
+{
+    fn new(file: &'file MachOFile<'data, Mach, R>) -> Result<Self> {
         let endian = file.endian;
         let twolevel = file.header.flags(endian).contains(macho::MH_TWOLEVEL);
         let libraries = if twolevel {
@@ -53,7 +122,7 @@ where
         };
         // `LC_DYSYMTAB` is not required, so use the symbol table directly.
         let iter = file.symbols.symbols().iter();
-        Ok(MachOImportIterator {
+        Ok(MachOImportSymbols {
             endian,
             libraries,
             twolevel,
@@ -97,14 +166,192 @@ where
     }
 }
 
-impl<'data, 'file, Mach, R> Iterator for MachOImportIterator<'data, 'file, Mach, R>
+struct MachOImportChainedFixups<'data, Mach>
 where
     Mach: MachHeader,
-    R: ReadRef<'data>,
 {
-    type Item = Result<Import<'data>>;
+    libraries: Vec<&'data [u8]>,
+    iter: DyldChainedImportIterator<'data, Mach::Endian>,
+}
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.next().transpose()
+impl<'data, Mach> MachOImportChainedFixups<'data, Mach>
+where
+    Mach: MachHeader,
+{
+    fn new<R: ReadRef<'data>>(
+        file: &MachOFile<'data, Mach, R>,
+        chained_fixups: &'data macho::LinkeditDataCommand<Mach::Endian>,
+    ) -> Result<Self> {
+        let endian = file.endian;
+        let data = file
+            .linkedit_data
+            .read_error("Missing Mach-O linkedit segment")?;
+        let iter = chained_fixups
+            .chained_fixups(endian, data.0)?
+            .imports(endian)?;
+        Ok(MachOImportChainedFixups {
+            libraries: file.libraries()?,
+            iter,
+        })
     }
+
+    fn next(&mut self) -> Result<Option<Import<'data>>> {
+        loop {
+            let Some(import) = self.iter.next()? else {
+                return Ok(None);
+            };
+            // The above iterator has made progress, so errors after here don't need to
+            // terminate iteration.
+
+            if import.dylib == macho::BIND_SPECIAL_DYLIB_SELF {
+                // Not really an import.
+                continue;
+            }
+
+            // Synthesise flags.
+            let flags = if import.weak_import {
+                macho::BIND_SYMBOL_FLAGS_WEAK_IMPORT
+            } else {
+                macho::BindSymbolFlags(0)
+            };
+
+            return Ok(Some(Import {
+                library: library(&self.libraries, import.dylib)?,
+                name: NameOrOrdinal::Name(import.name),
+                weak: import.weak_import,
+                flags: ImportFlags::MachOBind {
+                    dylib: import.dylib,
+                    flags,
+                },
+            }));
+        }
+    }
+}
+
+struct MachOImportDyldInfo<'data> {
+    libraries: Vec<&'data [u8]>,
+
+    /// The bind, weak bind, and lazy bind streams, in that order.
+    binds: [BindOperationIterator<'data>; 3],
+    index: usize,
+    lazy: bool,
+
+    dylib: Option<macho::BindDylib>,
+    symbol: Option<(macho::BindSymbolFlags, &'data [u8])>,
+    unbound: bool,
+}
+
+impl<'data> MachOImportDyldInfo<'data> {
+    fn new<Mach, R>(
+        file: &MachOFile<'data, Mach, R>,
+        dyld_info: &'data macho::DyldInfoCommand<Mach::Endian>,
+    ) -> Result<Self>
+    where
+        Mach: MachHeader,
+        R: ReadRef<'data>,
+    {
+        let endian = file.endian;
+        let data = file
+            .linkedit_data
+            .read_error("Missing Mach-O linkedit segment")?;
+        let binds = [
+            dyld_info.bind_operations(endian, data.0)?,
+            dyld_info.weak_bind_operations(endian, data.0)?,
+            dyld_info.lazy_bind_operations(endian, data.0)?,
+        ];
+        Ok(MachOImportDyldInfo {
+            libraries: file.libraries()?,
+            binds,
+            index: 0,
+            lazy: false,
+            dylib: None,
+            symbol: None,
+            unbound: false,
+        })
+    }
+
+    fn next(&mut self) -> Result<Option<Import<'data>>> {
+        loop {
+            let Some(iter) = self.binds.get_mut(self.index) else {
+                return Ok(None);
+            };
+            let Some((_opcode, operation)) = iter.next()? else {
+                self.next_index();
+                continue;
+            };
+            // The above iterator has made progress, so errors after here don't need to
+            // terminate iteration.
+
+            match operation {
+                BindOperation::Done => {
+                    if self.lazy {
+                        // Only the state for the current bind is reset.
+                        self.dylib = None;
+                        self.symbol = None;
+                    } else {
+                        self.next_index();
+                        continue;
+                    }
+                }
+                BindOperation::SetDylibOrdinal { ordinal } => {
+                    let ordinal = i32::try_from(ordinal)
+                        .ok()
+                        .read_error("Invalid Mach-O bind ordinal")?;
+                    self.dylib = Some(macho::BindDylib(ordinal));
+                }
+                BindOperation::SetDylibSpecial { ordinal } => {
+                    self.dylib = Some(ordinal);
+                }
+                BindOperation::SetSymbol { flags, name } => {
+                    self.symbol = Some((flags, name));
+                    // Only report a symbol for the first bind that uses it.
+                    self.unbound = true;
+                }
+                BindOperation::DoBindTimesSkipping { count: 0, .. } => {}
+                BindOperation::DoBind
+                | BindOperation::DoBindAddAddr { .. }
+                | BindOperation::DoBindTimesSkipping { .. }
+                | BindOperation::DoBindAddAddrScaled { .. } => {
+                    if self.unbound {
+                        self.unbound = false;
+                        let (flags, name) = self.symbol.read_error("Missing Mach-O bind symbol")?;
+                        let dylib = self.dylib.read_error("Missing Mach-O bind dylib")?;
+                        if dylib != macho::BIND_SPECIAL_DYLIB_SELF {
+                            return Ok(Some(Import {
+                                library: library(&self.libraries, dylib)?,
+                                name: NameOrOrdinal::Name(name),
+                                weak: flags.contains(macho::BIND_SYMBOL_FLAGS_WEAK_IMPORT),
+                                flags: ImportFlags::MachOBind { dylib, flags },
+                            }));
+                        }
+                    }
+                }
+                BindOperation::SetType { .. }
+                | BindOperation::SetAddend { .. }
+                | BindOperation::SetSegmentAndOffset { .. }
+                | BindOperation::AddAddr { .. } => {}
+            }
+        }
+    }
+
+    fn next_index(&mut self) {
+        self.index += 1;
+        self.lazy = self.index == 2;
+        self.dylib = if self.index == 1 {
+            Some(macho::BIND_SPECIAL_DYLIB_WEAK_LOOKUP)
+        } else {
+            None
+        };
+        self.symbol = None;
+    }
+}
+
+fn library<'data>(libraries: &[&'data [u8]], dylib: macho::BindDylib) -> Result<&'data [u8]> {
+    let Some(index) = dylib.index() else {
+        return Ok(&[]);
+    };
+    libraries
+        .get(index as usize)
+        .copied()
+        .read_error("Invalid Mach-O bind dylib ordinal")
 }

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -309,6 +309,15 @@ impl<'data, E: Endian> LoadCommandData<'data, E> {
         }
     }
 
+    /// Try to parse this command as an `LC_DYLD_CHAINED_FIXUPS` [`macho::LinkeditDataCommand`].
+    pub fn dyld_chained_fixups(self) -> Result<Option<&'data macho::LinkeditDataCommand<E>>> {
+        if self.cmd == macho::LC_DYLD_CHAINED_FIXUPS {
+            Some(self.data()).transpose()
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Try to parse this command as an [`macho::EntryPointCommand`].
     pub fn entry_point(self) -> Result<Option<&'data macho::EntryPointCommand<E>>> {
         if self.cmd == macho::LC_MAIN {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -453,7 +453,7 @@ impl<'data> Import<'data> {
     /// This is empty if the library name is not specified.
     ///
     /// For Mach-O, this will also be empty for a special library ordinal,
-    /// which can be obtained from the `n_desc` field in the flags.
+    /// which can be obtained from the `n_desc` or `dylib` field in the flags.
     #[inline]
     pub fn library(&self) -> &'data [u8] {
         self.library
@@ -504,6 +504,16 @@ pub enum ImportFlags<'data> {
         /// For a file using `MH_TWOLEVEL`, this contains the library ordinal.
         n_desc: crate::macho::SymbolDesc,
     },
+    /// Mach-O dynamic linker import flags.
+    ///
+    /// Used for imports that are obtained from `LC_DYLD_CHAINED_FIXUPS` or `LC_DYLD_INFO`.
+    #[cfg(feature = "macho")]
+    MachOBind {
+        /// The library ordinal that the symbol is imported from.
+        dylib: crate::macho::BindDylib,
+        /// The bind symbol flags.
+        flags: crate::macho::BindSymbolFlags,
+    },
     /// PE import flags.
     #[cfg(feature = "pe")]
     Pe {
@@ -541,6 +551,12 @@ impl<'data> fmt::Debug for ImportFlags<'data> {
                 .debug_struct("MachO")
                 .field("n_type", n_type)
                 .field("n_desc", n_desc)
+                .finish(),
+            #[cfg(feature = "macho")]
+            ImportFlags::MachOBind { dylib, flags } => f
+                .debug_struct("MachOBind")
+                .field("dylib", dylib)
+                .field("flags", flags)
                 .finish(),
             #[cfg(feature = "pe")]
             ImportFlags::Pe { delay } => {
@@ -680,7 +696,6 @@ pub enum ExportTarget<'data> {
         /// The name of the library.
         ///
         /// This is empty if the library is not specified.
-        // TODO: Mach-O special library ordinals
         library: &'data [u8],
         /// The name or ordinal of the symbol in the external library.
         name: NameOrOrdinal<&'data [u8]>,


### PR DESCRIPTION
Also small fix to dylib ordinal validation for exports.