### PR TITLE
Use ruzstd::FrameDecoder::decode_all_to_vec

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1206,6 +1206,13 @@ impl<'data> CompressedData<'data> {
 
     /// Return the uncompressed data.
     ///
+    /// If decompression is required, this allocates [`Self::uncompressed_size`] bytes.
+    /// This is typically a value recorded in the file, and is not bounded, so check it
+    /// first if you need to bound it for untrusted files.
+    ///
+    /// Returns an error if the decompressed length does not equal
+    /// [`Self::uncompressed_size`].
+    ///
     /// Returns an error for invalid data or unsupported compression.
     /// This includes if the data is compressed but the `compression` feature
     /// for this crate is disabled.
@@ -1216,7 +1223,6 @@ impl<'data> CompressedData<'data> {
             CompressionFormat::Zlib | CompressionFormat::Zstandard => {
                 use alloc::vec::Vec;
                 use core::convert::TryInto;
-                use std::io::Read;
                 let size = self
                     .uncompressed_size
                     .try_into()
@@ -1241,30 +1247,11 @@ impl<'data> CompressedData<'data> {
                             .read_error("Invalid zlib compressed data")?;
                     }
                     CompressionFormat::Zstandard => {
-                        let mut input = self.data;
-                        while !input.is_empty() {
-                            let mut decoder = match ruzstd::decoding::StreamingDecoder::new(&mut input) {
-                                Ok(decoder) => decoder,
-                                Err(
-                                    ruzstd::decoding::errors::FrameDecoderError::ReadFrameHeaderError(
-                                        ruzstd::decoding::errors::ReadFrameHeaderError::SkipFrame {
-                                            length,
-                                            ..
-                                        },
-                                    ),
-                                ) => {
-                                    input = input
-                                        .get(length as usize..)
-                                        .read_error("Invalid zstd compressed data")?;
-                                    continue;
-                                }
-                                x => x.ok().read_error("Invalid zstd compressed data")?,
-                            };
-                            decoder
-                                .read_to_end(&mut decompressed)
-                                .ok()
-                                .read_error("Invalid zstd compressed data")?;
-                        }
+                        let mut decoder = ruzstd::decoding::FrameDecoder::new();
+                        decoder
+                            .decode_all_to_vec(self.data, &mut decompressed)
+                            .ok()
+                            .read_error("Invalid zstd compressed data")?;
                     }
                     _ => unreachable!(),
                 }

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -397,6 +397,11 @@ pub trait ObjectSection<'data>: read::private::Sealed {
     /// The length of this data may be different from the size of the
     /// section in memory.
     ///
+    /// This may allocate the uncompressed size that is recorded in the file, which
+    /// is not bounded. Use [`Self::compressed_data`] and check
+    /// [`CompressedData::uncompressed_size`] first if you need to bound this for
+    /// untrusted files.
+    ///
     /// If no compression is detected, then returns the data unchanged.
     /// Returns `Err` if decompression fails.
     fn uncompressed_data(&self) -> Result<Cow<'data, [u8]>> {


### PR DESCRIPTION
This validates that the declared `CompressedData::uncompresed_size` matches the decoded data. This value is directly from the input, and `object` places no limits on it, so `Object::uncompressed_data` is still able to allocate arbitrary amounts of memory.

However, it does mean that callers can now implement their own check on `CompressedData::uncompressed_size` prior to calling `CompressedData::decompress` and rely on it to be honored.

Closes #950
Closes #951