### PR TITLE
macho: add reserved2 field to SectionFlags::MachO

### DIFF
--- a/crates/examples/testfiles/macho/base-aarch64-debug.o.objdump
+++ b/crates/examples/testfiles/macho/base-aarch64-debug.o.objdump
@@ -5,17 +5,17 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 2ca, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 34, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__cstring", address: 34, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS } }
-3: Section { segment: "__DWARF", name: "__debug_abbrev", address: 41, size: 3a, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-4: Section { segment: "__DWARF", name: "__debug_info", address: 7b, size: 53, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-5: Section { segment: "__DWARF", name: "__debug_str", address: ce, size: cb, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-6: Section { segment: "__DWARF", name: "__apple_names", address: 199, size: 3c, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-7: Section { segment: "__DWARF", name: "__apple_objc", address: 1d5, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-8: Section { segment: "__DWARF", name: "__apple_namespac", address: 1f9, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-9: Section { segment: "__DWARF", name: "__apple_types", address: 21d, size: 47, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-10: Section { segment: "__LD", name: "__compact_unwind", address: 268, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-11: Section { segment: "__DWARF", name: "__debug_line", address: 288, size: 42, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 34, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__cstring", address: 34, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS, reserved2: 0 } }
+3: Section { segment: "__DWARF", name: "__debug_abbrev", address: 41, size: 3a, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+4: Section { segment: "__DWARF", name: "__debug_info", address: 7b, size: 53, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+5: Section { segment: "__DWARF", name: "__debug_str", address: ce, size: cb, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+6: Section { segment: "__DWARF", name: "__apple_names", address: 199, size: 3c, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+7: Section { segment: "__DWARF", name: "__apple_objc", address: 1d5, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+8: Section { segment: "__DWARF", name: "__apple_namespac", address: 1f9, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+9: Section { segment: "__DWARF", name: "__apple_types", address: 21d, size: 47, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+10: Section { segment: "__LD", name: "__compact_unwind", address: 268, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+11: Section { segment: "__DWARF", name: "__debug_line", address: 288, size: 42, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "ltmp0", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/base-aarch64.o.objdump
+++ b/crates/examples/testfiles/macho/base-aarch64.o.objdump
@@ -5,9 +5,9 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 68, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 34, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__cstring", address: 34, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS } }
-3: Section { segment: "__LD", name: "__compact_unwind", address: 48, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 34, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__cstring", address: 34, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS, reserved2: 0 } }
+3: Section { segment: "__LD", name: "__compact_unwind", address: 48, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "ltmp0", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/base-aarch64.objdump
+++ b/crates/examples/testfiles/macho/base-aarch64.objdump
@@ -9,11 +9,11 @@ Segment { name: "__PAGEZERO", address: 0, size: 100000000, permissions: --- }
 Segment { name: "__TEXT", address: 100000000, size: 4000, permissions: R-X }
 Segment { name: "__DATA_CONST", address: 100004000, size: 4000, permissions: RW- }
 Segment { name: "__LINKEDIT", address: 100008000, size: 4000, permissions: R-- }
-1: Section { segment: "__TEXT", name: "__text", address: 100003f68, size: 34, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__stubs", address: 100003f9c, size: c, align: 4, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-3: Section { segment: "__TEXT", name: "__cstring", address: 100003fa8, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS } }
-4: Section { segment: "__TEXT", name: "__unwind_info", address: 100003fb8, size: 48, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR } }
-5: Section { segment: "__DATA_CONST", name: "__got", address: 100004000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS } }
+1: Section { segment: "__TEXT", name: "__text", address: 100003f68, size: 34, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__stubs", address: 100003f9c, size: c, align: 4, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: c } }
+3: Section { segment: "__TEXT", name: "__cstring", address: 100003fa8, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS, reserved2: 0 } }
+4: Section { segment: "__TEXT", name: "__unwind_info", address: 100003fb8, size: 48, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
+5: Section { segment: "__DATA_CONST", name: "__got", address: 100004000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "__mh_execute_header", address: 100000000, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Dynamic, weak: false, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0x10 } }

--- a/crates/examples/testfiles/macho/base-x86_64-debug.o.objdump
+++ b/crates/examples/testfiles/macho/base-x86_64-debug.o.objdump
@@ -5,18 +5,18 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 2f6, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 25, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__cstring", address: 25, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS } }
-3: Section { segment: "__DWARF", name: "__debug_abbrev", address: 32, size: 3a, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-4: Section { segment: "__DWARF", name: "__debug_info", address: 6c, size: 53, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-5: Section { segment: "__DWARF", name: "__debug_str", address: bf, size: c8, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-6: Section { segment: "__DWARF", name: "__apple_names", address: 187, size: 3c, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-7: Section { segment: "__DWARF", name: "__apple_objc", address: 1c3, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-8: Section { segment: "__DWARF", name: "__apple_namespac", address: 1e7, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-9: Section { segment: "__DWARF", name: "__apple_types", address: 20b, size: 47, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-10: Section { segment: "__LD", name: "__compact_unwind", address: 258, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-11: Section { segment: "__TEXT", name: "__eh_frame", address: 278, size: 40, align: 8, kind: ReadOnlyData, flags: MachO { flags: S_COALESCED | S_ATTR_NO_TOC | S_ATTR_STRIP_STATIC_SYMS | S_ATTR_LIVE_SUPPORT } }
-12: Section { segment: "__DWARF", name: "__debug_line", address: 2b8, size: 3e, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 25, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__cstring", address: 25, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS, reserved2: 0 } }
+3: Section { segment: "__DWARF", name: "__debug_abbrev", address: 32, size: 3a, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+4: Section { segment: "__DWARF", name: "__debug_info", address: 6c, size: 53, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+5: Section { segment: "__DWARF", name: "__debug_str", address: bf, size: c8, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+6: Section { segment: "__DWARF", name: "__apple_names", address: 187, size: 3c, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+7: Section { segment: "__DWARF", name: "__apple_objc", address: 1c3, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+8: Section { segment: "__DWARF", name: "__apple_namespac", address: 1e7, size: 24, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+9: Section { segment: "__DWARF", name: "__apple_types", address: 20b, size: 47, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+10: Section { segment: "__LD", name: "__compact_unwind", address: 258, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+11: Section { segment: "__TEXT", name: "__eh_frame", address: 278, size: 40, align: 8, kind: ReadOnlyData, flags: MachO { flags: S_COALESCED | S_ATTR_NO_TOC | S_ATTR_STRIP_STATIC_SYMS | S_ATTR_LIVE_SUPPORT, reserved2: 0 } }
+12: Section { segment: "__DWARF", name: "__debug_line", address: 2b8, size: 3e, align: 1, kind: Debug, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_main", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Dynamic, weak: false, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/base-x86_64.o.objdump
+++ b/crates/examples/testfiles/macho/base-x86_64.o.objdump
@@ -5,10 +5,10 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 98, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 25, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__cstring", address: 25, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS } }
-3: Section { segment: "__LD", name: "__compact_unwind", address: 38, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG } }
-4: Section { segment: "__TEXT", name: "__eh_frame", address: 58, size: 40, align: 8, kind: ReadOnlyData, flags: MachO { flags: S_COALESCED | S_ATTR_NO_TOC | S_ATTR_STRIP_STATIC_SYMS | S_ATTR_LIVE_SUPPORT } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 25, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__cstring", address: 25, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS, reserved2: 0 } }
+3: Section { segment: "__LD", name: "__compact_unwind", address: 38, size: 20, align: 8, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_DEBUG, reserved2: 0 } }
+4: Section { segment: "__TEXT", name: "__eh_frame", address: 58, size: 40, align: 8, kind: ReadOnlyData, flags: MachO { flags: S_COALESCED | S_ATTR_NO_TOC | S_ATTR_STRIP_STATIC_SYMS | S_ATTR_LIVE_SUPPORT, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_main", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Dynamic, weak: false, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/base-x86_64.objdump
+++ b/crates/examples/testfiles/macho/base-x86_64.objdump
@@ -10,14 +10,14 @@ Segment { name: "__TEXT", address: 100000000, size: 4000, permissions: R-X }
 Segment { name: "__DATA_CONST", address: 100004000, size: 4000, permissions: RW- }
 Segment { name: "__DATA", address: 100008000, size: 4000, permissions: RW- }
 Segment { name: "__LINKEDIT", address: 10000c000, size: 4000, permissions: R-- }
-1: Section { segment: "__TEXT", name: "__text", address: 100003f60, size: 25, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__stubs", address: 100003f86, size: 6, align: 2, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-3: Section { segment: "__TEXT", name: "__stub_helper", address: 100003f8c, size: 1a, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-4: Section { segment: "__TEXT", name: "__cstring", address: 100003fa6, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS } }
-5: Section { segment: "__TEXT", name: "__unwind_info", address: 100003fb4, size: 48, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR } }
-6: Section { segment: "__DATA_CONST", name: "__got", address: 100004000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS } }
-7: Section { segment: "__DATA", name: "__la_symbol_ptr", address: 100008000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_LAZY_SYMBOL_POINTERS } }
-8: Section { segment: "__DATA", name: "__data", address: 100008008, size: 8, align: 8, kind: Data, flags: MachO { flags: S_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 100003f60, size: 25, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__stubs", address: 100003f86, size: 6, align: 2, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 6 } }
+3: Section { segment: "__TEXT", name: "__stub_helper", address: 100003f8c, size: 1a, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+4: Section { segment: "__TEXT", name: "__cstring", address: 100003fa6, size: d, align: 1, kind: ReadOnlyString, flags: MachO { flags: S_CSTRING_LITERALS, reserved2: 0 } }
+5: Section { segment: "__TEXT", name: "__unwind_info", address: 100003fb4, size: 48, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
+6: Section { segment: "__DATA_CONST", name: "__got", address: 100004000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
+7: Section { segment: "__DATA", name: "__la_symbol_ptr", address: 100008000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
+8: Section { segment: "__DATA", name: "__data", address: 100008008, size: 8, align: 8, kind: Data, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "__dyld_private", address: 100008008, size: 0, kind: Data, section: Section(SectionIndex(8)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/exports.o.objdump
+++ b/crates/examples/testfiles/macho/exports.o.objdump
@@ -5,9 +5,9 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 2c, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: c, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__DATA", name: "__thread_vars", address: 10, size: 18, align: 8, kind: TlsVariables, flags: MachO { flags: S_THREAD_LOCAL_VARIABLES } }
-3: Section { segment: "__DATA", name: "__thread_data", address: 28, size: 4, align: 4, kind: Tls, flags: MachO { flags: S_THREAD_LOCAL_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: c, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__DATA", name: "__thread_vars", address: 10, size: 18, align: 8, kind: TlsVariables, flags: MachO { flags: S_THREAD_LOCAL_VARIABLES, reserved2: 0 } }
+3: Section { segment: "__DATA", name: "__thread_data", address: 28, size: 4, align: 4, kind: Tls, flags: MachO { flags: S_THREAD_LOCAL_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_tls$tlv$init", address: 28, size: 0, kind: Tls, section: Section(SectionIndex(3)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/imports-dyldinfo.bundle.objdump
+++ b/crates/examples/testfiles/macho/imports-dyldinfo.bundle.objdump
@@ -8,13 +8,13 @@ Mach UUID: [8f, 22, c8, 78, 8, 2e, 3a, cb, a1, 2, ed, 53, 52, f5, 81, 2a]
 Segment { name: "__TEXT", address: 0, size: 1000, permissions: R-X }
 Segment { name: "__DATA", address: 1000, size: 1000, permissions: RW- }
 Segment { name: "__LINKEDIT", address: 2000, size: 1000, permissions: R-- }
-1: Section { segment: "__TEXT", name: "__text", address: 480, size: 4c, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__stubs", address: 4cc, size: 24, align: 2, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-3: Section { segment: "__TEXT", name: "__stub_helper", address: 4f0, size: 4a, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-4: Section { segment: "__TEXT", name: "__unwind_info", address: 53c, size: 58, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR } }
-5: Section { segment: "__DATA", name: "__got", address: 1000, size: 10, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS } }
-6: Section { segment: "__DATA", name: "__la_symbol_ptr", address: 1010, size: 28, align: 8, kind: Unknown, flags: MachO { flags: S_LAZY_SYMBOL_POINTERS } }
-7: Section { segment: "__DATA", name: "__data", address: 1038, size: 8, align: 8, kind: Data, flags: MachO { flags: S_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 480, size: 4c, align: 10, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__stubs", address: 4cc, size: 24, align: 2, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 6 } }
+3: Section { segment: "__TEXT", name: "__stub_helper", address: 4f0, size: 4a, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+4: Section { segment: "__TEXT", name: "__unwind_info", address: 53c, size: 58, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
+5: Section { segment: "__DATA", name: "__got", address: 1000, size: 10, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
+6: Section { segment: "__DATA", name: "__la_symbol_ptr", address: 1010, size: 28, align: 8, kind: Unknown, flags: MachO { flags: S_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
+7: Section { segment: "__DATA", name: "__data", address: 1038, size: 8, align: 8, kind: Data, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "__dyld_private", address: 1038, size: 0, kind: Data, section: Section(SectionIndex(7)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/imports.bundle.objdump
+++ b/crates/examples/testfiles/macho/imports.bundle.objdump
@@ -8,10 +8,10 @@ Mach UUID: [82, 83, 4c, a9, a4, ad, 3d, 9a, 92, 2b, 3d, 24, bf, 2f, a1, 86]
 Segment { name: "__TEXT", address: 0, size: 4000, permissions: R-X }
 Segment { name: "__DATA_CONST", address: 4000, size: 4000, permissions: RW- }
 Segment { name: "__LINKEDIT", address: 8000, size: 4000, permissions: R-- }
-1: Section { segment: "__TEXT", name: "__text", address: 390, size: 4c, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__stubs", address: 3dc, size: 48, align: 4, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-3: Section { segment: "__TEXT", name: "__unwind_info", address: 424, size: 60, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR } }
-4: Section { segment: "__DATA_CONST", name: "__got", address: 4000, size: 30, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS } }
+1: Section { segment: "__TEXT", name: "__text", address: 390, size: 4c, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__stubs", address: 3dc, size: 48, align: 4, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: c } }
+3: Section { segment: "__TEXT", name: "__unwind_info", address: 424, size: 60, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
+4: Section { segment: "__DATA_CONST", name: "__got", address: 4000, size: 30, align: 8, kind: Unknown, flags: MachO { flags: S_NON_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_interposable", address: 390, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Dynamic, weak: false, flags: MachO { n_type: N_SECT | N_EXT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/libexports.dylib.objdump
+++ b/crates/examples/testfiles/macho/libexports.dylib.objdump
@@ -8,12 +8,12 @@ Mach UUID: [9c, 74, 2d, 58, db, b2, 33, 1, bd, 99, 78, 30, 93, d2, ef, 76]
 Segment { name: "__TEXT", address: 0, size: 4000, permissions: R-X }
 Segment { name: "__DATA", address: 4000, size: 4000, permissions: RW- }
 Segment { name: "__LINKEDIT", address: 8000, size: 4000, permissions: R-- }
-1: Section { segment: "__TEXT", name: "__text", address: 460, size: c, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__TEXT", name: "__stubs", address: 46c, size: c, align: 4, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-3: Section { segment: "__TEXT", name: "__resolver_help", address: 478, size: 64, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-4: Section { segment: "__DATA", name: "__la_symbol_ptr", address: 4000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_LAZY_SYMBOL_POINTERS } }
-5: Section { segment: "__DATA", name: "__thread_vars", address: 4008, size: 18, align: 8, kind: TlsVariables, flags: MachO { flags: S_THREAD_LOCAL_VARIABLES } }
-6: Section { segment: "__DATA", name: "__thread_data", address: 4020, size: 4, align: 4, kind: Tls, flags: MachO { flags: S_THREAD_LOCAL_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 460, size: c, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__TEXT", name: "__stubs", address: 46c, size: c, align: 4, kind: Unknown, flags: MachO { flags: S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: c } }
+3: Section { segment: "__TEXT", name: "__resolver_help", address: 478, size: 64, align: 4, kind: Unknown, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+4: Section { segment: "__DATA", name: "__la_symbol_ptr", address: 4000, size: 8, align: 8, kind: Unknown, flags: MachO { flags: S_LAZY_SYMBOL_POINTERS, reserved2: 0 } }
+5: Section { segment: "__DATA", name: "__thread_vars", address: 4008, size: 18, align: 8, kind: TlsVariables, flags: MachO { flags: S_THREAD_LOCAL_VARIABLES, reserved2: 0 } }
+6: Section { segment: "__DATA", name: "__thread_data", address: 4020, size: 4, align: 4, kind: Tls, flags: MachO { flags: S_THREAD_LOCAL_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_tls$tlv$init", address: 4020, size: 0, kind: Tls, section: Section(SectionIndex(6)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/reloc-aarch64.o.objdump
+++ b/crates/examples/testfiles/macho/reloc-aarch64.o.objdump
@@ -5,8 +5,8 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 48, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 28, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__DATA", name: "__data", address: 28, size: 20, align: 1, kind: Data, flags: MachO { flags: S_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 28, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__DATA", name: "__data", address: 28, size: 20, align: 1, kind: Data, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "ltmp0", address: 0, size: 0, kind: Section, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/reloc-arm.o.objdump
+++ b/crates/examples/testfiles/macho/reloc-arm.o.objdump
@@ -5,8 +5,8 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 3c, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 28, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__DATA", name: "__data", address: 28, size: 14, align: 1, kind: Data, flags: MachO { flags: S_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 28, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__DATA", name: "__data", address: 28, size: 14, align: 1, kind: Data, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_g1", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/reloc-i386.o.objdump
+++ b/crates/examples/testfiles/macho/reloc-i386.o.objdump
@@ -5,8 +5,8 @@ Flags: MachO { flags: MH_SUBSECTIONS_VIA_SYMBOLS }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 25, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 11, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__DATA", name: "__data", address: 11, size: 14, align: 1, kind: Data, flags: MachO { flags: S_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 11, align: 4, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__DATA", name: "__data", address: 11, size: 14, align: 1, kind: Data, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_g1", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/crates/examples/testfiles/macho/reloc-x86_64.o.objdump
+++ b/crates/examples/testfiles/macho/reloc-x86_64.o.objdump
@@ -5,8 +5,8 @@ Flags: MachO { flags: 0 }
 Relative Address Base: 0
 Entry Address: 0
 Segment { name: "", address: 0, size: 6b, permissions: RWX }
-1: Section { segment: "__TEXT", name: "__text", address: 0, size: 53, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS } }
-2: Section { segment: "__DATA", name: "__data", address: 53, size: 18, align: 1, kind: Data, flags: MachO { flags: S_REGULAR } }
+1: Section { segment: "__TEXT", name: "__text", address: 0, size: 53, align: 1, kind: Text, flags: MachO { flags: S_REGULAR | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS, reserved2: 0 } }
+2: Section { segment: "__DATA", name: "__data", address: 53, size: 18, align: 1, kind: Data, flags: MachO { flags: S_REGULAR, reserved2: 0 } }
 
 Symbols
 0: Symbol { name: "_g1", address: 0, size: 0, kind: Text, section: Section(SectionIndex(1)), scope: Compilation, weak: false, flags: MachO { n_type: N_SECT, n_desc: 0 } }

--- a/src/common.rs
+++ b/src/common.rs
@@ -627,6 +627,10 @@ pub enum SectionFlags {
     MachO {
         /// `flags` field in the section header.
         flags: crate::macho::SectionFlags,
+        /// `reserved2` field in the section header.
+        ///
+        /// This is the size of a stub in a section with type `S_SYMBOL_STUBS`.
+        reserved2: u32,
     },
     /// COFF section flags.
     #[cfg(feature = "coff")]

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -228,6 +228,7 @@ where
     fn flags(&self) -> SectionFlags {
         SectionFlags::MachO {
             flags: self.internal.section.flags(self.file.endian),
+            reserved2: self.internal.section.reserved2(self.file.endian),
         }
     }
 }

--- a/src/write/macho/object.rs
+++ b/src/write/macho/object.rs
@@ -140,6 +140,7 @@ impl<'a> Object<'a> {
                         | macho::S_ATTR_LIVE_SUPPORT
                         | macho::S_ATTR_NO_TOC
                         | macho::S_ATTR_STRIP_STATIC_SYMS,
+                    reserved2: 0,
                 },
             ),
         }
@@ -167,7 +168,10 @@ impl<'a> Object<'a> {
                 return SectionFlags::None;
             }
         };
-        SectionFlags::MachO { flags }
+        SectionFlags::MachO {
+            flags,
+            reserved2: 0,
+        }
     }
 
     pub(crate) fn macho_symbol_flags(&self, symbol: &Symbol) -> SymbolFlags<SectionId, SymbolId> {
@@ -687,7 +691,7 @@ impl<'a> Object<'a> {
                     ))
                 })?
                 .copy_from_slice(&section.segment);
-            let SectionFlags::MachO { flags } = self.section_flags(section) else {
+            let SectionFlags::MachO { flags, reserved2 } = self.section_flags(section) else {
                 return Err(Error(format!(
                     "unimplemented section `{}` kind {:?}",
                     section.name().unwrap_or(""),
@@ -705,7 +709,7 @@ impl<'a> Object<'a> {
                 nreloc: section_offsets[index].reloc_count as u32,
                 flags,
                 reserved1: 0,
-                reserved2: 0,
+                reserved2,
                 reserved3: 0,
             };
             encoder.section_header(buffer, section_header);

--- a/tests/round_trip/section_flags.rs
+++ b/tests/round_trip/section_flags.rs
@@ -71,7 +71,10 @@ fn macho_x86_64_section_flags() {
     let flags = object::macho::S_REGULAR | object::macho::S_ATTR_SELF_MODIFYING_CODE;
 
     let section = object.add_section(Vec::new(), b".text".to_vec(), SectionKind::Text);
-    object.section_mut(section).flags = SectionFlags::MachO { flags };
+    object.section_mut(section).flags = SectionFlags::MachO {
+        flags,
+        reserved2: 2,
+    };
 
     let bytes = object.write().unwrap();
 
@@ -82,5 +85,11 @@ fn macho_x86_64_section_flags() {
     let mut sections = object.sections();
     let section = sections.next().unwrap();
     assert_eq!(section.name(), Ok(".text"));
-    assert_eq!(section.flags(), SectionFlags::MachO { flags });
+    assert_eq!(
+        section.flags(),
+        SectionFlags::MachO {
+            flags,
+            reserved2: 2
+        }
+    );
 }


### PR DESCRIPTION
This makes it possible to set when writing relocatable object files.