### PR TITLE
macho: fix handling of common symbols

### DIFF
--- a/crates/examples/src/bin/nm.rs
+++ b/crates/examples/src/bin/nm.rs
@@ -71,7 +71,6 @@ fn print_symbol(symbol: &Symbol<'_, '_>, section_kinds: &HashMap<SectionIndex, S
             }
             Some(SectionKind::ReadOnlyData) | Some(SectionKind::ReadOnlyString) => 'r',
             Some(SectionKind::UninitializedData) | Some(SectionKind::UninitializedTls) => 'b',
-            Some(SectionKind::Common) => 'C',
             _ => '?',
         },
         _ => '?',

--- a/crates/examples/src/readobj/macho.rs
+++ b/crates/examples/src/readobj/macho.rs
@@ -925,10 +925,13 @@ fn print_symtab_symbols<Mach: MachHeader>(
                 let n_desc = nlist.n_desc(endian);
                 if nlist.is_stab() {
                     p.field_hex("Desc", n_desc);
+                } else if nlist.is_common() {
+                    p.field_hex("Desc", n_desc);
+                    p.flag_bits(n_desc.with_common_alignment(0), SymbolDesc::NAMES_UNDEFINED);
+                    p.field("CommonAlignment", n_desc.common_alignment());
                 } else if nlist.is_undefined() {
                     if state.filetype == MH_OBJECT {
                         p.field_flags("Desc", n_desc, SymbolDesc::NAMES_UNDEFINED);
-                        // TODO: alignment for common symbols
                     } else {
                         let mut n_desc_bits = n_desc.with_reference(SymbolReference(0));
                         if state.twolevel {

--- a/src/common.rs
+++ b/src/common.rs
@@ -193,12 +193,8 @@ pub enum SectionKind {
     ///
     /// Example ELF sections: `.bss`
     ///
-    /// Example Mach-O sections: `__DATA/__bss`
+    /// Example Mach-O sections: `__DATA/__bss`, `__DATA/__common`
     UninitializedData,
-    /// An uninitialized common data section.
-    ///
-    /// Example Mach-O sections: `__DATA/__common`
-    Common,
     /// A TLS data section.
     ///
     /// Example ELF sections: `.tdata`
@@ -249,9 +245,7 @@ pub enum SectionKind {
 impl SectionKind {
     /// Return true if this section contains zerofill data.
     pub fn is_bss(self) -> bool {
-        self == SectionKind::UninitializedData
-            || self == SectionKind::UninitializedTls
-            || self == SectionKind::Common
+        self == SectionKind::UninitializedData || self == SectionKind::UninitializedTls
     }
 }
 

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -3512,7 +3512,7 @@ impl SymbolDesc {
 
     /// Get the alignment for common symbols.
     ///
-    /// This is a power of 2 from 1 to 15. A value of 0 mean that the natural
+    /// This is a power of 2 from 1 to 15. A value of 0 means that the natural
     /// alignment based on the size is used.
     ///
     /// Common symbols are represented by undefined (`N_UNDF`) external (`N_EXT`) symbols

--- a/src/read/elf/symbol.rs
+++ b/src/read/elf/symbol.rs
@@ -388,6 +388,10 @@ impl<'data, 'file, Elf: FileHeader, R: ReadRef<'data>> ObjectSymbol<'data>
 
     #[inline]
     fn address(&self) -> u64 {
+        if self.is_common() {
+            // The value is the alignment, not an address.
+            return 0;
+        }
         self.symbol.st_value(self.endian).into()
     }
 

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -269,7 +269,7 @@ impl<'data, Mach: MachHeader, R: ReadRef<'data>> MachOSectionInternal<'data, Mac
             (b"__DATA", b"__data") => SectionKind::Data,
             (b"__DATA", b"__const") => SectionKind::ReadOnlyData,
             (b"__DATA", b"__bss") => SectionKind::UninitializedData,
-            (b"__DATA", b"__common") => SectionKind::Common,
+            (b"__DATA", b"__common") => SectionKind::UninitializedData,
             (b"__DATA", b"__thread_data") => SectionKind::Tls,
             (b"__DATA", b"__thread_bss") => SectionKind::UninitializedTls,
             (b"__DATA", b"__thread_vars") => SectionKind::TlsVariables,

--- a/src/read/macho/symbol.rs
+++ b/src/read/macho/symbol.rs
@@ -379,49 +379,65 @@ where
 
     #[inline]
     fn address(&self) -> u64 {
+        if self.is_common() {
+            // The value is the size, not an address.
+            return 0;
+        }
         self.nlist.n_value(self.file.endian).into()
     }
 
     #[inline]
     fn size(&self) -> u64 {
+        if self.is_common() {
+            return self.nlist.n_value(self.file.endian).into();
+        }
         0
     }
 
     fn kind(&self) -> SymbolKind {
-        self.section()
+        if let Some(section) = self
+            .section()
             .index()
             .and_then(|index| self.file.section_internal(index).ok())
-            .map(|section| {
-                if let Ok(name) = self.name_bytes() {
-                    // Heuristic to match LLVM's convention for section symbols; may misclassify.
-                    if self.is_local()
-                        && name.len() > 4
-                        && name.starts_with(b"ltmp")
-                        && name[4..].iter().all(|b| b.is_ascii_digit())
-                        && self.address() == section.section.addr(self.file.endian).into()
-                    {
-                        return SymbolKind::Section;
-                    }
+        {
+            if let Ok(name) = self.name_bytes() {
+                // Heuristic to match LLVM's convention for section symbols; may misclassify.
+                if self.is_local()
+                    && name.len() > 4
+                    && name.starts_with(b"ltmp")
+                    && name[4..].iter().all(|b| b.is_ascii_digit())
+                    && self.address() == section.section.addr(self.file.endian).into()
+                {
+                    return SymbolKind::Section;
                 }
-                match section.kind {
-                    SectionKind::Text => SymbolKind::Text,
-                    SectionKind::Data
-                    | SectionKind::ReadOnlyData
-                    | SectionKind::ReadOnlyString
-                    | SectionKind::UninitializedData
-                    | SectionKind::Common => SymbolKind::Data,
-                    SectionKind::Tls
-                    | SectionKind::UninitializedTls
-                    | SectionKind::TlsVariables => SymbolKind::Tls,
-                    _ => SymbolKind::Unknown,
+            }
+            match section.kind {
+                SectionKind::Text => SymbolKind::Text,
+                SectionKind::Data
+                | SectionKind::ReadOnlyData
+                | SectionKind::ReadOnlyString
+                | SectionKind::UninitializedData => SymbolKind::Data,
+                SectionKind::Tls | SectionKind::UninitializedTls | SectionKind::TlsVariables => {
+                    SymbolKind::Tls
                 }
-            })
-            .unwrap_or(SymbolKind::Unknown)
+                _ => SymbolKind::Unknown,
+            }
+        } else if self.is_common() {
+            SymbolKind::Data
+        } else {
+            SymbolKind::Unknown
+        }
     }
 
     fn section(&self) -> SymbolSection {
         match self.nlist.n_type().typ() {
-            macho::N_UNDF => SymbolSection::Undefined,
+            macho::N_UNDF => {
+                if self.is_common() {
+                    SymbolSection::Common
+                } else {
+                    SymbolSection::Undefined
+                }
+            }
             macho::N_ABS => SymbolSection::Absolute,
             macho::N_SECT => {
                 let n_sect = self.nlist.n_sect();
@@ -437,7 +453,7 @@ where
 
     #[inline]
     fn is_undefined(&self) -> bool {
-        self.nlist.n_type().typ() == macho::N_UNDF
+        self.nlist.is_undefined()
     }
 
     #[inline]
@@ -447,8 +463,7 @@ where
 
     #[inline]
     fn is_common(&self) -> bool {
-        // Mach-O common symbols are based on section, not symbol
-        false
+        self.nlist.is_common()
     }
 
     #[inline]
@@ -459,7 +474,7 @@ where
 
     fn scope(&self) -> SymbolScope {
         let n_type = self.nlist.n_type();
-        if n_type.typ() == macho::N_UNDF {
+        if self.is_undefined() {
             SymbolScope::Unknown
         } else if !n_type.is_ext() {
             SymbolScope::Compilation
@@ -523,9 +538,24 @@ pub trait Nlist: Debug + Pod + read::private::Sealed {
     }
 
     /// Return true if this is an undefined symbol.
+    ///
+    /// This returns false for common symbols.
     fn is_undefined(&self) -> bool {
         let n_type = self.n_type();
-        !n_type.is_stab() && n_type.typ() == macho::N_UNDF
+        !n_type.is_stab()
+            && n_type.typ() == macho::N_UNDF
+            // Comparing `n_value` with 0 gives the same result for any endian.
+            && self.n_value(Self::Endian::default()).into() == 0
+    }
+
+    /// Return true if this is a common symbol.
+    fn is_common(&self) -> bool {
+        let n_type = self.n_type();
+        // Don't require N_EXT, to match the behavior of lld.
+        !n_type.is_stab()
+            && n_type.typ() == macho::N_UNDF
+            // Comparing `n_value` with 0 gives the same result for any endian.
+            && self.n_value(Self::Endian::default()).into() != 0
     }
 
     /// Return true if the symbol is a definition of a function or data object.

--- a/src/read/traits.rs
+++ b/src/read/traits.rs
@@ -517,7 +517,10 @@ pub trait ObjectSymbol<'data>: read::private::Sealed {
     /// Returns an error if the name is not UTF-8.
     fn name(&self) -> Result<&'data str>;
 
-    /// The address of the symbol. May be zero if the address is unknown.
+    /// The address of the symbol.
+    ///
+    /// May be zero if the symbol does not have an address, such as for undefined or
+    /// common symbols.
     fn address(&self) -> u64;
 
     /// The size of the symbol. May be zero if the size is unknown.
@@ -546,8 +549,6 @@ pub trait ObjectSymbol<'data>: read::private::Sealed {
     fn is_definition(&self) -> bool;
 
     /// Return true if the symbol is common data.
-    ///
-    /// Note: does not check for [`SymbolSection::Section`] with [`SectionKind::Common`].
     fn is_common(&self) -> bool;
 
     /// Return true if the symbol is weak.

--- a/src/write/coff/object.rs
+++ b/src/write/coff/object.rs
@@ -64,10 +64,6 @@ impl<'a> Object<'a> {
                 // Unsupported section.
                 (&[], &[], SectionKind::TlsVariables, SectionFlags::None)
             }
-            StandardSection::Common => {
-                // Unsupported section.
-                (&[], &[], SectionKind::Common, SectionFlags::None)
-            }
             StandardSection::GnuProperty => {
                 // Unsupported section.
                 (&[], &[], SectionKind::Note, SectionFlags::None)
@@ -119,8 +115,7 @@ impl<'a> Object<'a> {
                     | coff::IMAGE_SCN_MEM_DISCARDABLE
             }
             SectionKind::Linker => coff::IMAGE_SCN_LNK_INFO | coff::IMAGE_SCN_LNK_REMOVE,
-            SectionKind::Common
-            | SectionKind::Tls
+            SectionKind::Tls
             | SectionKind::UninitializedTls
             | SectionKind::TlsVariables
             | SectionKind::Note

--- a/src/write/elf/object.rs
+++ b/src/write/elf/object.rs
@@ -102,10 +102,6 @@ impl<'a> Object<'a> {
                 // Unsupported section.
                 (&[], &[], SectionKind::TlsVariables, SectionFlags::None)
             }
-            StandardSection::Common => {
-                // Unsupported section.
-                (&[], &[], SectionKind::Common, SectionFlags::None)
-            }
             StandardSection::GnuProperty => (
                 &[],
                 &b".note.gnu.property"[..],
@@ -145,7 +141,7 @@ impl<'a> Object<'a> {
 
     pub(crate) fn elf_section_flags(&self, section: &Section<'_>) -> SectionFlags {
         let sh_type = match section.kind {
-            SectionKind::Unknown | SectionKind::Common | SectionKind::TlsVariables => {
+            SectionKind::Unknown | SectionKind::TlsVariables => {
                 // Unsupported sections.
                 return SectionFlags::None;
             }

--- a/src/write/macho/object.rs
+++ b/src/write/macho/object.rs
@@ -121,12 +121,6 @@ impl<'a> Object<'a> {
                 SectionKind::TlsVariables,
                 SectionFlags::None,
             ),
-            StandardSection::Common => (
-                &b"__DATA"[..],
-                &b"__common"[..],
-                SectionKind::Common,
-                SectionFlags::None,
-            ),
             StandardSection::GnuProperty => {
                 // Unsupported section.
                 (&[], &[], SectionKind::Note, SectionFlags::None)
@@ -155,7 +149,7 @@ impl<'a> Object<'a> {
                 macho::S_REGULAR.into()
             }
             SectionKind::ReadOnlyString => macho::S_CSTRING_LITERALS.into(),
-            SectionKind::UninitializedData | SectionKind::Common => macho::S_ZEROFILL.into(),
+            SectionKind::UninitializedData => macho::S_ZEROFILL.into(),
             SectionKind::Tls => macho::S_THREAD_LOCAL_REGULAR.into(),
             SectionKind::UninitializedTls => macho::S_THREAD_LOCAL_ZEROFILL.into(),
             SectionKind::TlsVariables => macho::S_THREAD_LOCAL_VARIABLES.into(),
@@ -177,10 +171,10 @@ impl<'a> Object<'a> {
     pub(crate) fn macho_symbol_flags(&self, symbol: &Symbol) -> SymbolFlags<SectionId, SymbolId> {
         // TODO: N_STAB
         let n_type = match symbol.section {
-            SymbolSection::Undefined => macho::N_UNDF | macho::N_EXT,
+            SymbolSection::Undefined | SymbolSection::Common => macho::N_UNDF | macho::N_EXT,
             SymbolSection::Absolute => macho::N_ABS.into(),
             SymbolSection::Section(_) => macho::N_SECT.into(),
-            SymbolSection::None | SymbolSection::Common => {
+            SymbolSection::None => {
                 return SymbolFlags::None;
             }
         } | match symbol.scope {
@@ -188,7 +182,7 @@ impl<'a> Object<'a> {
             SymbolScope::Linkage => macho::N_EXT | macho::N_PEXT,
             SymbolScope::Dynamic => macho::N_EXT,
         };
-        let n_desc = if symbol.weak {
+        let mut n_desc = if symbol.weak {
             if symbol.is_undefined() {
                 macho::N_WEAK_REF
             } else {
@@ -197,6 +191,14 @@ impl<'a> Object<'a> {
         } else {
             macho::SymbolDesc(0)
         };
+        if symbol.is_common() {
+            let align = if symbol.value > 1 {
+                symbol.value.trailing_zeros().min(15) as u8
+            } else {
+                0
+            };
+            n_desc = n_desc.with_common_alignment(align);
+        }
         SymbolFlags::MachO { n_type, n_desc }
     }
 
@@ -547,7 +549,7 @@ impl<'a> Object<'a> {
             if !symbol.name.is_empty() {
                 symbol_offsets[index].str_id = Some(strtab.add(&symbol.name));
             }
-            if symbol.is_undefined() {
+            if symbol.is_undefined() || symbol.is_common() {
                 undefined_symbols.push(index);
             } else if symbol.is_local() {
                 local_symbols.push(index);
@@ -889,9 +891,12 @@ impl<'a> Object<'a> {
                 _ => 0,
             };
 
-            let n_value = match symbol.section.id() {
-                Some(section) => section_offsets[section.0].address + symbol.value,
-                None => symbol.value,
+            let n_value = match symbol.section {
+                SymbolSection::Common => symbol.size,
+                SymbolSection::Section(section) => {
+                    section_offsets[section.0].address + symbol.value
+                }
+                _ => symbol.value,
             };
 
             let n_strx = symbol_offsets[index]

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -524,28 +524,18 @@ impl<'a> Object<'a> {
         self.format != BinaryFormat::Coff
     }
 
-    /// Return true if the file format supports `StandardSection::Common`.
-    #[inline]
-    pub fn has_common(&self) -> bool {
-        self.format == BinaryFormat::MachO
-    }
-
     /// Add a new common symbol and return its `SymbolId`.
     ///
-    /// For Mach-O, this appends the symbol to the `__common` section.
+    /// This sets `symbol.section` to [`SymbolSection::Common`], `symbol.size` to `size`,
+    /// and `symbol.value` to `align`.
     ///
-    /// `align` must be a power of two.
+    /// `align` must be a power of two. It is ignored for COFF, which has no way of
+    /// encoding the alignment of a common symbol.
     pub fn add_common_symbol(&mut self, mut symbol: Symbol, size: u64, align: u64) -> SymbolId {
-        if self.has_common() {
-            let symbol_id = self.add_symbol(symbol);
-            let section = self.section_id(StandardSection::Common);
-            self.add_symbol_bss(symbol_id, section, size, align);
-            symbol_id
-        } else {
-            symbol.section = SymbolSection::Common;
-            symbol.size = size;
-            self.add_symbol(symbol)
-        }
+        symbol.section = SymbolSection::Common;
+        symbol.size = size;
+        symbol.value = align;
+        self.add_symbol(symbol)
     }
 
     /// Add a new file symbol and return its `SymbolId`.
@@ -870,8 +860,6 @@ pub enum StandardSection {
     UninitializedTls,
     /// TLS variable structures. Only supported for Mach-O.
     TlsVariables,
-    /// Common data. Only supported for Mach-O.
-    Common,
     /// Notes for GNU properties. Only supported for ELF.
     GnuProperty,
     EhFrame,
@@ -890,7 +878,6 @@ impl StandardSection {
             StandardSection::Tls => SectionKind::Tls,
             StandardSection::UninitializedTls => SectionKind::UninitializedTls,
             StandardSection::TlsVariables => SectionKind::TlsVariables,
-            StandardSection::Common => SectionKind::Common,
             StandardSection::GnuProperty => SectionKind::Note,
             StandardSection::EhFrame => SectionKind::ReadOnlyData,
         }
@@ -908,7 +895,6 @@ impl StandardSection {
             StandardSection::Tls,
             StandardSection::UninitializedTls,
             StandardSection::TlsVariables,
-            StandardSection::Common,
             StandardSection::GnuProperty,
             StandardSection::EhFrame,
         ]
@@ -1068,7 +1054,9 @@ pub struct Symbol {
     pub name: Vec<u8>,
     /// The value of the symbol.
     ///
-    /// If the symbol defined in a section, then this is the section offset of the symbol.
+    /// For [`SymbolSection::Section`], this is the section offset of the symbol.
+    ///
+    /// For [`SymbolSection::Common`], this is its alignment, which must be a power of two.
     pub value: u64,
     /// The size of the symbol.
     pub size: u64,
@@ -1098,8 +1086,6 @@ impl Symbol {
     }
 
     /// Return true if the symbol is common data.
-    ///
-    /// Note: does not check for `SymbolSection::Section` with `SectionKind::Common`.
     #[inline]
     pub fn is_common(&self) -> bool {
         self.section == SymbolSection::Common

--- a/src/write/xcoff.rs
+++ b/src/write/xcoff.rs
@@ -58,10 +58,6 @@ impl<'a> Object<'a> {
                 // Unsupported section.
                 (&[], &[], SectionKind::Unknown, SectionFlags::None)
             }
-            StandardSection::Common => {
-                // Unsupported section.
-                (&[], &[], SectionKind::Unknown, SectionFlags::None)
-            }
             StandardSection::GnuProperty => {
                 // Unsupported section.
                 (&[], &[], SectionKind::Unknown, SectionFlags::None)
@@ -88,7 +84,6 @@ impl<'a> Object<'a> {
             SectionKind::Other | SectionKind::Metadata => xcoff::STYP_REG,
             SectionKind::Note
             | SectionKind::Linker
-            | SectionKind::Common
             | SectionKind::Unknown
             | SectionKind::TlsVariables => {
                 return SectionFlags::None;

--- a/tests/round_trip/common.rs
+++ b/tests/round_trip/common.rs
@@ -1,9 +1,8 @@
 #![cfg(all(feature = "read", feature = "write"))]
 
-use object::read::{Object, ObjectSection, ObjectSymbol};
-use object::{
-    Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
-};
+use object::read::elf::Sym;
+use object::read::{Object, ObjectSymbol};
+use object::{Architecture, BinaryFormat, Endianness, SymbolFlags, SymbolKind, SymbolScope};
 use object::{read, write};
 
 #[test]
@@ -66,6 +65,7 @@ fn coff_x86_64_common() {
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(!symbol.is_undefined());
+    assert!(symbol.is_common());
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 4);
 
@@ -77,6 +77,7 @@ fn coff_x86_64_common() {
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(!symbol.is_undefined());
+    assert!(symbol.is_common());
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 8);
 
@@ -88,6 +89,7 @@ fn coff_x86_64_common() {
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(symbol.is_undefined());
+    assert!(!symbol.is_common());
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 0);
 
@@ -128,8 +130,7 @@ fn elf_x86_64_common() {
 
     //std::fs::write(&"common.o", &bytes).unwrap();
 
-    let object = read::File::parse(&*bytes).unwrap();
-    assert_eq!(object.format(), BinaryFormat::Elf);
+    let object = read::elf::ElfFile64::<Endianness>::parse(&*bytes).unwrap();
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut symbols = object.symbols();
@@ -142,8 +143,11 @@ fn elf_x86_64_common() {
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(!symbol.is_undefined());
+    assert!(symbol.is_common());
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 4);
+    // For ELF, the value of a common symbol is its alignment.
+    assert_eq!(symbol.elf_symbol().st_value(Endianness::Little), 4);
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
@@ -153,8 +157,10 @@ fn elf_x86_64_common() {
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(!symbol.is_undefined());
+    assert!(symbol.is_common());
     assert_eq!(symbol.address(), 0);
     assert_eq!(symbol.size(), 8);
+    assert_eq!(symbol.elf_symbol().st_value(Endianness::Little), 8);
 
     let symbol = symbols.next();
     assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);
@@ -201,16 +207,6 @@ fn macho_x86_64_common() {
     assert_eq!(object.architecture(), Architecture::X86_64);
 
     let mut sections = object.sections();
-
-    let common = sections.next().unwrap();
-    println!("{:?}", common);
-    let common_index = common.index();
-    assert_eq!(common.name(), Ok("__common"));
-    assert_eq!(common.segment_name(), Ok(Some("__DATA")));
-    assert_eq!(common.kind(), SectionKind::Common);
-    assert_eq!(common.size(), 16);
-    assert_eq!(common.data(), Ok(&[][..]));
-
     let section = sections.next();
     assert!(section.is_none(), "unexpected section {:?}", section);
 
@@ -220,21 +216,33 @@ fn macho_x86_64_common() {
     println!("{:?}", symbol);
     assert_eq!(symbol.name(), Ok("_v1"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
-    assert_eq!(symbol.section_index(), Some(common_index));
+    assert_eq!(symbol.section(), read::SymbolSection::Common);
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(!symbol.is_undefined());
+    assert!(symbol.is_common());
     assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 4);
+    let SymbolFlags::MachO { n_desc, .. } = symbol.flags() else {
+        panic!("unexpected symbol flags");
+    };
+    assert_eq!(n_desc.common_alignment(), 2);
 
     let symbol = symbols.next().unwrap();
     println!("{:?}", symbol);
     assert_eq!(symbol.name(), Ok("_v2"));
     assert_eq!(symbol.kind(), SymbolKind::Data);
-    assert_eq!(symbol.section_index(), Some(common_index));
+    assert_eq!(symbol.section(), read::SymbolSection::Common);
     assert_eq!(symbol.scope(), SymbolScope::Linkage);
     assert!(!symbol.is_weak());
     assert!(!symbol.is_undefined());
-    assert_eq!(symbol.address(), 8);
+    assert!(symbol.is_common());
+    assert_eq!(symbol.address(), 0);
+    assert_eq!(symbol.size(), 8);
+    let SymbolFlags::MachO { n_desc, .. } = symbol.flags() else {
+        panic!("unexpected symbol flags");
+    };
+    assert_eq!(n_desc.common_alignment(), 3);
 
     let symbol = symbols.next();
     assert!(symbol.is_none(), "unexpected symbol {:?}", symbol);


### PR DESCRIPTION
The __common section is only used after linking, not for relocatable objects.

Also fix handling of symbol value for ELF common symbols.

Breaking changes:
- deleted `write::Object::has_common`, `write::StandardSection::Common`, and `SectionKind::Common`
- `read::macho::Nlist::is_undefined` now excludes common symbols