### PR TITLE
write: add from_raw methods for ELF/Mach-O encoder structs

### DIFF
--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -662,16 +662,12 @@ pub trait FileHeader: Debug + Pod + read::private::Sealed {
     /// Return the `e_phnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn phnum<'data, R: ReadRef<'data>>(
-        &self,
-        endian: Self::Endian,
-        data: R,
-    ) -> read::Result<usize> {
+    fn phnum<'data, R: ReadRef<'data>>(&self, endian: Self::Endian, data: R) -> read::Result<u32> {
         let e_phnum = self.e_phnum(endian);
         if e_phnum < elf::PN_XNUM {
-            Ok(e_phnum as usize)
+            Ok(e_phnum.into())
         } else if let Some(section_0) = self.section_0(endian, data)? {
-            Ok(section_0.sh_info(endian) as usize)
+            Ok(section_0.sh_info(endian))
         } else {
             // Section 0 must exist if e_phnum overflows.
             Err(Error("Missing ELF section headers for e_phnum overflow"))
@@ -681,14 +677,10 @@ pub trait FileHeader: Debug + Pod + read::private::Sealed {
     /// Return the `e_shnum` field of the header. Handles extended values.
     ///
     /// Returns `Err` for invalid values.
-    fn shnum<'data, R: ReadRef<'data>>(
-        &self,
-        endian: Self::Endian,
-        data: R,
-    ) -> read::Result<usize> {
+    fn shnum<'data, R: ReadRef<'data>>(&self, endian: Self::Endian, data: R) -> read::Result<u32> {
         let e_shnum = self.e_shnum(endian);
         if e_shnum > 0 {
-            Ok(e_shnum as usize)
+            Ok(e_shnum.into())
         } else if let Some(section_0) = self.section_0(endian, data)? {
             section_0
                 .sh_size(endian)
@@ -751,7 +743,7 @@ pub trait FileHeader: Debug + Pod + read::private::Sealed {
             // Program header size must match.
             return Err(Error("Invalid ELF program header entry size"));
         }
-        data.read_slice_at(phoff, phnum)
+        data.read_slice_at(phoff, phnum as usize)
             .read_error("Invalid ELF program header size or alignment")
     }
 
@@ -779,7 +771,7 @@ pub trait FileHeader: Debug + Pod + read::private::Sealed {
             // Section header size must match.
             return Err(Error("Invalid ELF section header entry size"));
         }
-        data.read_slice_at(shoff, shnum)
+        data.read_slice_at(shoff, shnum as usize)
             .read_error("Invalid ELF section header offset/size/alignment")
     }
 

--- a/src/read/macho/codesign.rs
+++ b/src/read/macho/codesign.rs
@@ -263,7 +263,20 @@ impl<'data> CodeDirectory<'data> {
         Some(self.v2?.team_offset.get(BigEndian))
     }
 
+    /// Return the limit to the main image signature range.
+    ///
+    /// This handles both the 32-bit and 64-bit fields.
+    pub fn code_limit(&self) -> u64 {
+        match self.code_limit64() {
+            Some(code_limit64) if code_limit64 != 0 => code_limit64,
+            _ => self.header.code_limit.get(BigEndian).into(),
+        }
+    }
+
     /// Return the 64-bit limit to the main image signature range.
+    ///
+    /// This is zero for images that are smaller than 4GB. Use [`Self::code_limit`]
+    /// to obtain the limit for any image.
     ///
     /// Returns `None` if the version does not support this field.
     pub fn code_limit64(&self) -> Option<u64> {

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -342,6 +342,7 @@ pub trait Section: Debug + Pod + read::private::Sealed {
     fn flags(&self, endian: Self::Endian) -> macho::SectionFlags;
     fn reserved1(&self, endian: Self::Endian) -> u32;
     fn reserved2(&self, endian: Self::Endian) -> u32;
+    fn reserved3(&self, endian: Self::Endian) -> u32;
 
     /// Return the `sectname` bytes up until the null terminator.
     fn name(&self) -> &[u8] {
@@ -495,6 +496,9 @@ impl<Endian: endian::Endian> Section for macho::Section32<Endian> {
     fn reserved2(&self, endian: Self::Endian) -> u32 {
         self.reserved2.get(endian)
     }
+    fn reserved3(&self, _endian: Self::Endian) -> u32 {
+        0
+    }
 }
 
 impl<Endian: endian::Endian> read::private::Sealed for macho::Section64<Endian> {}
@@ -535,5 +539,8 @@ impl<Endian: endian::Endian> Section for macho::Section64<Endian> {
     }
     fn reserved2(&self, endian: Self::Endian) -> u32 {
         self.reserved2.get(endian)
+    }
+    fn reserved3(&self, endian: Self::Endian) -> u32 {
+        self.reserved3.get(endian)
     }
 }

--- a/src/write/elf/encoder.rs
+++ b/src/write/elf/encoder.rs
@@ -6,6 +6,8 @@ use crate::Wrap;
 use crate::elf;
 use crate::endian::*;
 use crate::pod;
+#[cfg(feature = "read_core")]
+use crate::read;
 use crate::write::{self, Error, Result, StringTable, WritableBuffer, WritableBufferExt};
 
 /// Alignment for .symtab_shndx.
@@ -31,6 +33,23 @@ pub struct FileHeader {
     pub e_flags: elf::FileFlags,
 }
 
+#[cfg(feature = "read_core")]
+impl FileHeader {
+    /// Convert from a raw file header.
+    ///
+    /// The layout-related fields are not converted. See [`FileHeaderLayout`].
+    pub fn from_raw<Elf: read::elf::FileHeader>(endian: Elf::Endian, header: &Elf) -> Self {
+        FileHeader {
+            os_abi: header.e_ident().os_abi,
+            abi_version: header.e_ident().abi_version,
+            e_type: header.e_type(endian),
+            e_machine: header.e_machine(endian),
+            e_entry: header.e_entry(endian).into(),
+            e_flags: header.e_flags(endian),
+        }
+    }
+}
+
 /// Native endian layout-related fields of [`elf::FileHeader64`].
 #[derive(Debug, Clone, Default)]
 pub struct FileHeaderLayout {
@@ -52,6 +71,32 @@ pub struct FileHeaderLayout {
     pub shstrtab_index: u32,
 }
 
+#[cfg(feature = "read_core")]
+impl FileHeaderLayout {
+    /// Convert from a raw file header.
+    ///
+    /// `data` is the entire file data; it is used to obtain the first section header if required.
+    pub fn from_raw<'data, Elf: read::elf::FileHeader, R: read::ReadRef<'data>>(
+        endian: Elf::Endian,
+        header: &Elf,
+        data: R,
+    ) -> read::Result<Self> {
+        let e_shstrndx = header.e_shstrndx(endian);
+        let shstrtab_index = if e_shstrndx == elf::SHN_UNDEF {
+            0
+        } else {
+            header.shstrndx(endian, data)?
+        };
+        Ok(FileHeaderLayout {
+            e_phoff: header.e_phoff(endian).into(),
+            segment_num: header.phnum(endian, data)?,
+            e_shoff: header.e_shoff(endian).into(),
+            section_num: header.shnum(endian, data)?,
+            shstrtab_index,
+        })
+    }
+}
+
 /// Native endian version of [`elf::ProgramHeader64`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -64,6 +109,23 @@ pub struct ProgramHeader {
     pub p_filesz: u64,
     pub p_memsz: u64,
     pub p_align: u64,
+}
+
+#[cfg(feature = "read_core")]
+impl ProgramHeader {
+    /// Convert from a raw program header.
+    pub fn from_raw<Phdr: read::elf::ProgramHeader>(endian: Phdr::Endian, header: &Phdr) -> Self {
+        ProgramHeader {
+            p_type: header.p_type(endian),
+            p_flags: header.p_flags(endian),
+            p_offset: header.p_offset(endian).into(),
+            p_vaddr: header.p_vaddr(endian).into(),
+            p_paddr: header.p_paddr(endian).into(),
+            p_filesz: header.p_filesz(endian).into(),
+            p_memsz: header.p_memsz(endian).into(),
+            p_align: header.p_align(endian).into(),
+        }
+    }
 }
 
 /// Native endian version of [`elf::SectionHeader64`].
@@ -83,6 +145,25 @@ pub struct SectionHeader {
     pub sh_entsize: u64,
 }
 
+#[cfg(feature = "read_core")]
+impl SectionHeader {
+    /// Convert from a raw section header.
+    pub fn from_raw<Shdr: read::elf::SectionHeader>(endian: Shdr::Endian, header: &Shdr) -> Self {
+        SectionHeader {
+            sh_name: header.sh_name(endian),
+            sh_type: header.sh_type(endian),
+            sh_flags: header.sh_flags(endian),
+            sh_addr: header.sh_addr(endian).into(),
+            sh_offset: header.sh_offset(endian).into(),
+            sh_size: header.sh_size(endian).into(),
+            sh_link: header.sh_link(endian),
+            sh_info: header.sh_info(endian),
+            sh_addralign: header.sh_addralign(endian).into(),
+            sh_entsize: header.sh_entsize(endian).into(),
+        }
+    }
+}
+
 /// Native endian version of [`elf::Sym64`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -100,6 +181,25 @@ pub struct Sym {
     pub st_size: u64,
 }
 
+#[cfg(feature = "read_core")]
+impl Sym {
+    /// Convert from a raw symbol.
+    ///
+    /// `section` can be obtained using [`read::elf::SymbolTable::symbol_section`].
+    pub fn from_raw<S: read::elf::Sym>(endian: S::Endian, sym: &S, section: Option<u32>) -> Self {
+        let st_shndx = sym.st_shndx(endian);
+        Sym {
+            section,
+            st_name: sym.st_name(endian),
+            st_info: sym.st_info(),
+            st_other: sym.st_other(),
+            st_shndx,
+            st_value: sym.st_value(endian).into(),
+            st_size: sym.st_size(endian).into(),
+        }
+    }
+}
+
 /// Unified native endian version of [`elf::Rel64`] and [`elf::Rela64`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -108,6 +208,29 @@ pub struct Rel {
     pub r_sym: u32,
     pub r_type: elf::RelocationType,
     pub r_addend: i64,
+}
+
+#[cfg(feature = "read_core")]
+impl Rel {
+    /// Convert from a raw relocation without an addend.
+    pub fn from_rel<R: read::elf::Rel>(endian: R::Endian, rel: &R) -> Self {
+        Rel {
+            r_offset: rel.r_offset(endian).into(),
+            r_sym: rel.r_sym(endian),
+            r_type: rel.r_type(endian),
+            r_addend: 0,
+        }
+    }
+
+    /// Convert from a raw relocation with an addend.
+    pub fn from_rela<R: read::elf::Rela>(endian: R::Endian, rela: &R, is_mips64el: bool) -> Self {
+        Rel {
+            r_offset: rela.r_offset(endian).into(),
+            r_sym: rela.r_sym(endian, is_mips64el),
+            r_type: rela.r_type(endian, is_mips64el),
+            r_addend: rela.r_addend(endian).into(),
+        }
+    }
 }
 
 /// Information required for writing [`elf::GnuHashHeader`].
@@ -119,6 +242,27 @@ pub struct GnuHashTable {
     pub bloom_shift: u32,
     pub symbol_base: u32,
     pub symbol_count: u32,
+}
+
+#[cfg(feature = "read_core")]
+impl GnuHashTable {
+    /// Convert from a raw GNU hash header.
+    ///
+    /// `symbol_count` is the number of symbols in the hash. This is used in
+    /// [`Encoder::gnu_hash_table`] and is not stored in the header.
+    pub fn from_raw<E: Endian>(
+        endian: E,
+        header: &elf::GnuHashHeader<E>,
+        symbol_count: u32,
+    ) -> Self {
+        GnuHashTable {
+            bucket_count: header.bucket_count.get(endian),
+            bloom_count: header.bloom_count.get(endian),
+            bloom_shift: header.bloom_shift.get(endian),
+            symbol_base: header.symbol_base.get(endian),
+            symbol_count,
+        }
+    }
 }
 
 /// Information required for writing [`elf::Verdef`].
@@ -138,6 +282,23 @@ pub struct Verdef {
     pub hash: u32,
 }
 
+#[cfg(feature = "read_core")]
+impl Verdef {
+    /// Convert from a raw version definition.
+    ///
+    /// `name` is the `vda_name` field of the first [`elf::Verdaux`] entry.
+    pub fn from_raw<E: Endian>(endian: E, verdef: &elf::Verdef<E>, name: u32) -> Self {
+        Verdef {
+            version: verdef.vd_version.get(endian),
+            flags: verdef.vd_flags.get(endian),
+            index: verdef.vd_ndx.get(endian),
+            aux_count: verdef.vd_cnt.get(endian),
+            name,
+            hash: verdef.vd_hash.get(endian),
+        }
+    }
+}
+
 /// Information required for writing [`elf::Verneed`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -146,6 +307,18 @@ pub struct Verneed {
     pub aux_count: u16,
     /// The string table offset of the file name. Written to `vn_file`.
     pub file: u32,
+}
+
+#[cfg(feature = "read_core")]
+impl Verneed {
+    /// Convert from a raw version dependency.
+    pub fn from_raw<E: Endian>(endian: E, verneed: &elf::Verneed<E>) -> Self {
+        Verneed {
+            version: verneed.vn_version.get(endian),
+            aux_count: verneed.vn_cnt.get(endian),
+            file: verneed.vn_file.get(endian),
+        }
+    }
 }
 
 /// Information required for writing [`elf::Vernaux`].
@@ -158,6 +331,19 @@ pub struct Vernaux {
     pub name: u32,
     /// The hash of the version name, as computed by [`elf::hash`]. Written to `vna_hash`.
     pub hash: u32,
+}
+
+#[cfg(feature = "read_core")]
+impl Vernaux {
+    /// Convert from a raw version dependency auxiliary entry.
+    pub fn from_raw<E: Endian>(endian: E, vernaux: &elf::Vernaux<E>) -> Self {
+        Vernaux {
+            flags: vernaux.vna_flags.get(endian),
+            index: vernaux.vna_other.get(endian),
+            name: vernaux.vna_name.get(endian),
+            hash: vernaux.vna_hash.get(endian),
+        }
+    }
 }
 
 /// A helper for encoding headers and data when writing an ELF file.

--- a/src/write/macho/encoder.rs
+++ b/src/write/macho/encoder.rs
@@ -2,6 +2,8 @@ use core::mem;
 
 use crate::endian::*;
 use crate::macho;
+#[cfg(feature = "read_core")]
+use crate::read;
 use crate::write::util::align;
 use crate::write::{Error, Result, StringTable, WritableBuffer, WritableBufferExt};
 
@@ -17,6 +19,21 @@ pub struct MachHeader {
     pub flags: macho::FileFlags,
 }
 
+#[cfg(feature = "read_core")]
+impl MachHeader {
+    /// Convert from a raw file header.
+    pub fn from_raw<Mach: read::macho::MachHeader>(endian: Mach::Endian, header: &Mach) -> Self {
+        MachHeader {
+            cputype: header.cputype(endian),
+            cpusubtype: header.cpusubtype(endian),
+            filetype: header.filetype(endian),
+            ncmds: header.ncmds(endian),
+            sizeofcmds: header.sizeofcmds(endian),
+            flags: header.flags(endian),
+        }
+    }
+}
+
 /// Native endian version of [`macho::SegmentCommand64`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -30,6 +47,24 @@ pub struct SegmentCommand {
     pub initprot: macho::VmProt,
     pub nsects: u32,
     pub flags: macho::SegmentFlags,
+}
+
+#[cfg(feature = "read_core")]
+impl SegmentCommand {
+    /// Convert from a raw segment command.
+    pub fn from_raw<S: read::macho::Segment>(endian: S::Endian, segment: &S) -> Self {
+        SegmentCommand {
+            segname: *segment.segname(),
+            vmaddr: segment.vmaddr(endian).into(),
+            vmsize: segment.vmsize(endian).into(),
+            fileoff: segment.fileoff(endian).into(),
+            filesize: segment.filesize(endian).into(),
+            maxprot: segment.maxprot(endian),
+            initprot: segment.initprot(endian),
+            nsects: segment.nsects(endian),
+            flags: segment.flags(endian),
+        }
+    }
 }
 
 /// Native endian version of [`macho::Section64`].
@@ -50,6 +85,27 @@ pub struct SectionHeader {
     pub reserved3: u32,
 }
 
+#[cfg(feature = "read_core")]
+impl SectionHeader {
+    /// Convert from a raw section header.
+    pub fn from_raw<S: read::macho::Section>(endian: S::Endian, section: &S) -> Self {
+        SectionHeader {
+            sectname: *section.sectname(),
+            segname: *section.segname(),
+            addr: section.addr(endian).into(),
+            size: section.size(endian).into(),
+            offset: section.offset(endian),
+            align: section.align(endian),
+            reloff: section.reloff(endian),
+            nreloc: section.nreloc(endian),
+            flags: section.flags(endian),
+            reserved1: section.reserved1(endian),
+            reserved2: section.reserved2(endian),
+            reserved3: section.reserved3(endian),
+        }
+    }
+}
+
 /// Native endian version of [`macho::SymtabCommand`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -58,6 +114,19 @@ pub struct SymtabCommand {
     pub nsyms: u32,
     pub stroff: u32,
     pub strsize: u32,
+}
+
+#[cfg(feature = "read_core")]
+impl SymtabCommand {
+    /// Convert from a raw symtab load command.
+    pub fn from_raw<E: Endian>(endian: E, command: &macho::SymtabCommand<E>) -> Self {
+        SymtabCommand {
+            symoff: command.symoff.get(endian),
+            nsyms: command.nsyms.get(endian),
+            stroff: command.stroff.get(endian),
+            strsize: command.strsize.get(endian),
+        }
+    }
 }
 
 /// Native endian version of [`macho::DysymtabCommand`].
@@ -84,6 +153,33 @@ pub struct DysymtabCommand {
     pub nlocrel: u32,
 }
 
+#[cfg(feature = "read_core")]
+impl DysymtabCommand {
+    /// Convert from a raw dynamic symtab load command.
+    pub fn from_raw<E: Endian>(endian: E, command: &macho::DysymtabCommand<E>) -> Self {
+        DysymtabCommand {
+            ilocalsym: command.ilocalsym.get(endian),
+            nlocalsym: command.nlocalsym.get(endian),
+            iextdefsym: command.iextdefsym.get(endian),
+            nextdefsym: command.nextdefsym.get(endian),
+            iundefsym: command.iundefsym.get(endian),
+            nundefsym: command.nundefsym.get(endian),
+            tocoff: command.tocoff.get(endian),
+            ntoc: command.ntoc.get(endian),
+            modtaboff: command.modtaboff.get(endian),
+            nmodtab: command.nmodtab.get(endian),
+            extrefsymoff: command.extrefsymoff.get(endian),
+            nextrefsyms: command.nextrefsyms.get(endian),
+            indirectsymoff: command.indirectsymoff.get(endian),
+            nindirectsyms: command.nindirectsyms.get(endian),
+            extreloff: command.extreloff.get(endian),
+            nextrel: command.nextrel.get(endian),
+            locreloff: command.locreloff.get(endian),
+            nlocrel: command.nlocrel.get(endian),
+        }
+    }
+}
+
 /// Native endian version of [`macho::Nlist64`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -93,6 +189,20 @@ pub struct Nlist {
     pub n_sect: u8,
     pub n_desc: macho::SymbolDesc,
     pub n_value: u64,
+}
+
+#[cfg(feature = "read_core")]
+impl Nlist {
+    /// Convert from a raw symbol.
+    pub fn from_raw<N: read::macho::Nlist>(endian: N::Endian, nlist: &N) -> Self {
+        Nlist {
+            n_strx: nlist.n_strx(endian),
+            n_type: nlist.n_type(),
+            n_sect: nlist.n_sect(),
+            n_desc: nlist.n_desc(endian),
+            n_value: nlist.n_value(endian).into(),
+        }
+    }
 }
 
 /// Native endian version of [`macho::DylibCommand`].
@@ -106,6 +216,27 @@ pub struct DylibCommand<'data> {
     pub compatibility_version: macho::Version,
 }
 
+#[cfg(feature = "read_core")]
+impl<'data> DylibCommand<'data> {
+    /// Convert from a raw dylib load command.
+    ///
+    /// `name` is the string referenced by the `dylib.name` field. It can be obtained
+    /// using [`read::macho::LoadCommandData::string`].
+    pub fn from_raw<E: Endian>(
+        endian: E,
+        command: &macho::DylibCommand<E>,
+        name: &'data [u8],
+    ) -> Self {
+        DylibCommand {
+            cmd: command.cmd.get(endian),
+            name,
+            timestamp: command.dylib.timestamp.get(endian),
+            current_version: command.dylib.current_version.get(endian),
+            compatibility_version: command.dylib.compatibility_version.get(endian),
+        }
+    }
+}
+
 /// Native endian version of [`macho::BuildVersionCommand`].
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -114,6 +245,19 @@ pub struct BuildVersionCommand {
     pub minos: macho::Version,
     pub sdk: macho::Version,
     pub ntools: u32,
+}
+
+#[cfg(feature = "read_core")]
+impl BuildVersionCommand {
+    /// Convert from a raw build version load command.
+    pub fn from_raw<E: Endian>(endian: E, command: &macho::BuildVersionCommand<E>) -> Self {
+        BuildVersionCommand {
+            platform: command.platform.get(endian),
+            minos: command.minos.get(endian),
+            sdk: command.sdk.get(endian),
+            ntools: command.ntools.get(endian),
+        }
+    }
 }
 
 /// Native endian version of [`macho::DyldInfoCommand`].
@@ -130,6 +274,25 @@ pub struct DyldInfoCommand {
     pub lazy_bind_size: u32,
     pub export_off: u32,
     pub export_size: u32,
+}
+
+#[cfg(feature = "read_core")]
+impl DyldInfoCommand {
+    /// Convert from a raw dyld info load command.
+    pub fn from_raw<E: Endian>(endian: E, command: &macho::DyldInfoCommand<E>) -> Self {
+        DyldInfoCommand {
+            rebase_off: command.rebase_off.get(endian),
+            rebase_size: command.rebase_size.get(endian),
+            bind_off: command.bind_off.get(endian),
+            bind_size: command.bind_size.get(endian),
+            weak_bind_off: command.weak_bind_off.get(endian),
+            weak_bind_size: command.weak_bind_size.get(endian),
+            lazy_bind_off: command.lazy_bind_off.get(endian),
+            lazy_bind_size: command.lazy_bind_size.get(endian),
+            export_off: command.export_off.get(endian),
+            export_size: command.export_size.get(endian),
+        }
+    }
 }
 
 /// A helper for encoding headers and data when writing a Mach-O file.
@@ -649,6 +812,38 @@ pub struct CodeDirectory {
     pub exec_seg_base: u64,
     pub exec_seg_limit: u64,
     pub exec_seg_flags: macho::CsExecSegFlags,
+}
+
+#[cfg(feature = "read_core")]
+impl CodeDirectory {
+    /// Convert from a raw code directory.
+    ///
+    /// Fields that are not present for the version of the code directory are set to 0.
+    pub fn from_raw(code_directory: &read::macho::CodeDirectory<'_>) -> Self {
+        let header = code_directory.header();
+        let exec_seg = code_directory.exec_seg();
+        CodeDirectory {
+            length: header.length.get(BigEndian),
+            version: header.version.get(BigEndian),
+            flags: header.flags.get(BigEndian),
+            hash_offset: header.hash_offset.get(BigEndian),
+            ident_offset: header.ident_offset.get(BigEndian),
+            n_special_slots: header.n_special_slots.get(BigEndian),
+            n_code_slots: header.n_code_slots.get(BigEndian),
+            code_limit: code_directory.code_limit(),
+            hash_size: header.hash_size,
+            hash_type: header.hash_type,
+            platform: header.platform,
+            page_size: header.page_size,
+            scatter_offset: code_directory.scatter_offset().unwrap_or(0),
+            team_offset: code_directory.team_offset().unwrap_or(0),
+            exec_seg_base: exec_seg.map_or(0, |v| v.exec_seg_base.get(BigEndian)),
+            exec_seg_limit: exec_seg.map_or(0, |v| v.exec_seg_limit.get(BigEndian)),
+            exec_seg_flags: exec_seg.map_or(macho::CsExecSegFlags(0), |v| {
+                v.exec_seg_flags.get(BigEndian)
+            }),
+        }
+    }
 }
 
 /// A helper for encoding code signatures.


### PR DESCRIPTION
Also add `read::macho::Section::reserved3` and `read::macho::CodedDirectory::code_limit()`.

Breaking change: changed return types of read::elf::FileHeader::phnum/shnum.