### PR TITLE
read/macho: add Segment::section_offsets

### DIFF
--- a/src/build/macho.rs
+++ b/src/build/macho.rs
@@ -302,8 +302,10 @@ impl<'data> Builder<'data> {
     {
         let id = self.segments.next_id();
         let mut sections = Vec::new();
-        for section in segment.sections(endian, section_data)? {
-            let id = self.read_section(endian, data, section, state)?;
+        let segment_sections = segment.sections(endian, section_data)?;
+        for section_offset in segment.section_offsets(endian, segment_sections) {
+            let (section, offset) = section_offset?;
+            let id = self.read_section(endian, data, section, offset, state)?;
             sections.push(id);
         }
         self.segments.push(Segment {
@@ -326,6 +328,7 @@ impl<'data> Builder<'data> {
         endian: Endianness,
         data: R,
         section: &S,
+        offset: u64,
         state: &ReadState<'_>,
     ) -> Result<SectionId>
     where
@@ -333,10 +336,8 @@ impl<'data> Builder<'data> {
         R: ReadRef<'data>,
     {
         let id = self.sections.next_id();
-        // TODO: reuse MachOFile::parse_sections
-        let offset = section.offset(endian).into();
         let size = section.size(endian).into();
-        let section_data = if section.file_range(endian, offset).is_some() {
+        let section_data = if section.file_size(endian).is_some() {
             SectionData::Data(section.data(endian, data, offset)?.into())
         } else {
             SectionData::UninitializedData(size as u32)

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -176,11 +176,6 @@ where
         section_data: &'data [u8],
         sections: &mut Vec<MachOSectionInternal<'data, Mach, R>>,
     ) -> Result<()> {
-        let segment_fileoff: u64 = segment.fileoff(endian).into();
-        let segment_end = segment_fileoff.wrapping_add(segment.filesize(endian).into());
-        let overflow_possible = segment_end > u32::MAX as u64;
-        let mut prev_offset = segment_fileoff;
-
         let readonly = if header.filetype(endian) == macho::MH_OBJECT {
             // Let the section parser determine it from segment name.
             None
@@ -191,27 +186,9 @@ where
             )
         };
 
-        for section in segment.sections(endian, section_data)? {
-            let mut offset = u64::from(section.offset(endian));
-
-            // Section headers only have 32-bit file offsets, which can overflow in files
-            // larger than 4GB. When that is possible, reconstruct the full offset by
-            // assuming sections are ordered by file offset.
-            // This is a refinement of the algorithm used by LLVM.
-            if overflow_possible {
-                if let Some((_, size)) = section.file_range(endian, offset) {
-                    offset |= prev_offset & 0xffff_ffff_0000_0000;
-                    if offset < prev_offset {
-                        offset = offset.wrapping_add(0x1_0000_0000);
-                    }
-                    let section_end = offset.wrapping_add(size);
-                    if section_end > segment_end {
-                        return Err(Error("Unsupported Mach-O large section offsets"));
-                    }
-                    prev_offset = section_end;
-                }
-            }
-
+        let segment_sections = segment.sections(endian, section_data)?;
+        for section_offset in segment.section_offsets(endian, segment_sections) {
+            let (section, offset) = section_offset?;
             let index = SectionIndex(sections.len() + 1);
             sections.push(MachOSectionInternal::parse(
                 endian, index, readonly, section, data, offset,

--- a/src/read/macho/section.rs
+++ b/src/read/macho/section.rs
@@ -334,7 +334,11 @@ pub trait Section: Debug + Pod + read::private::Sealed {
     fn size(&self, endian: Self::Endian) -> Self::Word;
     /// The file offset of the section.
     ///
-    /// Note that for offsets larger than 32-bit this will be truncated.
+    /// Note that for offsets larger than `u32::MAX` this will be truncated, so you will
+    /// need to determine the offset in another way.
+    /// `(section.addr - segment.vmaddr) + segment.fileoff` is equivalent for well-formed files.
+    /// Alternatively, you can use [`Segment::section_offsets`](super::Segment::section_offsets)
+    /// to track the file offset of consecutive sections to determine when overflow occurs.
     fn offset(&self, endian: Self::Endian) -> u32;
     fn align(&self, endian: Self::Endian) -> u32;
     fn reloff(&self, endian: Self::Endian) -> u32;
@@ -367,25 +371,31 @@ pub trait Section: Debug + Pod + read::private::Sealed {
         self.flags(endian).typ()
     }
 
+    /// Return the size of the section in the file.
+    ///
+    /// Returns `None` for sections that have no data in the file.
+    fn file_size(&self, endian: Self::Endian) -> Option<u64> {
+        match self.section_type(endian) {
+            macho::S_ZEROFILL | macho::S_GB_ZEROFILL | macho::S_THREAD_LOCAL_ZEROFILL => None,
+            _ => Some(self.size(endian).into()),
+        }
+    }
+
     /// Return the offset and size of the section in the file.
     ///
-    /// `offset` must be the section file offset. Note that for file offsets larger than
-    /// `u32::MAX`, [`Self::offset`] will be truncated, so you will need to determine the
-    /// offset in another way. `(section.addr - segment.vmaddr) + segment.fileoff` is
-    /// equivalent for well-formed files. Alternatively, you could track the file offset
-    /// of consecutive sections to determine when overflow occurs.
+    /// `offset` must be the section file offset. See [`Self::offset`] and
+    /// [`Segment::section_offsets`](super::Segment::section_offsets).
     ///
     /// Returns `None` for sections that have no data in the file.
     fn file_range(&self, endian: Self::Endian, offset: u64) -> Option<(u64, u64)> {
-        match self.section_type(endian) {
-            macho::S_ZEROFILL | macho::S_GB_ZEROFILL | macho::S_THREAD_LOCAL_ZEROFILL => None,
-            _ => Some((offset, self.size(endian).into())),
-        }
+        let size = self.file_size(endian)?;
+        Some((offset, size))
     }
 
     /// Return the section data.
     ///
-    /// `offset` must be the section file offset. See [`Self::file_range`].
+    /// `offset` must be the section file offset. See [`Self::offset`] and
+    /// [`Segment::section_offsets`](super::Segment::section_offsets).
     ///
     /// Returns `Ok(&[])` if the section has no data.
     /// Returns `Err` for invalid values.
@@ -395,7 +405,7 @@ pub trait Section: Debug + Pod + read::private::Sealed {
         data: R,
         offset: u64,
     ) -> Result<&'data [u8]> {
-        if let Some((offset, size)) = self.file_range(endian, offset) {
+        if let Some(size) = self.file_size(endian) {
             data.read_bytes_at(offset, size)
                 .read_error("Invalid Mach-O section size or offset")
         } else {

--- a/src/read/macho/segment.rs
+++ b/src/read/macho/segment.rs
@@ -4,7 +4,9 @@ use core::{result, slice, str};
 use crate::endian::{self, Endianness};
 use crate::macho;
 use crate::pod::Pod;
-use crate::read::{self, ObjectSegment, Permissions, ReadError, ReadRef, Result, SegmentFlags};
+use crate::read::{
+    self, Error, ObjectSegment, Permissions, ReadError, ReadRef, Result, SegmentFlags,
+};
 
 use super::{LoadCommandData, MachHeader, MachOFile, Section};
 
@@ -177,6 +179,47 @@ pub(super) struct MachOSegmentInternal<'data, Mach: MachHeader, R: ReadRef<'data
     pub data: R,
 }
 
+/// An iterator for the header and file offset of each section in a Mach-O segment.
+///
+/// Returned by [`Segment::section_offsets`].
+#[derive(Debug, Clone)]
+pub struct SectionOffsetIterator<'data, S: Segment> {
+    endian: S::Endian,
+    sections: slice::Iter<'data, S::Section>,
+    overflow_possible: bool,
+    prev_offset: u64,
+    segment_end: u64,
+}
+
+impl<'data, S: Segment> Iterator for SectionOffsetIterator<'data, S> {
+    type Item = Result<(&'data S::Section, u64)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let section = self.sections.next()?;
+        let mut offset = u64::from(section.offset(self.endian));
+
+        // Reconstruct the full file offset by assuming that sections are ordered by
+        // file offset. This is a refinement of the algorithm used by LLVM.
+        if self.overflow_possible {
+            if let Some(size) = section.file_size(self.endian) {
+                offset |= self.prev_offset & 0xffff_ffff_0000_0000;
+                if offset < self.prev_offset {
+                    offset = offset.wrapping_add(0x1_0000_0000);
+                }
+                let section_end = offset.wrapping_add(size);
+                if section_end > self.segment_end {
+                    // Fuse.
+                    self.sections = Default::default();
+                    return Some(Err(Error("Unsupported Mach-O large section offsets")));
+                }
+                self.prev_offset = section_end;
+            }
+        }
+
+        Some(Ok((section, offset)))
+    }
+}
+
 /// A trait for generic access to [`macho::SegmentCommand32`] and [`macho::SegmentCommand64`].
 #[allow(missing_docs)]
 pub trait Segment: Debug + Pod + read::private::Sealed {
@@ -235,6 +278,31 @@ pub trait Segment: Debug + Pod + read::private::Sealed {
         section_data
             .read_slice_at(0, self.nsects(endian) as usize)
             .read_error("Invalid Mach-O number of sections")
+    }
+
+    /// Return an iterator for the header and file offset of each section in this segment.
+    ///
+    /// Section headers only have 32-bit file offsets, which can overflow in files
+    /// larger than 4GB. This iterator reconstructs the full offset by assuming that
+    /// sections are ordered by file offset. Use this instead of [`Section::offset`]
+    /// if you may need to parse large files.
+    ///
+    /// `sections` must be the sections for this segment, such as those returned by
+    /// [`Self::sections`].
+    fn section_offsets<'data>(
+        &self,
+        endian: Self::Endian,
+        sections: &'data [Self::Section],
+    ) -> SectionOffsetIterator<'data, Self> {
+        let segment_fileoff: u64 = self.fileoff(endian).into();
+        let segment_end = segment_fileoff.wrapping_add(self.filesize(endian).into());
+        SectionOffsetIterator {
+            endian,
+            sections: sections.iter(),
+            overflow_possible: segment_end > u32::MAX as u64,
+            prev_offset: segment_fileoff,
+            segment_end,
+        }
     }
 }
 
@@ -327,5 +395,115 @@ impl<Endian: endian::Endian> Segment for macho::SegmentCommand64<Endian> {
     }
     fn flags(&self, endian: Self::Endian) -> macho::SegmentFlags {
         self.flags.get(endian)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LittleEndian as LE;
+    use crate::endian::{U32, U64};
+
+    fn segment(fileoff: u64, filesize: u64) -> macho::SegmentCommand64<LE> {
+        macho::SegmentCommand64 {
+            cmd: U32::new(LE, macho::LC_SEGMENT_64),
+            cmdsize: U32::new(LE, 0),
+            segname: [0; 16],
+            vmaddr: U64::new(LE, 0),
+            vmsize: U64::new(LE, filesize),
+            fileoff: U64::new(LE, fileoff),
+            filesize: U64::new(LE, filesize),
+            maxprot: U32::new(LE, macho::VmProt(0)),
+            initprot: U32::new(LE, macho::VmProt(0)),
+            nsects: U32::new(LE, 0),
+            flags: U32::new(LE, macho::SegmentFlags(0)),
+        }
+    }
+
+    fn section(offset: u32, size: u64, typ: macho::SectionType) -> macho::Section64<LE> {
+        macho::Section64 {
+            sectname: [0; 16],
+            segname: [0; 16],
+            addr: U64::new(LE, 0),
+            size: U64::new(LE, size),
+            offset: U32::new(LE, offset),
+            align: U32::new(LE, 0),
+            reloff: U32::new(LE, 0),
+            nreloc: U32::new(LE, 0),
+            flags: U32::new(LE, typ.to_flags()),
+            reserved1: U32::new(LE, 0),
+            reserved2: U32::new(LE, 0),
+            reserved3: U32::new(LE, 0),
+        }
+    }
+
+    fn assert_offsets(
+        segment: &macho::SegmentCommand64<LE>,
+        sections: &[macho::Section64<LE>],
+        expected: &[u64],
+    ) {
+        let mut iter = segment.section_offsets(LE, sections);
+        for expected in expected {
+            let (_, offset) = iter.next().unwrap().unwrap();
+            assert_eq!(offset, *expected);
+        }
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn section_offsets_small() {
+        // Overflow not possible, order does not matter.
+        let segment = segment(0x1000, 0x2000);
+        let sections = [
+            section(0x2000, 0x1000, macho::S_REGULAR),
+            section(0x1000, 0x1000, macho::S_REGULAR),
+        ];
+        assert_offsets(&segment, &sections, &[0x2000, 0x1000]);
+    }
+
+    #[test]
+    fn section_offsets_large() {
+        // Overflow possible.
+        let segment = segment(0, 0x2_0000_1000);
+        let sections = [
+            section(0x1000, 0xffff_e000, macho::S_REGULAR),
+            section(0xffff_f000, 0x2000, macho::S_REGULAR),
+            // Truncated from 0x1_0000_1000.
+            section(0x1000, 0x1000, macho::S_REGULAR),
+            // Zerofill sections have no file data, so they are left alone.
+            section(0, 0x1000, macho::S_ZEROFILL),
+            // Truncated from 0x1_0000_2000.
+            section(0x2000, 0xffff_d000, macho::S_REGULAR),
+            // Truncated from 0x2_0000_0000, tests `offset < self.prev_offset` branch.
+            section(0, 0x1000, macho::S_REGULAR),
+        ];
+        assert_offsets(
+            &segment,
+            &sections,
+            &[
+                0x1000,
+                0xffff_f000,
+                0x1_0000_1000,
+                0,
+                0x1_0000_2000,
+                0x2_0000_0000,
+            ],
+        );
+    }
+
+    #[test]
+    fn section_offsets_invalid() {
+        // Overflow possible, but total section size is invalid.
+        let segment = segment(0, 0x1_0000_1000);
+        let sections = [
+            section(0x1000, 0x1000, macho::S_REGULAR),
+            section(0x2000, 0x1_0000_0000, macho::S_REGULAR),
+            // Fused before here.
+            section(0x3000, 0x1000, macho::S_REGULAR),
+        ];
+        let mut iter = segment.section_offsets(LE, &sections);
+        assert_eq!(iter.next().unwrap().unwrap().1, 0x1000);
+        assert!(iter.next().unwrap().is_err());
+        assert!(iter.next().is_none());
     }
 }


### PR DESCRIPTION
Needed by low-level API users to handle 64-bit file offsets.