### PR TITLE
Add missing BitOr conversions for newtypes

### DIFF
--- a/src/macho.rs
+++ b/src/macho.rs
@@ -169,6 +169,13 @@ impl From<CpuSubtype> for CpuSubtypeId {
     }
 }
 
+impl core::ops::BitOr<CpuSubtype> for CpuSubtypeId {
+    type Output = CpuSubtype;
+    fn bitor(self, rhs: CpuSubtype) -> CpuSubtype {
+        rhs.with_id(self)
+    }
+}
+
 /*
  * Capability bits used in the definition of cpu_subtype.
  */

--- a/src/xcoff.rs
+++ b/src/xcoff.rs
@@ -346,6 +346,13 @@ impl From<SectionType> for SectionFlags {
     }
 }
 
+impl core::ops::BitOr<SectionFlags> for SectionType {
+    type Output = SectionFlags;
+    fn bitor(self, subtype: SectionFlags) -> SectionFlags {
+        subtype.with_type(self)
+    }
+}
+
 newtype!(
     /// Values for the type field of `SectionHeader*::s_flags`.
     ///


### PR DESCRIPTION
These already existed for a number of other types.