### PR TITLE
Guard the ESDID underflow on the GOFF TXT record path

### DIFF
--- a/src/read/goff/file.rs
+++ b/src/read/goff/file.rs
@@ -190,9 +190,10 @@ where
         );
 
         // if esdid is a PR, get the parent ED
-        let symbol = self
-            .symbols
-            .get(esdid as usize - 1)
+        // ESDID 0 means "none"; guard the underflow the way is_descendant_of does
+        let symbol = (esdid as usize)
+            .checked_sub(1)
+            .and_then(|index| self.symbols.get(index))
             .ok_or(Error("txt record references undefined symbol"))?;
         let ed_symbolindex: SymbolIndex = match symbol.symbol_type() {
             ESD_SYMTYPE_ED => symbolindex,

--- a/tests/goff_esdid_zero.rs
+++ b/tests/goff_esdid_zero.rs
@@ -1,0 +1,37 @@
+#![cfg(all(feature = "read", feature = "write", feature = "goff"))]
+
+use object::read::goff::GoffFile;
+use object::{Architecture, BinaryFormat, Endianness, SectionKind, write};
+
+fn build() -> Vec<u8> {
+    let mut object = write::Object::new(BinaryFormat::Goff, Architecture::S390x, Endianness::Big);
+    let sec = object.add_section(
+        Vec::new(),
+        vec![0xC4, 0x6D, 0xC9, 0xD5, 0xC6, 0xD6],
+        SectionKind::Debug,
+    );
+    object.append_section_data(sec, &[0x01, 0x02, 0x03, 0x04], 1);
+    object.write().unwrap()
+}
+
+#[test]
+fn txt_esdid_zero() {
+    let mut bytes = build();
+    // Locate the TXT record (ptv 0x031000 / 0x031100) on an 80-byte boundary and zero element_esdid.
+    let mut patched = 0;
+    for rec in bytes.chunks_mut(80) {
+        if rec.len() == 80 && rec[0] == 0x03 && (rec[1] == 0x10 || rec[1] == 0x11) && rec[2] == 0x00
+        {
+            rec[4..8].copy_from_slice(&[0, 0, 0, 0]);
+            patched += 1;
+        }
+    }
+    assert!(patched > 0, "no TXT record found to patch");
+    println!(
+        "patched {} TXT record(s), {} bytes total",
+        patched,
+        bytes.len()
+    );
+    let r = GoffFile::parse(&bytes[..]);
+    println!("parse result: {:?}", r.err());
+}


### PR DESCRIPTION
`GoffFile::parse` reads `element_esdid` straight off the TXT record (`src/read/goff/file.rs:188`) and then indexes with it (`:195`):

```rust
let symbol = self
    .symbols
    .get(esdid as usize - 1)
    .ok_or(Error("txt record references undefined symbol"))?;
```

A file with `element_esdid == 0` makes `0usize - 1` wrap.

- **debug**: `thread 'txt_esdid_zero' panicked at src/read/goff/file.rs:195:18: attempt to subtract with overflow`
- **release**: no panic -- it wraps to `usize::MAX`, `.get(usize::MAX)` returns `None`, and the `.ok_or(...)` already there produces `Error("txt record references undefined symbol")`

So the honest scope is: **a debug-profile panic on malformed input; release already degrades correctly.** `goff` is opt-in behind `unstable`, which caps it further. I would rather state that than imply more.

The repro builds a valid GOFF with this crate's own writer, zeroes bytes 4..8 of one 80-byte TXT record, and re-parses through the public `GoffFile::parse` -- 400 bytes, one record patched.

## Your own `is_descendant_of` already does this

`src/read/goff/relocation.rs:178` and `src/read/goff/section.rs:83`, verbatim:

```rust
// ESDID 0 means "no parent"; guard against underflow and false positives
if esdid.0 == 0 {
    return false;
}
if let Some(symbol) = self.file.symbols.get(esdid.0 - 1) {
```

The comment names the exact hazard. The guard exists at two sites and not at the one on the parse path, so this is a hole in an existing guard rather than a missing one. The fix uses `checked_sub` and chains into the `.ok_or(...)` that is already there, so **release output is byte-identical** -- the same `Error` value -- and debug's panic simply becomes that same error.

## The other sites, which I did not touch

The same unguarded `esdid - 1` appears at `section.rs:119`, `:151`, `:159`, `:275`, `relocation.rs:198`, and `symbol.rs:388`, `:417`. They are reached from `Object` trait methods on an already-parsed file rather than from the parse path, and I only built one repro, so I did not want to change seven lines while pinning one. If you would like them swept the same way I am happy to do it in a follow-up, or to extend this PR -- your call which is easier to review.

## Verification

`cargo fmt --check` clean. One test added, run in **both profiles**: debug and release both pass with the fix. Reverting only this site reproduces the panic at `file.rs:195:18`, so the test pins the line I changed.

One caveat about my environment: my clone was `--depth 1` and so lacks the `testfiles` submodule, which makes 12 unrelated read tests fail here both before and after my change. My test lives in its own target and does not depend on it, but I could not run the full suite as CI does, and I would rather say so.

`src/read/goff/` and the GOFF tests contain no occurrence of `usize::MAX`, `u32::MAX`, or `overflow`, so nothing asserted the old behaviour.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
