### PR TITLE
read/wasm: fix entry point and global symbol addresses

### DIFF
--- a/crates/examples/testfiles/wasm/dylink-debug.wasm.objdump
+++ b/crates/examples/testfiles/wasm/dylink-debug.wasm.objdump
@@ -37,13 +37,13 @@ Symbols
 11: Symbol { name: "retained_int", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 12: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 13: Symbol { name: "get", address: 24, size: 45, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
-14: Symbol { name: "data_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-15: Symbol { name: "bss_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-16: Symbol { name: "tls_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-17: Symbol { name: "tbss_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+14: Symbol { name: "data_int", address: c, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+15: Symbol { name: "bss_int", address: 1c, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+16: Symbol { name: "tls_int", address: 10, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+17: Symbol { name: "tbss_int", address: 20, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
 18: Symbol { name: "rodata_bytes", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-19: Symbol { name: "rodata_str", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-20: Symbol { name: "retained_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+19: Symbol { name: "rodata_str", address: 14, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+20: Symbol { name: "retained_int", address: 18, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
 21: Symbol { name: "__wasm_apply_data_relocs", address: 5, size: f, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
 22: Symbol { name: "__wasm_call_ctors", address: 2, size: 2, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
 23: Symbol { name: "__wasm_init_memory", address: 15, size: e, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
@@ -51,8 +51,14 @@ Symbols
 Dynamic symbols
 
 Symbol map
-0x0-0x1 "retained_int"
+0x0-0x1 "rodata_bytes"
 0x2-0x4 "__wasm_call_ctors"
 0x5-0x14 "__wasm_apply_data_relocs"
+0xc-0x10 "data_int"
+0x10-0x14 "tls_int"
+0x14-0x15 "rodata_str"
 0x15-0x23 "__wasm_init_memory"
+0x18-0x1c "retained_int"
+0x1c-0x20 "bss_int"
+0x20-0x22 "tbss_int"
 0x24-0x69 "get"

--- a/crates/examples/testfiles/wasm/dylink-shared-memory.wasm.objdump
+++ b/crates/examples/testfiles/wasm/dylink-shared-memory.wasm.objdump
@@ -31,13 +31,13 @@ Symbols
 9: Symbol { name: "retained_int", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 10: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 11: Symbol { name: "get", address: 97, size: 5d, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
-12: Symbol { name: "data_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-13: Symbol { name: "bss_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+12: Symbol { name: "data_int", address: 14, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+13: Symbol { name: "bss_int", address: 20, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
 14: Symbol { name: "tls_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-15: Symbol { name: "tbss_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-16: Symbol { name: "rodata_bytes", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-17: Symbol { name: "rodata_str", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-18: Symbol { name: "retained_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+15: Symbol { name: "tbss_int", address: 4, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+16: Symbol { name: "rodata_bytes", address: 8, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+17: Symbol { name: "rodata_str", address: 18, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+18: Symbol { name: "retained_int", address: 1c, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
 19: Symbol { name: "__wasm_apply_data_relocs", address: 5, size: f, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
 20: Symbol { name: "__wasm_call_ctors", address: 2, size: 2, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
 21: Symbol { name: "__wasm_init_memory", address: 16, size: 80, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
@@ -45,8 +45,14 @@ Symbols
 Dynamic symbols
 
 Symbol map
-0x0-0x1 "retained_int"
+0x0-0x1 "tls_int"
 0x2-0x4 "__wasm_call_ctors"
+0x4-0x5 "tbss_int"
 0x5-0x14 "__wasm_apply_data_relocs"
+0x8-0x14 "rodata_bytes"
+0x14-0x16 "data_int"
 0x16-0x96 "__wasm_init_memory"
+0x18-0x1c "rodata_str"
+0x1c-0x1e "retained_int"
+0x20-0x24 "bss_int"
 0x97-0xf4 "get"

--- a/crates/examples/testfiles/wasm/dylink.wasm.objdump
+++ b/crates/examples/testfiles/wasm/dylink.wasm.objdump
@@ -33,13 +33,13 @@ Symbols
 11: Symbol { name: "retained_int", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 12: Symbol { name: "", address: 0, size: 0, kind: File, section: None, scope: Compilation, weak: false, flags: None }
 13: Symbol { name: "get", address: 24, size: 45, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
-14: Symbol { name: "data_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-15: Symbol { name: "bss_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-16: Symbol { name: "tls_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-17: Symbol { name: "tbss_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+14: Symbol { name: "data_int", address: c, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+15: Symbol { name: "bss_int", address: 1c, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+16: Symbol { name: "tls_int", address: 10, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+17: Symbol { name: "tbss_int", address: 20, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
 18: Symbol { name: "rodata_bytes", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-19: Symbol { name: "rodata_str", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
-20: Symbol { name: "retained_int", address: 0, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+19: Symbol { name: "rodata_str", address: 14, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
+20: Symbol { name: "retained_int", address: 18, size: 0, kind: Data, section: Section(SectionIndex(b)), scope: Dynamic, weak: false, flags: None }
 21: Symbol { name: "__wasm_apply_data_relocs", address: 5, size: f, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
 22: Symbol { name: "__wasm_call_ctors", address: 2, size: 2, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
 23: Symbol { name: "__wasm_init_memory", address: 15, size: e, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
@@ -47,8 +47,14 @@ Symbols
 Dynamic symbols
 
 Symbol map
-0x0-0x1 "retained_int"
+0x0-0x1 "rodata_bytes"
 0x2-0x4 "__wasm_call_ctors"
 0x5-0x14 "__wasm_apply_data_relocs"
+0xc-0x10 "data_int"
+0x10-0x14 "tls_int"
+0x14-0x15 "rodata_str"
 0x15-0x23 "__wasm_init_memory"
+0x18-0x1c "retained_int"
+0x1c-0x20 "bss_int"
+0x20-0x22 "tbss_int"
 0x24-0x69 "get"

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -223,16 +223,19 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
             weak: false,
         });
 
-        let mut local_func_kinds = Vec::new();
         let mut entry_func_id = None;
         let mut code_range_start = 0;
-        let mut code_ranges = Vec::new();
         let mut imports_section = None;
         let mut exports = None;
         let mut names = None;
         let mut symbols = None;
         let mut segment_infos: Vec<wp::Segment<'data>> = Vec::new();
-        // One-to-one mapping of globals to their value (if the global is a constant integer).
+
+        // Function kind for each function section entry.
+        let mut local_func_kinds = Vec::new();
+        // Address range of each code section entry.
+        let mut code_ranges = Vec::new();
+        // Value of each global section entry if the global is a constant integer.
         let mut global_values = Vec::new();
 
         for payload in parser {
@@ -275,7 +278,7 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                             // There should be exactly one instruction.
                             let init = global.init_expr.get_operators_reader().read();
                             address = match init.read_error("Couldn't read a global init expr")? {
-                                wp::Operator::I32Const { value } => Some(value as u64),
+                                wp::Operator::I32Const { value } => Some(value as u32 as u64),
                                 wp::Operator::I64Const { value } => Some(value as u64),
                                 _ => None,
                             };
@@ -406,12 +409,6 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
             }
         }
 
-        if let Some(entry_func_id) = entry_func_id {
-            if let Some(range) = code_ranges.get(entry_func_id as usize) {
-                file.entry = range.0;
-            }
-        }
-
         // Apply any `SegmentInfo` entries collected from the `linking` section to the already-parsed data segments.
         for (i, info) in segment_infos.into_iter().enumerate() {
             if let Some(slot) = file.data_segments.get_mut(i) {
@@ -493,6 +490,19 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
             }
         }
 
+        // Bias to apply to function indices when accessing `local_func_kinds` and `code_ranges`.
+        let local_func_base = import_func_names.len() as u32;
+        // Bias to apply to global indices when accessing `global_values`.
+        let local_global_base = import_global_names.len() as u32;
+
+        if let Some(entry_func_id) = entry_func_id {
+            if let Some(local_func_index) = entry_func_id.checked_sub(local_func_base) {
+                if let Some(range) = code_ranges.get(local_func_index as usize) {
+                    file.entry = range.0;
+                }
+            }
+        }
+
         if let Some(symbols) = symbols {
             // We have a symbol table, so we don't need to add symbols for locals or exports.
             // These sections shouldn't be present at the same time as a symbol table anyway.
@@ -561,9 +571,9 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                     wp::SymbolInfo::Func {
                         index, mut name, ..
                     } => {
-                        if let Some(local_index) = index.checked_sub(import_func_names.len() as u32)
-                        {
-                            if let Some(range) = code_ranges.get(local_index as usize).copied() {
+                        if let Some(local_func_index) = index.checked_sub(local_func_base) {
+                            if let Some(range) = code_ranges.get(local_func_index as usize).copied()
+                            {
                                 address = range.0;
                                 size = range.1;
                             }
@@ -586,12 +596,21 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                         // TODO: find the section name
                         None
                     }
-                    wp::SymbolInfo::Global { name, index, .. } => {
-                        if !flags.contains(wp::SymbolFlags::EXPLICIT_NAME) {
-                            import_global_names.get(index as usize).copied()
+                    wp::SymbolInfo::Global {
+                        index, mut name, ..
+                    } => {
+                        if let Some(local_global_index) = index.checked_sub(local_global_base) {
+                            if let Some(Some(value)) =
+                                global_values.get(local_global_index as usize).copied()
+                            {
+                                address = value;
+                            }
                         } else {
-                            name
+                            if !flags.contains(wp::SymbolFlags::EXPLICIT_NAME) {
+                                name = import_global_names.get(index as usize).copied()
+                            }
                         }
+                        name
                     }
                     wp::SymbolInfo::Event { name, .. } | wp::SymbolInfo::Table { name, .. } => name,
                 };
@@ -618,11 +637,9 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
 
                 let (kind, section_idx) = match export.kind {
                     wp::ExternalKind::Func | wp::ExternalKind::FuncExact => {
-                        if let Some(local_func_id) =
-                            export.index.checked_sub(import_func_names.len() as u32)
-                        {
+                        if let Some(local_func_index) = export.index.checked_sub(local_func_base) {
                             let local_func_kind = local_func_kinds
-                                .get_mut(local_func_id as usize)
+                                .get_mut(local_func_index as usize)
                                 .read_error("Invalid Wasm export index")?;
                             *local_func_kind = LocalFunctionKind::Exported;
                         }
@@ -640,15 +657,15 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                 let mut address = 0;
                 let mut size = 0;
                 if export.kind == wp::ExternalKind::Global {
-                    if let Some(&Some(x)) = global_values.get(export.index as usize) {
-                        address = x;
+                    if let Some(local_global_index) = export.index.checked_sub(local_global_base) {
+                        if let Some(&Some(x)) = global_values.get(local_global_index as usize) {
+                            address = x;
+                        }
                     }
                 }
                 if export.kind == wp::ExternalKind::Func {
-                    if let Some(local_func_id) =
-                        export.index.checked_sub(import_func_names.len() as u32)
-                    {
-                        if let Some(range) = code_ranges.get(local_func_id as usize) {
+                    if let Some(local_func_index) = export.index.checked_sub(local_func_base) {
+                        if let Some(range) = code_ranges.get(local_func_index as usize) {
                             address = range.0;
                             size = range.1
                         }
@@ -677,17 +694,15 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                 };
                 for naming in name_map {
                     let naming = naming.read_error("Couldn't read a function name")?;
-                    let Some(local_index) =
-                        naming.index.checked_sub(import_func_names.len() as u32)
-                    else {
+                    let Some(local_func_index) = naming.index.checked_sub(local_func_base) else {
                         continue;
                     };
                     let Some(LocalFunctionKind::Unknown) =
-                        local_func_kinds.get(local_index as usize)
+                        local_func_kinds.get(local_func_index as usize)
                     else {
                         continue;
                     };
-                    let Some((address, size)) = code_ranges.get(local_index as usize).copied()
+                    let Some((address, size)) = code_ranges.get(local_func_index as usize).copied()
                     else {
                         continue;
                     };


### PR DESCRIPTION
These were wrong in the presence of imports.

Also don't sign extend u32 global addresses.