### PR TITLE
Read string tables as one block for most files

### DIFF
--- a/crates/examples/src/readobj/elf.rs
+++ b/crates/examples/src/readobj/elf.rs
@@ -165,7 +165,7 @@ fn print_segment_dynamic<Elf: FileHeader>(
         // TODO: print error if DT_STRTAB/DT_STRSZ are invalid
         for s in segments {
             if let Ok(Some(data)) = s.data_range(endian, data, strtab, strsz) {
-                dynstr = StringTable::new(data, 0, data.len() as u64);
+                dynstr = StringTable::from_bytes(data);
                 break;
             }
         }

--- a/src/read/coff/symbol.rs
+++ b/src/read/coff/symbol.rs
@@ -54,17 +54,19 @@ impl<'data, R: ReadRef<'data>, Coff: CoffHeader> SymbolTable<'data, R, Coff> {
                 .read_at::<U32<_>>(offset)
                 .read_error("Missing COFF string table")?
                 .get(LE);
-            let str_end = offset
-                .checked_add(length as u64)
+            let strings = data
+                .read_bytes(&mut offset, length.into())
                 .read_error("Invalid COFF string table length")?;
-            let strings = StringTable::new(data, offset, str_end);
 
             (symbols, strings)
         } else {
-            (&[][..], StringTable::default())
+            (&[][..], &[][..])
         };
 
-        Ok(SymbolTable { symbols, strings })
+        Ok(SymbolTable {
+            symbols,
+            strings: StringTable::from_bytes(strings),
+        })
     }
 
     /// Return the string table used for the symbol names.

--- a/src/read/elf/file.rs
+++ b/src/read/elf/file.rs
@@ -799,15 +799,10 @@ pub trait FileHeader: Debug + Pod + read::private::Sealed {
         }
         let index = self.section_strings_index(endian, data)?;
         let shstrtab = sections.get(index.0).read_error("Invalid ELF e_shstrndx")?;
-        let strings = if let Some((shstrtab_offset, shstrtab_size)) = shstrtab.file_range(endian) {
-            let shstrtab_end = shstrtab_offset
-                .checked_add(shstrtab_size)
-                .read_error("Invalid ELF shstrtab size")?;
-            StringTable::new(data, shstrtab_offset, shstrtab_end)
-        } else {
-            StringTable::default()
-        };
-        Ok(strings)
+        let shstrtab_data = shstrtab
+            .data(endian, data)
+            .read_error("Invalid ELF shstrtab offset or size")?;
+        Ok(StringTable::from_bytes(shstrtab_data))
     }
 
     /// Return the section table.

--- a/src/read/elf/section.rs
+++ b/src/read/elf/section.rs
@@ -798,12 +798,10 @@ pub trait SectionHeader: Debug + Pod + read::private::Sealed {
         if self.sh_type(endian) != elf::SHT_STRTAB {
             return Ok(None);
         }
-        let str_offset = self.sh_offset(endian).into();
-        let str_size = self.sh_size(endian).into();
-        let str_end = str_offset
-            .checked_add(str_size)
+        let strtab_data = self
+            .data(endian, data)
             .read_error("Invalid ELF string section offset or size")?;
-        Ok(Some(StringTable::new(data, str_offset, str_end)))
+        Ok(Some(StringTable::from_bytes(strtab_data)))
     }
 
     /// Return the symbols in the section.

--- a/src/read/macho/file.rs
+++ b/src/read/macho/file.rs
@@ -152,7 +152,7 @@ where
         // The symbols are found in the __LINKEDIT segment, so make sure to read them from the
         // correct subcache.
         let symbols = match (symtab, linkedit_data) {
-            (Some(symtab), Some(linkedit_data)) => symtab.symbols(endian, linkedit_data)?,
+            (Some(symtab), Some(linkedit_data)) => symtab.symbols_lazy(endian, linkedit_data)?,
             _ => SymbolTable::default(),
         };
 

--- a/src/read/macho/load_command.rs
+++ b/src/read/macho/load_command.rs
@@ -458,17 +458,47 @@ impl<E: Endian> macho::SymtabCommand<E> {
         endian: E,
         data: R,
     ) -> Result<SymbolTable<'data, Mach, R>> {
+        self.symbols_internal(endian, data, false)
+    }
+
+    /// Return the symbol table that this command references, and read the
+    /// symbol names as needed.
+    ///
+    /// This allows us to avoid loading the entire string table in the dyld shared
+    /// cache. Prefer [`Self::symbols`] for other uses.
+    pub(super) fn symbols_lazy<'data, Mach: MachHeader<Endian = E>, R: ReadRef<'data>>(
+        &self,
+        endian: E,
+        data: R,
+    ) -> Result<SymbolTable<'data, Mach, R>> {
+        self.symbols_internal(endian, data, true)
+    }
+
+    fn symbols_internal<'data, Mach: MachHeader<Endian = E>, R: ReadRef<'data>>(
+        &self,
+        endian: E,
+        data: R,
+        lazy: bool,
+    ) -> Result<SymbolTable<'data, Mach, R>> {
         let symbols = data
             .read_slice_at(
                 self.symoff.get(endian).into(),
                 self.nsyms.get(endian) as usize,
             )
             .read_error("Invalid Mach-O symbol table offset or size")?;
-        let str_start: u64 = self.stroff.get(endian).into();
-        let str_end = str_start
-            .checked_add(self.strsize.get(endian).into())
-            .read_error("Invalid Mach-O string table length")?;
-        let strings = StringTable::new(data, str_start, str_end);
+        let stroff: u64 = self.stroff.get(endian).into();
+        let strsize: u64 = self.strsize.get(endian).into();
+        let strings = if lazy {
+            let str_end = stroff
+                .checked_add(strsize)
+                .read_error("Invalid Mach-O string table offset or size")?;
+            StringTable::new(data, stroff, str_end)
+        } else {
+            let strings = data
+                .read_bytes_at(stroff, strsize)
+                .read_error("Invalid Mach-O string table offset or size")?;
+            StringTable::from_bytes(strings)
+        };
         Ok(SymbolTable::new(symbols, strings))
     }
 }

--- a/src/read/util.rs
+++ b/src/read/util.rs
@@ -1,7 +1,6 @@
 use alloc::string::String;
 use core::convert::TryInto;
 use core::fmt;
-use core::marker::PhantomData;
 
 use crate::SkipDebugList;
 use crate::pod::{Pod, from_bytes, slice_from_bytes};
@@ -276,31 +275,56 @@ pub struct StringTable<'data, R = &'data [u8]>
 where
     R: ReadRef<'data>,
 {
-    data: Option<SkipDebugList<R>>,
-    start: u64,
-    end: u64,
-    marker: PhantomData<&'data ()>,
+    data: StringTableData<'data, R>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StringTableData<'data, R>
+where
+    R: ReadRef<'data>,
+{
+    /// The complete string table data.
+    Bytes(Bytes<'data>),
+    /// A range of data that strings are read from as needed.
+    Lazy {
+        data: SkipDebugList<R>,
+        start: u64,
+        end: u64,
+    },
 }
 
 impl<'data, R: ReadRef<'data>> StringTable<'data, R> {
     /// Interpret the given data as a string table.
+    // TODO: rename to `new` when doing breaking changes
+    pub fn from_bytes(data: &'data [u8]) -> Self {
+        StringTable {
+            data: StringTableData::Bytes(Bytes(data)),
+        }
+    }
+
+    /// Interpret the given range of data as a string table, and read each string as
+    /// needed.
+    ///
+    /// This allows us to avoid loading the entire string table in the dyld shared
+    /// cache. Prefer [`Self::from_bytes`] for other uses.
     pub fn new(data: R, start: u64, end: u64) -> Self {
         StringTable {
-            data: Some(SkipDebugList(data)),
-            start,
-            end,
-            marker: PhantomData,
+            data: StringTableData::Lazy {
+                data: SkipDebugList(data),
+                start,
+                end,
+            },
         }
     }
 
     /// Return the string at the given offset.
     pub fn get(&self, offset: u32) -> Result<&'data [u8], ()> {
         match self.data {
-            Some(data) => {
-                let r_start = self.start.checked_add(offset.into()).ok_or(())?;
-                data.read_bytes_at_until(r_start..self.end, 0)
+            StringTableData::Bytes(data) => data.read_string_at(offset as usize),
+            StringTableData::Lazy { data, start, end } => {
+                let r_start = start.checked_add(offset.into()).ok_or(())?;
+                data.read_bytes_at_until(r_start..end, 0)
             }
-            None => Err(()),
         }
     }
 }
@@ -308,10 +332,7 @@ impl<'data, R: ReadRef<'data>> StringTable<'data, R> {
 impl<'data, R: ReadRef<'data>> Default for StringTable<'data, R> {
     fn default() -> Self {
         StringTable {
-            data: None,
-            start: 0,
-            end: 0,
-            marker: PhantomData,
+            data: StringTableData::Bytes(Bytes(&[])),
         }
     }
 }

--- a/src/read/xcoff/symbol.rs
+++ b/src/read/xcoff/symbol.rs
@@ -63,19 +63,18 @@ where
                 .read_at::<U32<_>>(offset)
                 .read_error("Missing XCOFF string table")?
                 .get(BE);
-            let str_end = offset
-                .checked_add(length as u64)
+            let strings = data
+                .read_bytes(&mut offset, length.into())
                 .read_error("Invalid XCOFF string table length")?;
-            let strings = StringTable::new(data, offset, str_end);
 
             (symbols, strings)
         } else {
-            (&[][..], StringTable::default())
+            (&[][..], &[][..])
         };
 
         Ok(SymbolTable {
             symbols,
-            strings,
+            strings: StringTable::from_bytes(strings),
             header: PhantomData,
         })
     }

--- a/tests/read/elf.rs
+++ b/tests/read/elf.rs
@@ -38,12 +38,8 @@ fn get_buildid_less_bad_elf() {
     ]
     .iter()
     .collect();
-    let buildid = get_buildid(&path).unwrap().unwrap();
-    // ground truth obtained from GNU binutils's readelf
-    assert_eq!(
-        buildid,
-        b"\xf9\xc0\xc6\x05\xd3\x76\xbb\xa5\x7e\x02\xf5\x74\x50\x9d\x16\xcc\xe9\x9c\x1b\xf1"
-    );
+    // TODO: we error early due to invalid string table
+    let _ = get_buildid(&path);
 }
 
 #[cfg(feature = "std")]

--- a/tests/round_trip/elf.rs
+++ b/tests/round_trip/elf.rs
@@ -404,3 +404,29 @@ fn gnu_property_inner<Elf: FileHeader<Endian = Endianness>>(architecture: Archit
     assert!(props.next().unwrap().is_none());
     assert!(notes.next().unwrap().is_none());
 }
+
+#[test]
+#[cfg(feature = "std")]
+fn long_symbol_name() {
+    // `ReadCache::read_bytes_at_until` can't read long strings.
+    let name = vec![b'a'; 8192];
+
+    let mut object =
+        write::Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+    object.add_symbol(write::Symbol {
+        name: name.clone(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Text,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: write::SymbolSection::Absolute,
+        flags: SymbolFlags::None,
+    });
+    let bytes = object.write().unwrap();
+
+    let cache = read::ReadCache::new(std::io::Cursor::new(bytes));
+    let object = read::File::parse(&cache).unwrap();
+    let symbol = object.symbol_by_name_bytes(&name).unwrap();
+    assert_eq!(symbol.name_bytes().unwrap(), &name[..]);
+}


### PR DESCRIPTION
Only keep the lazy behaviour for the dyld cache. This fixes the reading of long symbol names in ELF when using `ReadCache`, and improves overall efficiency of string table parsing.

Note that this means we now return an error in File::parse for invalid string tables. This is now the same as the error handling for symbol tables, but we can revisit this decision if it is a problem.

Partial revert of 24d513f58cd0c440942b7047e4c1b830ca3aef88

Closes #975