### PR TITLE
wasm: sections always include the data section and the data segments

### DIFF
--- a/crates/examples/testfiles/wasm/base.o.objdump
+++ b/crates/examples/testfiles/wasm/base.o.objdump
@@ -7,8 +7,9 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: b, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 5e, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 6d, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 13, align: 1, kind: Metadata, flags: None }
 0: Section { name: "linking", address: 0, size: 5d, align: 1, kind: Linker, flags: None }
 0: Section { name: "reloc.CODE", address: 0, size: 15, align: 1, kind: Linker, flags: None }
 0: Section { name: "producers", address: 0, size: 6c, align: 1, kind: Other, flags: None }

--- a/crates/examples/testfiles/wasm/base.wasm.objdump
+++ b/crates/examples/testfiles/wasm/base.wasm.objdump
@@ -9,15 +9,17 @@ Segment { address: d68, size: ec, permissions: RW- }
 1: Section { name: "<type>", address: 0, size: 4a, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: b0, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 25, align: 1, kind: Metadata, flags: None }
-4: Section { name: "<table>", address: 0, size: 5, align: 1, kind: UninitializedData, flags: None }
-5: Section { name: "<memory>", address: 0, size: 3, align: 1, kind: UninitializedData, flags: None }
-6: Section { name: "<global>", address: 0, size: 8, align: 1, kind: Data, flags: None }
+4: Section { name: "<table>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
+5: Section { name: "<memory>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
+6: Section { name: "<global>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: 13, align: 1, kind: Linker, flags: None }
-9: Section { name: "<element>", address: 0, size: a, align: 1, kind: Data, flags: None }
+9: Section { name: "<element>", address: 0, size: a, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 3bc6, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: a60, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: a60, align: 1, kind: Metadata, flags: None }
 0: Section { name: "name", address: 0, size: 1e8, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 6c, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 400, size: 965, align: 1, kind: Data, flags: None }
+15: Section { name: "<data_segment>", address: d68, size: ec, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "wasi_snapshot_preview1", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }

--- a/crates/examples/testfiles/wasm/dylink-debug.o.objdump
+++ b/crates/examples/testfiles/wasm/dylink-debug.o.objdump
@@ -7,8 +7,9 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: ea, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 2, align: 1, kind: Metadata, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 47, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 4a, align: 1, kind: Metadata, flags: None }
 0: Section { name: ".debug_abbrev", address: 0, size: 7d, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_info", address: 0, size: 135, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_str", address: 0, size: f6, align: 1, kind: Other, flags: None }
@@ -21,24 +22,24 @@ Entry Address: 0
 0: Section { name: "producers", address: 0, size: 6d, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 90, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.data_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".data.tls_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-16: Section { name: ".rodata.rodata_bytes", address: 0, size: 3, align: 1, kind: ReadOnlyData, flags: Wasm { flags: 0 } }
-17: Section { name: ".rodata..L.str", address: 0, size: 6, align: 1, kind: ReadOnlyString, flags: Wasm { flags: WASM_SEG_FLAG_STRINGS } }
-18: Section { name: ".data.rodata_str", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.retained_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: WASM_SEG_FLAG_RETAIN } }
-20: Section { name: ".bss.bss_int", address: 0, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
-21: Section { name: ".bss.tbss_int", address: 0, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
+15: Section { name: ".data.tls_int", address: 4, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+16: Section { name: ".rodata.rodata_bytes", address: 8, size: 3, align: 1, kind: ReadOnlyData, flags: Wasm { flags: 0 } }
+17: Section { name: ".rodata..L.str", address: b, size: 6, align: 1, kind: ReadOnlyString, flags: Wasm { flags: WASM_SEG_FLAG_STRINGS } }
+18: Section { name: ".data.rodata_str", address: 14, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.retained_int", address: 18, size: 4, align: 4, kind: Data, flags: Wasm { flags: WASM_SEG_FLAG_RETAIN } }
+20: Section { name: ".bss.bss_int", address: 1c, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
+21: Section { name: ".bss.tbss_int", address: 20, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
 
 Symbols
 0: Symbol { name: "get", address: 2, size: 45, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
 1: Symbol { name: "data_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Dynamic, weak: false, flags: None }
-2: Symbol { name: "bss_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(14)), scope: Dynamic, weak: false, flags: None }
-3: Symbol { name: "tls_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: None }
-4: Symbol { name: "tbss_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(15)), scope: Dynamic, weak: false, flags: None }
-5: Symbol { name: "rodata_bytes", address: 0, size: 3, kind: Data, section: Section(SectionIndex(10)), scope: Dynamic, weak: false, flags: None }
-6: Symbol { name: "rodata_str", address: 0, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Dynamic, weak: false, flags: None }
-7: Symbol { name: "retained_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: None }
-8: Symbol { name: ".L.str", address: 0, size: 6, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
+2: Symbol { name: "bss_int", address: 1c, size: 4, kind: Data, section: Section(SectionIndex(14)), scope: Dynamic, weak: false, flags: None }
+3: Symbol { name: "tls_int", address: 4, size: 4, kind: Data, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: None }
+4: Symbol { name: "tbss_int", address: 20, size: 4, kind: Data, section: Section(SectionIndex(15)), scope: Dynamic, weak: false, flags: None }
+5: Symbol { name: "rodata_bytes", address: 8, size: 3, kind: Data, section: Section(SectionIndex(10)), scope: Dynamic, weak: false, flags: None }
+6: Symbol { name: "rodata_str", address: 14, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Dynamic, weak: false, flags: None }
+7: Symbol { name: "retained_int", address: 18, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: None }
+8: Symbol { name: ".L.str", address: b, size: 6, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
 9: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 10: Symbol { name: "__memory_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 11: Symbol { name: "__tls_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
@@ -101,5 +102,12 @@ Symbols
 Dynamic symbols
 
 Symbol map
-0x0-0x4 "retained_int"
+0x0-0x4 "data_int"
 0x2-0x47 "get"
+0x4-0x8 "tls_int"
+0x8-0xb "rodata_bytes"
+0xb-0x11 ".L.str"
+0x14-0x18 "rodata_str"
+0x18-0x1c "retained_int"
+0x1c-0x20 "bss_int"
+0x20-0x24 "tbss_int"

--- a/crates/examples/testfiles/wasm/dylink-debug.wasm.objdump
+++ b/crates/examples/testfiles/wasm/dylink-debug.wasm.objdump
@@ -9,11 +9,11 @@ Segment { address: 0, size: 1c, permissions: RW- }
 1: Section { name: "<type>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: cc, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
-6: Section { name: "<global>", address: 0, size: 24, align: 1, kind: Data, flags: None }
+6: Section { name: "<global>", address: 0, size: 24, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: 77, align: 1, kind: Linker, flags: None }
-8: Section { name: "<start>", address: 0, size: 1, align: 1, kind: Linker, flags: None }
+8: Section { name: "<start>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 69, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: 22, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: 22, align: 1, kind: Metadata, flags: None }
 0: Section { name: ".debug_abbrev", address: 0, size: 7d, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_info", address: 0, size: 135, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_str", address: 0, size: ea, align: 1, kind: Other, flags: None }
@@ -21,6 +21,7 @@ Segment { address: 0, size: 1c, permissions: RW- }
 0: Section { name: "name", address: 0, size: d5, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 6d, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 84, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 0, size: 1c, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "env", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }

--- a/crates/examples/testfiles/wasm/dylink-shared-memory.o.objdump
+++ b/crates/examples/testfiles/wasm/dylink-shared-memory.o.objdump
@@ -7,33 +7,34 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 97, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 2, align: 1, kind: Metadata, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 5f, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 4a, align: 1, kind: Metadata, flags: None }
 0: Section { name: "linking", address: 0, size: 124, align: 1, kind: Linker, flags: None }
 0: Section { name: "reloc.CODE", address: 0, size: 1c, align: 1, kind: Linker, flags: None }
 0: Section { name: "reloc.DATA", address: 0, size: 6, align: 1, kind: Linker, flags: None }
 0: Section { name: "producers", address: 0, size: 5e, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 8d, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.data_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".tdata.tls_int", address: 0, size: 4, align: 4, kind: Tls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
-16: Section { name: ".rodata.rodata_bytes", address: 0, size: 3, align: 1, kind: ReadOnlyData, flags: Wasm { flags: 0 } }
-17: Section { name: ".rodata..L.str", address: 0, size: 6, align: 1, kind: ReadOnlyString, flags: Wasm { flags: WASM_SEG_FLAG_STRINGS } }
-18: Section { name: ".data.rodata_str", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.retained_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: WASM_SEG_FLAG_RETAIN } }
-20: Section { name: ".bss.bss_int", address: 0, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
-21: Section { name: ".tbss.tbss_int", address: 0, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
+15: Section { name: ".tdata.tls_int", address: 4, size: 4, align: 4, kind: Tls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
+16: Section { name: ".rodata.rodata_bytes", address: 8, size: 3, align: 1, kind: ReadOnlyData, flags: Wasm { flags: 0 } }
+17: Section { name: ".rodata..L.str", address: b, size: 6, align: 1, kind: ReadOnlyString, flags: Wasm { flags: WASM_SEG_FLAG_STRINGS } }
+18: Section { name: ".data.rodata_str", address: 14, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.retained_int", address: 18, size: 4, align: 4, kind: Data, flags: Wasm { flags: WASM_SEG_FLAG_RETAIN } }
+20: Section { name: ".bss.bss_int", address: 1c, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
+21: Section { name: ".tbss.tbss_int", address: 20, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
 
 Symbols
 0: Symbol { name: "get", address: 2, size: 5d, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
 1: Symbol { name: "data_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Dynamic, weak: false, flags: None }
-2: Symbol { name: "bss_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(14)), scope: Dynamic, weak: false, flags: None }
-3: Symbol { name: "tls_int", address: 0, size: 4, kind: Tls, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: None }
+2: Symbol { name: "bss_int", address: 1c, size: 4, kind: Data, section: Section(SectionIndex(14)), scope: Dynamic, weak: false, flags: None }
+3: Symbol { name: "tls_int", address: 4, size: 4, kind: Tls, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: None }
 4: Symbol { name: "__tls_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
-5: Symbol { name: "tbss_int", address: 0, size: 4, kind: Tls, section: Section(SectionIndex(15)), scope: Dynamic, weak: false, flags: None }
-6: Symbol { name: "rodata_bytes", address: 0, size: 3, kind: Data, section: Section(SectionIndex(10)), scope: Dynamic, weak: false, flags: None }
-7: Symbol { name: "rodata_str", address: 0, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Dynamic, weak: false, flags: None }
-8: Symbol { name: "retained_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: None }
-9: Symbol { name: ".L.str", address: 0, size: 6, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
+5: Symbol { name: "tbss_int", address: 20, size: 4, kind: Tls, section: Section(SectionIndex(15)), scope: Dynamic, weak: false, flags: None }
+6: Symbol { name: "rodata_bytes", address: 8, size: 3, kind: Data, section: Section(SectionIndex(10)), scope: Dynamic, weak: false, flags: None }
+7: Symbol { name: "rodata_str", address: 14, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Dynamic, weak: false, flags: None }
+8: Symbol { name: "retained_int", address: 18, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: None }
+9: Symbol { name: ".L.str", address: b, size: 6, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
 
 <code> relocations
 (6, Relocation { kind: Unknown, encoding: Generic, size: 28, target: Symbol(SymbolIndex(1)), addend: 0, implicit_addend: false, flags: Wasm { r_type: 7 } })
@@ -51,5 +52,10 @@ Symbols
 Dynamic symbols
 
 Symbol map
-0x0-0x4 "retained_int"
+0x0-0x4 "data_int"
 0x2-0x5f "get"
+0x8-0xb "rodata_bytes"
+0xb-0x11 ".L.str"
+0x14-0x18 "rodata_str"
+0x18-0x1c "retained_int"
+0x1c-0x20 "bss_int"

--- a/crates/examples/testfiles/wasm/dylink-shared-memory.wasm.objdump
+++ b/crates/examples/testfiles/wasm/dylink-shared-memory.wasm.objdump
@@ -8,15 +8,18 @@ Entry Address: 16
 1: Section { name: "<type>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: a6, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
-6: Section { name: "<global>", address: 0, size: 29, align: 1, kind: Data, flags: None }
+6: Section { name: "<global>", address: 0, size: 29, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: 77, align: 1, kind: Linker, flags: None }
-8: Section { name: "<start>", address: 0, size: 1, align: 1, kind: Linker, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+8: Section { name: "<start>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: f4, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: 24, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: 24, align: 1, kind: Metadata, flags: None }
 0: Section { name: "name", address: 0, size: e7, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 5e, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 8d, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 0, size: 8, align: 1, kind: Data, flags: None }
+15: Section { name: "<data_segment>", address: 0, size: 9, align: 1, kind: Data, flags: None }
+16: Section { name: "<data_segment>", address: 0, size: c, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "env", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }
@@ -49,7 +52,7 @@ Symbol map
 0x2-0x4 "__wasm_call_ctors"
 0x4-0x5 "tbss_int"
 0x5-0x14 "__wasm_apply_data_relocs"
-0x8-0x14 "rodata_bytes"
+0x8-0x9 "rodata_bytes"
 0x14-0x16 "data_int"
 0x16-0x96 "__wasm_init_memory"
 0x18-0x1c "rodata_str"

--- a/crates/examples/testfiles/wasm/dylink.o.objdump
+++ b/crates/examples/testfiles/wasm/dylink.o.objdump
@@ -7,32 +7,33 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: ac, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 2, align: 1, kind: Metadata, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 47, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 4a, align: 1, kind: Metadata, flags: None }
 0: Section { name: "linking", address: 0, size: 11d, align: 1, kind: Linker, flags: None }
 0: Section { name: "reloc.CODE", address: 0, size: 17, align: 1, kind: Linker, flags: None }
 0: Section { name: "reloc.DATA", address: 0, size: 6, align: 1, kind: Linker, flags: None }
 0: Section { name: "producers", address: 0, size: 5e, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 90, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.data_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".data.tls_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-16: Section { name: ".rodata.rodata_bytes", address: 0, size: 3, align: 1, kind: ReadOnlyData, flags: Wasm { flags: 0 } }
-17: Section { name: ".rodata..L.str", address: 0, size: 6, align: 1, kind: ReadOnlyString, flags: Wasm { flags: WASM_SEG_FLAG_STRINGS } }
-18: Section { name: ".data.rodata_str", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.retained_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: WASM_SEG_FLAG_RETAIN } }
-20: Section { name: ".bss.bss_int", address: 0, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
-21: Section { name: ".bss.tbss_int", address: 0, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
+15: Section { name: ".data.tls_int", address: 4, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+16: Section { name: ".rodata.rodata_bytes", address: 8, size: 3, align: 1, kind: ReadOnlyData, flags: Wasm { flags: 0 } }
+17: Section { name: ".rodata..L.str", address: b, size: 6, align: 1, kind: ReadOnlyString, flags: Wasm { flags: WASM_SEG_FLAG_STRINGS } }
+18: Section { name: ".data.rodata_str", address: 14, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.retained_int", address: 18, size: 4, align: 4, kind: Data, flags: Wasm { flags: WASM_SEG_FLAG_RETAIN } }
+20: Section { name: ".bss.bss_int", address: 1c, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
+21: Section { name: ".bss.tbss_int", address: 20, size: 4, align: 4, kind: UninitializedData, flags: Wasm { flags: 0 } }
 
 Symbols
 0: Symbol { name: "get", address: 2, size: 45, kind: Text, section: Section(SectionIndex(a)), scope: Dynamic, weak: false, flags: None }
 1: Symbol { name: "data_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Dynamic, weak: false, flags: None }
-2: Symbol { name: "bss_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(14)), scope: Dynamic, weak: false, flags: None }
-3: Symbol { name: "tls_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: None }
-4: Symbol { name: "tbss_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(15)), scope: Dynamic, weak: false, flags: None }
-5: Symbol { name: "rodata_bytes", address: 0, size: 3, kind: Data, section: Section(SectionIndex(10)), scope: Dynamic, weak: false, flags: None }
-6: Symbol { name: "rodata_str", address: 0, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Dynamic, weak: false, flags: None }
-7: Symbol { name: "retained_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: None }
-8: Symbol { name: ".L.str", address: 0, size: 6, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
+2: Symbol { name: "bss_int", address: 1c, size: 4, kind: Data, section: Section(SectionIndex(14)), scope: Dynamic, weak: false, flags: None }
+3: Symbol { name: "tls_int", address: 4, size: 4, kind: Data, section: Section(SectionIndex(f)), scope: Dynamic, weak: false, flags: None }
+4: Symbol { name: "tbss_int", address: 20, size: 4, kind: Data, section: Section(SectionIndex(15)), scope: Dynamic, weak: false, flags: None }
+5: Symbol { name: "rodata_bytes", address: 8, size: 3, kind: Data, section: Section(SectionIndex(10)), scope: Dynamic, weak: false, flags: None }
+6: Symbol { name: "rodata_str", address: 14, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Dynamic, weak: false, flags: None }
+7: Symbol { name: "retained_int", address: 18, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Dynamic, weak: false, flags: None }
+8: Symbol { name: ".L.str", address: b, size: 6, kind: Data, section: Section(SectionIndex(11)), scope: Compilation, weak: false, flags: None }
 
 <code> relocations
 (4, Relocation { kind: Unknown, encoding: Generic, size: 28, target: Symbol(SymbolIndex(1)), addend: 0, implicit_addend: false, flags: Wasm { r_type: 7 } })
@@ -49,5 +50,12 @@ Symbols
 Dynamic symbols
 
 Symbol map
-0x0-0x4 "retained_int"
+0x0-0x4 "data_int"
 0x2-0x47 "get"
+0x4-0x8 "tls_int"
+0x8-0xb "rodata_bytes"
+0xb-0x11 ".L.str"
+0x14-0x18 "rodata_str"
+0x18-0x1c "retained_int"
+0x1c-0x20 "bss_int"
+0x20-0x24 "tbss_int"

--- a/crates/examples/testfiles/wasm/dylink.wasm.objdump
+++ b/crates/examples/testfiles/wasm/dylink.wasm.objdump
@@ -9,14 +9,15 @@ Segment { address: 0, size: 1c, permissions: RW- }
 1: Section { name: "<type>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: cc, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 5, align: 1, kind: Metadata, flags: None }
-6: Section { name: "<global>", address: 0, size: 24, align: 1, kind: Data, flags: None }
+6: Section { name: "<global>", address: 0, size: 24, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: 77, align: 1, kind: Linker, flags: None }
-8: Section { name: "<start>", address: 0, size: 1, align: 1, kind: Linker, flags: None }
+8: Section { name: "<start>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 69, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: 22, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: 22, align: 1, kind: Metadata, flags: None }
 0: Section { name: "name", address: 0, size: cf, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 5e, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 84, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 0, size: 1c, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "env", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }

--- a/crates/examples/testfiles/wasm/global-wasm32.objdump
+++ b/crates/examples/testfiles/wasm/global-wasm32.objdump
@@ -8,14 +8,15 @@ Segment { address: 400, size: 8, permissions: RW- }
 1: Section { name: "<type>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 13, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
-5: Section { name: "<memory>", address: 0, size: 3, align: 1, kind: UninitializedData, flags: None }
-6: Section { name: "<global>", address: 0, size: 4b, align: 1, kind: Data, flags: None }
+5: Section { name: "<memory>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
+6: Section { name: "<global>", address: 0, size: 4b, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: bd, align: 1, kind: Linker, flags: None }
 10: Section { name: "<code>", address: 0, size: 38, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: f, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: f, align: 1, kind: Metadata, flags: None }
 0: Section { name: "name", address: 0, size: 48, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 5c, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 1c, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 400, size: 8, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "env", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }

--- a/crates/examples/testfiles/wasm/global-wasm64-import.objdump
+++ b/crates/examples/testfiles/wasm/global-wasm64-import.objdump
@@ -8,13 +8,14 @@ Segment { address: 400, size: 8, permissions: RW- }
 1: Section { name: "<type>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 21, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
-6: Section { name: "<global>", address: 0, size: 50, align: 1, kind: Data, flags: None }
+6: Section { name: "<global>", address: 0, size: 50, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: c5, align: 1, kind: Linker, flags: None }
 10: Section { name: "<code>", address: 0, size: 48, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: f, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: f, align: 1, kind: Metadata, flags: None }
 0: Section { name: "name", address: 0, size: 48, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 5c, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 26, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 400, size: 8, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "env", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }

--- a/crates/examples/testfiles/wasm/global-wasm64.objdump
+++ b/crates/examples/testfiles/wasm/global-wasm64.objdump
@@ -8,14 +8,15 @@ Segment { address: 400, size: 8, permissions: RW- }
 1: Section { name: "<type>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 13, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
-5: Section { name: "<memory>", address: 0, size: 3, align: 1, kind: UninitializedData, flags: None }
-6: Section { name: "<global>", address: 0, size: 50, align: 1, kind: Data, flags: None }
+5: Section { name: "<memory>", address: 0, size: 3, align: 1, kind: Metadata, flags: None }
+6: Section { name: "<global>", address: 0, size: 50, align: 1, kind: Metadata, flags: None }
 7: Section { name: "<export>", address: 0, size: ce, align: 1, kind: Linker, flags: None }
 10: Section { name: "<code>", address: 0, size: 48, align: 1, kind: Text, flags: None }
-11: Section { name: "<data>", address: 0, size: f, align: 1, kind: Data, flags: None }
+11: Section { name: "<data>", address: 0, size: f, align: 1, kind: Metadata, flags: None }
 0: Section { name: "name", address: 0, size: 48, align: 1, kind: Other, flags: None }
 0: Section { name: "producers", address: 0, size: 5c, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: 26, align: 1, kind: Other, flags: None }
+14: Section { name: "<data_segment>", address: 400, size: 8, align: 1, kind: Data, flags: None }
 
 Symbols
 0: Symbol { name: "env", address: 0, size: 0, kind: File, section: None, scope: Dynamic, weak: false, flags: None }

--- a/crates/examples/testfiles/wasm/reloc-rel-wasm64.o.objdump
+++ b/crates/examples/testfiles/wasm/reloc-rel-wasm64.o.objdump
@@ -7,9 +7,10 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 11, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 109, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 4, align: 1, kind: Metadata, flags: None }
-9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Data, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 10b, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 47, align: 1, kind: Metadata, flags: None }
 0: Section { name: ".debug_abbrev", address: 0, size: 91, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_info", address: 0, size: 16d, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_ranges", address: 0, size: 30, align: 1, kind: Other, flags: None }
@@ -26,11 +27,11 @@ Entry Address: 0
 0: Section { name: "producers", address: 0, size: 8f, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: ab, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.global_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".data.global_point", address: 0, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-16: Section { name: ".tbss.tls_counter", address: 0, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
-17: Section { name: ".data.data_ptr_to_global", address: 0, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
-18: Section { name: ".data.data_ptr_with_addend", address: 0, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.data_func_ptr", address: 0, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
+15: Section { name: ".data.global_point", address: 4, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+16: Section { name: ".tbss.tls_counter", address: c, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
+17: Section { name: ".data.data_ptr_to_global", address: 10, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
+18: Section { name: ".data.data_ptr_with_addend", address: 18, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.data_func_ptr", address: 20, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
 
 Symbols
 0: Symbol { name: "_Z6relocsv", address: 3, size: ee, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: false, flags: None }
@@ -41,16 +42,16 @@ Symbols
 5: Symbol { name: "", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 6: Symbol { name: "global_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Linkage, weak: false, flags: None }
 7: Symbol { name: "__memory_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
-8: Symbol { name: "global_point", address: 0, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
-9: Symbol { name: "tls_counter", address: 0, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
+8: Symbol { name: "global_point", address: 4, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
+9: Symbol { name: "tls_counter", address: c, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
 10: Symbol { name: "__tls_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 11: Symbol { name: "", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Dynamic, weak: false, flags: None }
 12: Symbol { name: "__cxa_begin_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 13: Symbol { name: "__cxa_end_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 14: Symbol { name: "_ZTW11tls_counter", address: f6, size: 15, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: true, flags: None }
-15: Symbol { name: "data_ptr_to_global", address: 0, size: 8, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
-16: Symbol { name: "data_ptr_with_addend", address: 0, size: 8, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
-17: Symbol { name: "data_func_ptr", address: 0, size: 8, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
+15: Symbol { name: "data_ptr_to_global", address: 10, size: 8, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
+16: Symbol { name: "data_ptr_with_addend", address: 18, size: 8, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
+17: Symbol { name: "data_func_ptr", address: 20, size: 8, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
 18: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 19: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 20: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
@@ -144,7 +145,11 @@ llvm.func_attr.annotate.my_annotation relocations
 Dynamic symbols
 
 Symbol map
-0x0-0x8 "data_func_ptr"
+0x0-0x4 "global_int"
 0x3-0xf1 "_Z6relocsv"
+0x4-0xc "global_point"
+0x10-0x18 "data_ptr_to_global"
+0x18-0x20 "data_ptr_with_addend"
+0x20-0x28 "data_func_ptr"
 0xf2-0xf5 "_ZL11static_funcv"
 0xf6-0x10b "_ZTW11tls_counter"

--- a/crates/examples/testfiles/wasm/reloc-rel.o.objdump
+++ b/crates/examples/testfiles/wasm/reloc-rel.o.objdump
@@ -7,9 +7,10 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 11, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: 109, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 4, align: 1, kind: Metadata, flags: None }
-9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Data, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: ee, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 3b, align: 1, kind: Metadata, flags: None }
 0: Section { name: ".debug_abbrev", address: 0, size: 91, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_info", address: 0, size: 149, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_ranges", address: 0, size: 18, align: 1, kind: Other, flags: None }
@@ -26,11 +27,11 @@ Entry Address: 0
 0: Section { name: "producers", address: 0, size: 8f, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: a1, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.global_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".data.global_point", address: 0, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-16: Section { name: ".tbss.tls_counter", address: 0, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
-17: Section { name: ".data.data_ptr_to_global", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-18: Section { name: ".data.data_ptr_with_addend", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.data_func_ptr", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+15: Section { name: ".data.global_point", address: 4, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+16: Section { name: ".tbss.tls_counter", address: c, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
+17: Section { name: ".data.data_ptr_to_global", address: 10, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+18: Section { name: ".data.data_ptr_with_addend", address: 14, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.data_func_ptr", address: 18, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
 
 Symbols
 0: Symbol { name: "_Z6relocsv", address: 3, size: d6, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: false, flags: None }
@@ -41,16 +42,16 @@ Symbols
 5: Symbol { name: "", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 6: Symbol { name: "global_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Linkage, weak: false, flags: None }
 7: Symbol { name: "__memory_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
-8: Symbol { name: "global_point", address: 0, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
-9: Symbol { name: "tls_counter", address: 0, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
+8: Symbol { name: "global_point", address: 4, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
+9: Symbol { name: "tls_counter", address: c, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
 10: Symbol { name: "__tls_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 11: Symbol { name: "", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Dynamic, weak: false, flags: None }
 12: Symbol { name: "__cxa_begin_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 13: Symbol { name: "__cxa_end_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 14: Symbol { name: "_ZTW11tls_counter", address: de, size: 10, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: true, flags: None }
-15: Symbol { name: "data_ptr_to_global", address: 0, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
-16: Symbol { name: "data_ptr_with_addend", address: 0, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
-17: Symbol { name: "data_func_ptr", address: 0, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
+15: Symbol { name: "data_ptr_to_global", address: 10, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
+16: Symbol { name: "data_ptr_with_addend", address: 14, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
+17: Symbol { name: "data_func_ptr", address: 18, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
 18: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 19: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 20: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
@@ -144,7 +145,11 @@ llvm.func_attr.annotate.my_annotation relocations
 Dynamic symbols
 
 Symbol map
-0x0-0x4 "data_func_ptr"
+0x0-0x4 "global_int"
 0x3-0xd9 "_Z6relocsv"
+0x4-0xc "global_point"
+0x10-0x14 "data_ptr_to_global"
+0x14-0x18 "data_ptr_with_addend"
+0x18-0x1c "data_func_ptr"
 0xda-0xdd "_ZL11static_funcv"
 0xde-0xee "_ZTW11tls_counter"

--- a/crates/examples/testfiles/wasm/reloc-wasm64.o.objdump
+++ b/crates/examples/testfiles/wasm/reloc-wasm64.o.objdump
@@ -7,9 +7,10 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 11, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: c1, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 4, align: 1, kind: Metadata, flags: None }
-9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Data, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: 104, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 47, align: 1, kind: Metadata, flags: None }
 0: Section { name: ".debug_abbrev", address: 0, size: 91, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_info", address: 0, size: 14a, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_ranges", address: 0, size: 30, align: 1, kind: Other, flags: None }
@@ -26,11 +27,11 @@ Entry Address: 0
 0: Section { name: "producers", address: 0, size: 8f, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: ab, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.global_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".data.global_point", address: 0, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-16: Section { name: ".tbss.tls_counter", address: 0, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
-17: Section { name: ".data.data_ptr_to_global", address: 0, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
-18: Section { name: ".data.data_ptr_with_addend", address: 0, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.data_func_ptr", address: 0, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
+15: Section { name: ".data.global_point", address: 4, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+16: Section { name: ".tbss.tls_counter", address: c, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
+17: Section { name: ".data.data_ptr_to_global", address: 10, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
+18: Section { name: ".data.data_ptr_with_addend", address: 18, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.data_func_ptr", address: 20, size: 8, align: 8, kind: Data, flags: Wasm { flags: 0 } }
 
 Symbols
 0: Symbol { name: "_Z6relocsv", address: 3, size: e7, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: false, flags: None }
@@ -39,16 +40,16 @@ Symbols
 3: Symbol { name: "_ZL11static_funcv", address: eb, size: 3, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
 4: Symbol { name: "", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 5: Symbol { name: "global_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Linkage, weak: false, flags: None }
-6: Symbol { name: "global_point", address: 0, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
-7: Symbol { name: "tls_counter", address: 0, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
+6: Symbol { name: "global_point", address: 4, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
+7: Symbol { name: "tls_counter", address: c, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
 8: Symbol { name: "__tls_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 9: Symbol { name: "", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Dynamic, weak: false, flags: None }
 10: Symbol { name: "__cxa_begin_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 11: Symbol { name: "__cxa_end_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 12: Symbol { name: "_ZTW11tls_counter", address: ef, size: 15, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: true, flags: None }
-13: Symbol { name: "data_ptr_to_global", address: 0, size: 8, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
-14: Symbol { name: "data_ptr_with_addend", address: 0, size: 8, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
-15: Symbol { name: "data_func_ptr", address: 0, size: 8, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
+13: Symbol { name: "data_ptr_to_global", address: 10, size: 8, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
+14: Symbol { name: "data_ptr_with_addend", address: 18, size: 8, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
+15: Symbol { name: "data_func_ptr", address: 20, size: 8, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
 16: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 17: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 18: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
@@ -136,7 +137,11 @@ llvm.func_attr.annotate.my_annotation relocations
 Dynamic symbols
 
 Symbol map
-0x0-0x8 "data_func_ptr"
+0x0-0x4 "global_int"
 0x3-0xea "_Z6relocsv"
+0x4-0xc "global_point"
+0x10-0x18 "data_ptr_to_global"
+0x18-0x20 "data_ptr_with_addend"
+0x20-0x28 "data_func_ptr"
 0xeb-0xee "_ZL11static_funcv"
 0xef-0x104 "_ZTW11tls_counter"

--- a/crates/examples/testfiles/wasm/reloc.o.objdump
+++ b/crates/examples/testfiles/wasm/reloc.o.objdump
@@ -7,9 +7,10 @@ Entry Address: 0
 1: Section { name: "<type>", address: 0, size: 11, align: 1, kind: Metadata, flags: None }
 2: Section { name: "<import>", address: 0, size: c1, align: 1, kind: Linker, flags: None }
 3: Section { name: "<function>", address: 0, size: 4, align: 1, kind: Metadata, flags: None }
-9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Data, flags: None }
-12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: UninitializedData, flags: None }
+9: Section { name: "<element>", address: 0, size: 8, align: 1, kind: Metadata, flags: None }
+12: Section { name: "<data_count>", address: 0, size: 1, align: 1, kind: Metadata, flags: None }
 10: Section { name: "<code>", address: 0, size: dd, align: 1, kind: Text, flags: None }
+11: Section { name: "<data>", address: 0, size: 3b, align: 1, kind: Metadata, flags: None }
 0: Section { name: ".debug_abbrev", address: 0, size: 91, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_info", address: 0, size: 126, align: 1, kind: Other, flags: None }
 0: Section { name: ".debug_ranges", address: 0, size: 18, align: 1, kind: Other, flags: None }
@@ -26,11 +27,11 @@ Entry Address: 0
 0: Section { name: "producers", address: 0, size: 8f, align: 1, kind: Other, flags: None }
 0: Section { name: "target_features", address: 0, size: a1, align: 1, kind: Other, flags: None }
 14: Section { name: ".data.global_int", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-15: Section { name: ".data.global_point", address: 0, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-16: Section { name: ".tbss.tls_counter", address: 0, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
-17: Section { name: ".data.data_ptr_to_global", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-18: Section { name: ".data.data_ptr_with_addend", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
-19: Section { name: ".data.data_func_ptr", address: 0, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+15: Section { name: ".data.global_point", address: 4, size: 8, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+16: Section { name: ".tbss.tls_counter", address: c, size: 4, align: 4, kind: UninitializedTls, flags: Wasm { flags: WASM_SEG_FLAG_TLS } }
+17: Section { name: ".data.data_ptr_to_global", address: 10, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+18: Section { name: ".data.data_ptr_with_addend", address: 14, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
+19: Section { name: ".data.data_func_ptr", address: 18, size: 4, align: 4, kind: Data, flags: Wasm { flags: 0 } }
 
 Symbols
 0: Symbol { name: "_Z6relocsv", address: 3, size: c5, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: false, flags: None }
@@ -39,16 +40,16 @@ Symbols
 3: Symbol { name: "_ZL11static_funcv", address: c9, size: 3, kind: Text, section: Section(SectionIndex(a)), scope: Compilation, weak: false, flags: None }
 4: Symbol { name: "", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 5: Symbol { name: "global_int", address: 0, size: 4, kind: Data, section: Section(SectionIndex(e)), scope: Linkage, weak: false, flags: None }
-6: Symbol { name: "global_point", address: 0, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
-7: Symbol { name: "tls_counter", address: 0, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
+6: Symbol { name: "global_point", address: 4, size: 8, kind: Data, section: Section(SectionIndex(f)), scope: Linkage, weak: false, flags: None }
+7: Symbol { name: "tls_counter", address: c, size: 4, kind: Tls, section: Section(SectionIndex(10)), scope: Linkage, weak: false, flags: None }
 8: Symbol { name: "__tls_base", address: 0, size: 0, kind: Data, section: Undefined, scope: Dynamic, weak: false, flags: None }
 9: Symbol { name: "", address: 0, size: 0, kind: Unknown, section: Undefined, scope: Dynamic, weak: false, flags: None }
 10: Symbol { name: "__cxa_begin_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 11: Symbol { name: "__cxa_end_catch", address: 0, size: 0, kind: Text, section: Undefined, scope: Dynamic, weak: false, flags: None }
 12: Symbol { name: "_ZTW11tls_counter", address: cd, size: 10, kind: Text, section: Section(SectionIndex(a)), scope: Linkage, weak: true, flags: None }
-13: Symbol { name: "data_ptr_to_global", address: 0, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
-14: Symbol { name: "data_ptr_with_addend", address: 0, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
-15: Symbol { name: "data_func_ptr", address: 0, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
+13: Symbol { name: "data_ptr_to_global", address: 10, size: 4, kind: Data, section: Section(SectionIndex(11)), scope: Linkage, weak: false, flags: None }
+14: Symbol { name: "data_ptr_with_addend", address: 14, size: 4, kind: Data, section: Section(SectionIndex(12)), scope: Linkage, weak: false, flags: None }
+15: Symbol { name: "data_func_ptr", address: 18, size: 4, kind: Data, section: Section(SectionIndex(13)), scope: Linkage, weak: false, flags: None }
 16: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 17: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
 18: Symbol { name: "", address: 0, size: 0, kind: Section, section: Unknown, scope: Compilation, weak: false, flags: None }
@@ -136,7 +137,11 @@ llvm.func_attr.annotate.my_annotation relocations
 Dynamic symbols
 
 Symbol map
-0x0-0x4 "data_func_ptr"
+0x0-0x4 "global_int"
 0x3-0xc8 "_Z6relocsv"
+0x4-0xc "global_point"
+0x10-0x14 "data_ptr_to_global"
+0x14-0x18 "data_ptr_with_addend"
+0x18-0x1c "data_func_ptr"
 0xc9-0xcc "_ZL11static_funcv"
 0xcd-0xdd "_ZTW11tls_counter"

--- a/src/read/wasm.rs
+++ b/src/read/wasm.rs
@@ -140,7 +140,7 @@ struct WasmDataSegmentInternal<'data> {
 
 impl<'data> WasmDataSegmentInternal<'data> {
     fn name(&self) -> &'data str {
-        self.info.map(|info| info.name).unwrap_or("")
+        self.info.map(|info| info.name).unwrap_or("<data_segment>")
     }
 
     fn align(&self) -> u64 {
@@ -466,6 +466,7 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                         last_module_name = Some(module);
                     }
 
+                    // TODO: these are imports, not symbols
                     file.symbols.push(WasmSymbolInternal {
                         name,
                         address: 0,
@@ -518,6 +519,14 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
 
             for symbol in symbols {
                 let symbol = symbol.read_error("Invalid Wasm linking symbol")?;
+                if let wp::SymbolInfo::Data {
+                    symbol: Some(data), ..
+                } = symbol
+                {
+                    if (data.index as usize) >= file.data_segments.len() {
+                        return Err(Error("Invalid Wasm data symbol segment index"));
+                    }
+                }
                 let flags = match symbol {
                     wp::SymbolInfo::Func { flags, .. } => flags,
                     wp::SymbolInfo::Data { flags, .. } => flags,
@@ -550,9 +559,6 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                         wp::SymbolInfo::Data {
                             symbol: Some(data), ..
                         } => {
-                            if (data.index as usize) >= file.data_segments.len() {
-                                return Err(Error("Invalid Wasm data symbol segment index"));
-                            }
                             SymbolSection::Section(WasmDataSegmentIndex(data.index).section_index())
                         }
                         _ => {
@@ -592,8 +598,9 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                     }
                     wp::SymbolInfo::Data { name, symbol, .. } => {
                         if let Some(symbol) = symbol {
-                            // Offset and size within the data segment, which is exposed as a section.
-                            address = symbol.offset.into();
+                            // Offset and size are within a data segment, which is exposed as a section.
+                            let segment_address = file.data_segments[symbol.index as usize].address;
+                            address = segment_address.wrapping_add(u64::from(symbol.offset));
                             size = symbol.size.into();
                         }
                         Some(name)
@@ -678,6 +685,7 @@ impl<'data, R: ReadRef<'data>> WasmFile<'data, R> {
                     }
                 }
 
+                // TODO: these are exports, not symbols
                 file.symbols.push(WasmSymbolInternal {
                     name: export.name,
                     address,
@@ -836,7 +844,7 @@ impl<'data, R: ReadRef<'data>> Object<'data> for WasmFile<'data, R> {
     }
 
     fn segments(&self) -> Self::SegmentIterator<'_> {
-        // Relocatable objects expose data segments as sections, not segments.
+        // Relocatable objects only expose data segments as sections.
         let segments: &[WasmDataSegmentInternal<'data>] = if self.has_linking {
             &[]
         } else {
@@ -858,20 +866,17 @@ impl<'data, R: ReadRef<'data>> Object<'data> for WasmFile<'data, R> {
 
     fn section_by_index(&self, index: SectionIndex) -> Result<WasmSection<'data, '_, R>> {
         if let Some(segment_index) = WasmDataSegmentIndex::from_section_index(index) {
-            if self.has_linking {
-                let segment = self
-                    .data_segments
-                    .get(segment_index.0 as usize)
-                    .read_error("Invalid Wasm section index")?;
-                return Ok(WasmSection {
-                    file: self,
-                    inner: WasmSectionInner::DataSegment {
-                        segment_index,
-                        segment,
-                    },
-                });
-            }
-            return Err(Error("Invalid Wasm section index"));
+            let segment = self
+                .data_segments
+                .get(segment_index.0 as usize)
+                .read_error("Invalid Wasm section index")?;
+            return Ok(WasmSection {
+                file: self,
+                inner: WasmSectionInner::DataSegment {
+                    segment_index,
+                    segment,
+                },
+            });
         }
         let section_index = self
             .id_sections
@@ -879,9 +884,6 @@ impl<'data, R: ReadRef<'data>> Object<'data> for WasmFile<'data, R> {
             .and_then(|x| *x)
             .read_error("Invalid Wasm section index")?;
         let section = &self.sections[section_index.0 as usize];
-        if self.has_linking && section.id == SectionId::Data {
-            return Err(Error("Invalid Wasm section index"));
-        }
         Ok(WasmSection {
             file: self,
             inner: WasmSectionInner::Header {
@@ -1077,10 +1079,7 @@ impl<'data, 'file, R> Iterator for WasmSectionIterator<'data, 'file, R> {
     type Item = WasmSection<'data, 'file, R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for (index, section) in self.sections.by_ref() {
-            if self.file.has_linking && section.id == SectionId::Data {
-                continue;
-            }
+        if let Some((index, section)) = self.sections.next() {
             return Some(WasmSection {
                 file: self.file,
                 inner: WasmSectionInner::Header {
@@ -1089,17 +1088,14 @@ impl<'data, 'file, R> Iterator for WasmSectionIterator<'data, 'file, R> {
                 },
             });
         }
-        if self.file.has_linking {
-            let (index, segment) = self.data_segments.next()?;
-            return Some(WasmSection {
-                file: self.file,
-                inner: WasmSectionInner::DataSegment {
-                    segment_index: WasmDataSegmentIndex(index as u32),
-                    segment,
-                },
-            });
-        }
-        None
+        let (index, segment) = self.data_segments.next()?;
+        Some(WasmSection {
+            file: self.file,
+            inner: WasmSectionInner::DataSegment {
+                segment_index: WasmDataSegmentIndex(index as u32),
+                segment,
+            },
+        })
     }
 }
 
@@ -1147,7 +1143,10 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSection<'data> for WasmSection<'data
 
     #[inline]
     fn address(&self) -> u64 {
-        0
+        match self.inner {
+            WasmSectionInner::Header { .. } => 0,
+            WasmSectionInner::DataSegment { segment, .. } => segment.address,
+        }
     }
 
     #[inline]
@@ -1266,16 +1265,16 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSection<'data> for WasmSection<'data
                 SectionId::Type => SectionKind::Metadata,
                 SectionId::Import => SectionKind::Linker,
                 SectionId::Function => SectionKind::Metadata,
-                SectionId::Table => SectionKind::UninitializedData,
-                SectionId::Memory => SectionKind::UninitializedData,
-                SectionId::Global => SectionKind::Data,
+                SectionId::Table => SectionKind::Metadata,
+                SectionId::Memory => SectionKind::Metadata,
+                SectionId::Global => SectionKind::Metadata,
                 SectionId::Export => SectionKind::Linker,
-                SectionId::Start => SectionKind::Linker,
-                SectionId::Element => SectionKind::Data,
+                SectionId::Start => SectionKind::Metadata,
+                SectionId::Element => SectionKind::Metadata,
                 SectionId::Code => SectionKind::Text,
-                SectionId::Data => SectionKind::Data,
-                SectionId::DataCount => SectionKind::UninitializedData,
-                SectionId::Tag => SectionKind::Data,
+                SectionId::Data => SectionKind::Metadata,
+                SectionId::DataCount => SectionKind::Metadata,
+                SectionId::Tag => SectionKind::Metadata,
                 SectionId::Unknown => SectionKind::Unknown,
             },
             WasmSectionInner::DataSegment { segment, .. } => segment.section_kind(),
@@ -1285,7 +1284,16 @@ impl<'data, 'file, R: ReadRef<'data>> ObjectSection<'data> for WasmSection<'data
     #[inline]
     fn relocations(&self) -> WasmRelocationIterator<'data, 'file, R> {
         let (target, offset_range) = match self.inner {
-            WasmSectionInner::Header { section_index, .. } => (Some(section_index), 0..u64::MAX),
+            WasmSectionInner::Header {
+                section_index,
+                section,
+            } => {
+                if section.id == SectionId::Data {
+                    (None, 0..u64::MAX)
+                } else {
+                    (Some(section_index), 0..u64::MAX)
+                }
+            }
             WasmSectionInner::DataSegment { segment, .. } => (
                 self.file.id_sections[SectionId::Data as usize],
                 segment.section_offset..segment.section_offset + segment.data.len() as u64,


### PR DESCRIPTION
Before:
- data section is only listed for non-relocatable files, with section kind `Data`
- data segments are listed as sections for relocatable files, with section kind `Data`
- data relocations are applied to whichever of the two is listed

After:
- data section is listed for all files, with section kind `Metadata`
- data segments are listed as sections for all files, with section kind `Data`
- data relocations are only applied to data segments

No change to segment listing: active data segments are listed as segments for non-relocatable files only.

Also:
- fix the address for data segments listed as sections
- fix the address for data symbols in data segments
- change a number of other sections to section kind to `Metadata`